### PR TITLE
fix(e2e): Add attachResult(ITestResult) overload

### DIFF
--- a/e2e/ims-e2e/ims-core/src/main/java/com/ims/services/NovusReportingService.java
+++ b/e2e/ims-e2e/ims-core/src/main/java/com/ims/services/NovusReportingService.java
@@ -122,6 +122,17 @@ public class NovusReportingService {
         }
     }
 
+    public synchronized void attachResult(ITestResult result) {
+        if (reportingEnabled) {
+            if (testSteps == null || testSteps.get() == null) {
+                return;
+            }
+            Status testStatus = result.getStatus() == ITestResult.SUCCESS ? Status.PASS : Status.SKIP;
+            ExtentColor labelColor = result.getStatus() == ITestResult.SUCCESS ? ExtentColor.GREEN : ExtentColor.YELLOW;
+            testSteps.get().log(testStatus, MarkupHelper.createLabel("Test finished with result: " + testStatus, labelColor));
+        }
+    }
+
     public synchronized void attachResult(ITestResult result, String path) {
         if (reportingEnabled) {
             if (testSteps == null) {


### PR DESCRIPTION
## Summary
Nightly E2E failing with compilation error: `no suitable method found for attachResult(ITestResult)`.

Added `attachResult(ITestResult)` single-arg overload to `NovusReportingService` for SUCCESS path (no screenshot needed).

## Root Cause
PR #120 changed `attachResult(result, null)` → `attachResult(result)` but didn't add the matching overload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)