### PR TITLE
fix(e2e): Fix critical reporting gaps and add manual CI trigger

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -42,7 +42,9 @@
       "Bash(git checkout:*)",
       "Bash(npm run:*)",
       "Bash(GIT_EDITOR=true git rebase --continue)",
-      "Bash(git push:*)"
+      "Bash(git push:*)",
+      "Bash(gh workflow:*)",
+      "Bash(git cherry-pick:*)"
     ]
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, dev, staging]
   push:
     branches: [main, dev, staging]
+  workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -89,7 +90,9 @@ jobs:
         if: always()
         with:
           name: e2e-report
-          path: e2e/ims-e2e/ims-tests/src/test/resources/reports/
+          path: |
+            e2e/ims-e2e/ims-tests/src/test/resources/reports/
+            e2e/ims-e2e/ims-tests/src/test/resources/screenshots/
           retention-days: 30
 
   terraform-validate:

--- a/e2e/ims-e2e/ims-core-ui/src/test/java/com/ims/NovusGuiTestBase.java
+++ b/e2e/ims-e2e/ims-core-ui/src/test/java/com/ims/NovusGuiTestBase.java
@@ -68,7 +68,7 @@ public class NovusGuiTestBase extends AbstractTestNGSpringContextTests {
             }
             reportingService.attachResult(result, ssPath.toAbsolutePath().toString());
         } else if (result.getStatus() == ITestResult.SUCCESS) {
-            reportingService.attachResult(result, null);
+            reportingService.attachResult(result);
         }
     }
 

