### PR TITLE
fix(e2e): force TestNG provider — fixes 0 tests running in CI

### DIFF
--- a/e2e/ims-e2e/ims-tests/pom.xml
+++ b/e2e/ims-e2e/ims-tests/pom.xml
@@ -47,6 +47,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-testng</artifactId>
+                        <version>3.1.2</version>
+                    </dependency>
+                </dependencies>
                 <configuration>
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>


### PR DESCRIPTION
## Root Cause

Surefire auto-detected `JUnitPlatformProvider` (brought in by `spring-boot-starter-test`) instead of TestNG. This caused the suite XML to be completely ignored — **every CI run has been reporting 0 tests**.

```
[INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0
```

## Fix

Explicitly declare `surefire-testng` provider dependency in `ims-tests/pom.xml`:

```xml
<dependencies>
    <dependency>
        <groupId>org.apache.maven.surefire</groupId>
        <artifactId>surefire-testng</artifactId>
        <version>3.1.2</version>
    </dependency>
</dependencies>
```

## Expected Result

After this fix, CI will use TestNG provider → read suite XML → actually execute tests → generate ExtentReport → publish to GitHub Pages.

## Test plan

- [ ] CI E2E step should show `Tests run: N` (not 0)
- [ ] ExtentReport artifact should be generated
- [ ] GitHub Pages report should be published

🤖 Generated with [Claude Code](https://claude.com/claude-code)