--- a/e2e/ims-e2e/ims-core/src/main/java/com/ims/services/NovusReportingService.java
+++ b/e2e/ims-e2e/ims-core/src/main/java/com/ims/services/NovusReportingService.java
@@ -73,7 +73,12 @@ public class NovusReportingService {
 
     public synchronized void addTest(Method testInfo) {
         if (reportingEnabled) {
-            test.set(report.createTest(testInfo.getDeclaringClass().getSimpleName() + " - " + testInfo.getAnnotation(Description.class).value()));
+            var desc = testInfo.getAnnotation(Description.class);
+            var testAnnotation = testInfo.getAnnotation(Test.class);
+            String testName = desc != null ? desc.value()
+                    : (testAnnotation != null && !testAnnotation.description().isEmpty()) ? testAnnotation.description()
+                    : testInfo.getName();
+            test.set(report.createTest(testInfo.getDeclaringClass().getSimpleName() + " - " + testName));
             addScenario(testInfo);
             testSteps.set(test.get().createNode("Test Case Execution Steps"));
             addTestMetadata(testInfo);
@@ -82,20 +87,29 @@ public class NovusReportingService {
 
     public synchronized void addScenario(Method testInfo) {
         if (reportingEnabled) {
+            var desc = testInfo.getAnnotation(Description.class);
+            var outcome = testInfo.getAnnotation(Outcome.class);
+            var testAnnotation = testInfo.getAnnotation(Test.class);
+            String descText = desc != null ? desc.value()
+                    : (testAnnotation != null && !testAnnotation.description().isEmpty()) ? testAnnotation.description()
+                    : "No description";
+            String outcomeText = outcome != null ? outcome.value() : "Verify test passes";
+
             ExtentTest testDetails = test.get().createNode("Test Case Details");
             String[][] details = {
                 {"Test Description", "Expected Outcome"},
-                {testInfo.getAnnotation(Description.class).value(), testInfo.getAnnotation(Outcome.class).value()}};
+                {descText, outcomeText}};
             testDetails.info(MarkupHelper.createTable(details));
             var meta = testInfo.getAnnotation(MetaData.class);
-            var testInfoAnnotation = testInfo.getAnnotation(Test.class);
-            ExtentTest testMeta = test.get().createNode("Test Case Meta Data");
-            var isExpected = meta.bugs().length != 0 || testInfoAnnotation.expectedExceptions().length != 0;
-            String[][] metaData = {
-                {"References", "Bugs"},
-                {Arrays.toString(meta.stories()), Arrays.toString(meta.bugs())}};
-            testMeta.info(MarkupHelper.createTable(metaData));
-            if (isExpected) test.get().warning(MarkupHelper.createLabel("This Test Case is Expected to FAIL", ExtentColor.RED));
+            if (meta != null) {
+                var isExpected = meta.bugs().length != 0 || (testAnnotation != null && testAnnotation.expectedExceptions().length != 0);
+                String[][] metaData = {
+                    {"References", "Bugs"},
+                    {Arrays.toString(meta.stories()), Arrays.toString(meta.bugs())}};
+                ExtentTest testMeta = test.get().createNode("Test Case Meta Data");
+                testMeta.info(MarkupHelper.createTable(metaData));
+                if (isExpected) test.get().warning(MarkupHelper.createLabel("This Test Case is Expected to FAIL", ExtentColor.RED));
+            }
         }
     }
 
@@ -165,8 +179,10 @@ public class NovusReportingService {
 
     private synchronized void addTestMetadata(Method method) {
         var metaData = method.getAnnotation(MetaData.class);
-        test.get().assignAuthor(metaData.author());
-        test.get().assignCategory(metaData.category());
+        if (metaData != null) {
+            test.get().assignAuthor(metaData.author());
+            test.get().assignCategory(metaData.category());
+        }
     }
 
     private String base64(String path) {

--- a/e2e/ims-e2e/ims-tests/src/test/java/com/ims/automation/auth/AuthTests.java
+++ b/e2e/ims-e2e/ims-tests/src/test/java/com/ims/automation/auth/AuthTests.java
@@ -2,7 +2,9 @@ package com.ims.automation.auth;
 
 import com.ims.NovusGuiTestBase;
 import com.ims.actor.Actor;
+import com.ims.annotations.Description;
 import com.ims.annotations.MetaData;
+import com.ims.annotations.Outcome;
 import com.ims.automation.constants.TestGroups;
 import com.ims.automation.macros.Login;
 import com.ims.automation.pages.common.LoginPage;
@@ -29,6 +31,8 @@ public class AuthTests extends NovusGuiTestBase {
         actor.setBrowser(browser);
     }
 
+    @Description("Verify login with valid admin credentials redirects to dashboard")
+    @Outcome("User is authenticated and dashboard is displayed")
     @MetaData(testCaseId = "IMS-AUTH-001", author = "ims-automation", category = "auth")
     @Test(description = "Verify login with valid admin credentials")
     public void verifyLoginWithValidCredentials() {
@@ -45,6 +49,8 @@ public class AuthTests extends NovusGuiTestBase {
         softly.assertAll();
     }
 
+    @Description("Verify login with invalid credentials shows error banner")
+    @Outcome("Error message 'Invalid email or password' is displayed")
     @MetaData(testCaseId = "IMS-AUTH-002", author = "ims-automation", category = "auth")
     @Test(description = "Verify login with invalid credentials shows error")
     public void verifyLoginWithInvalidCredentials() {
@@ -65,6 +71,8 @@ public class AuthTests extends NovusGuiTestBase {
         softly.assertAll();
     }
 
+    @Description("Verify sign out clears session and redirects to login page")
+    @Outcome("User is logged out and login page is displayed")
     @MetaData(testCaseId = "IMS-AUTH-003", author = "ims-automation", category = "auth")
     @Test(description = "Verify sign out redirects to login")
     public void verifySignOut() {
@@ -87,6 +95,8 @@ public class AuthTests extends NovusGuiTestBase {
         softly.assertAll();
     }
 
+    @Description("Verify admin user sees all 7 navigation items including User Management")
+    @Outcome("All navigation links are visible in sidebar for Admin role")
     @MetaData(testCaseId = "IMS-AUTH-004", author = "ims-automation", category = "auth")
     @Test(description = "Verify admin sees all navigation items including User Management")
     public void verifyRbacAdminSeesAllNavItems() {
@@ -108,6 +118,8 @@ public class AuthTests extends NovusGuiTestBase {
         softly.assertAll();
     }
 
+    @Description("Verify technician role sees only Dashboard, Inventory, and Service Orders")
+    @Outcome("Only 3 navigation links are visible for Technician role")
     @MetaData(testCaseId = "IMS-AUTH-005", author = "ims-automation", category = "auth")
     @Test(description = "Verify technician sees limited navigation")
     public void verifyRbacTechnicianSeesLimitedNav() {

--- a/e2e/ims-e2e/ims-tests/src/test/resources/application-test.properties
+++ b/e2e/ims-e2e/ims-tests/src/test/resources/application-test.properties
@@ -2,3 +2,5 @@ aut.protocol=http://
 aut.domain=localhost:5173
 report.name=IMS Gen2 E2E Report
 report.emailable=true
+emailable.report.enabled=true
+emailable.report.name=IMS-Gen2-E2E-Report

--- a/e2e/ims-e2e/ims-tests/src/test/resources/suites/smoke-suite.xml
+++ b/e2e/ims-e2e/ims-tests/src/test/resources/suites/smoke-suite.xml
@@ -5,15 +5,8 @@
         <listener class-name="com.ims.automation.listeners.ImsTestListener"/>
     </listeners>
     <test name="Smoke Tests">
-        <groups>
-            <run>
-                <include name="smoke"/>
-            </run>
-        </groups>
-        <packages>
-            <package name="com.ims.automation.*"/>
-        </packages>
         <classes>
+            <class name="com.ims.automation.smoke.SmokeTests"/>
             <class name="com.ims.automation.auth.AuthTests"/>
         </classes>
     </test>


### PR DESCRIPTION
## Summary
- **Report property missing:** Add `emailable.report.enabled=true` and `emailable.report.name` to application-test.properties — Spring injection was failing silently, reports never generated
- **NPE in NovusReportingService:** `addTest()`, `addScenario()`, `addTestMetadata()` crash when `@Description`, `@Outcome`, or `@MetaData` annotations are missing — made null-safe with fallback to `@Test(description)`
- **NPE on SUCCESS:** `NovusGuiTestBase.afterMethodSetup()` called `attachResult(result, null)` for passing tests — `base64(null)` throws NPE — fixed to use no-arg `attachResult()`
- **Smoke suite XML:** Had both `<packages>` and `<classes>` causing duplicate/missed test execution — now uses explicit `<classes>` only
- **AuthTests annotations:** Added `@Description` and `@Outcome` to all 5 tests as gold standard
- **Manual CI trigger:** Added `workflow_dispatch` to ci.yml so you can run CI manually from Actions tab
- **Screenshots upload:** E2E artifact now includes both reports/ and screenshots/

## How to verify
1. Merge this PR
2. Go to Actions → CI → "Run workflow" button (now available)
3. After run completes → download `e2e-report` artifact → open HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)