### PR TITLE
fix(e2e): activate Spring test profile — fixes context boot failure in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,9 +85,7 @@ jobs:
 
       - name: Run E2E smoke tests
         working-directory: e2e/ims-e2e/ims-tests
-        run: mvn test -DsuiteXmlFile=src/test/resources/suites/smoke-suite.xml
-        env:
-          AUT_DOMAIN: localhost:4173
+        run: mvn test -DsuiteXmlFile=src/test/resources/suites/smoke-suite.xml -Dspring.profiles.active=test,web -Daut.domain=localhost:4173
 
       - name: Upload E2E report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -88,18 +88,16 @@ jobs:
           SUITE="${{ steps.suite.outputs.suite_name }}"
           SUITE_XML="${{ steps.suite.outputs.xml }}"
           EXTRA_ARGS="${{ steps.suite.outputs.extra_args }}"
+          SPRING_ARGS="-Dspring.profiles.active=test,web -Daut.domain=localhost:4173"
 
           # For module suite, use the specific module's regression suite instead
           # module-suite.xml requires Maven property interpolation which doesn't work reliably
           if [ "$SUITE" = "module" ] && [ -n "${{ github.event.inputs.module }}" ]; then
             MODULE="${{ github.event.inputs.module }}"
-            # Run regression suite filtered by TestNG group
-            mvn test -DsuiteXmlFile=src/test/resources/suites/regression-suite.xml -Dgroups="$MODULE"
+            mvn test -DsuiteXmlFile=src/test/resources/suites/regression-suite.xml -Dgroups="$MODULE" $SPRING_ARGS
           else
-            mvn test -DsuiteXmlFile=src/test/resources/suites/$SUITE_XML $EXTRA_ARGS
+            mvn test -DsuiteXmlFile=src/test/resources/suites/$SUITE_XML $EXTRA_ARGS $SPRING_ARGS
           fi
-        env:
-          AUT_DOMAIN: localhost:4173
         continue-on-error: true
 
       # ── Test Results Summary (visible on Actions run page) ──


### PR DESCRIPTION
## Root Cause

```
Could not resolve placeholder 'aut.protocol' in value "${aut.protocol}"
→ Failed to load ApplicationContext
→ All 91 tests fail in ~2 seconds (Spring context never boots)
```

`aut.protocol` and `aut.domain` are defined in `application-test.properties` but Spring only loads profile-specific properties when the profile is active. CI wasn't activating the `test` profile.

## Fix

Added `-Dspring.profiles.active=test,web -Daut.domain=localhost:4173` to both:
- `ci.yml` (PR smoke tests)  
- `e2e-nightly.yml` (nightly/manual runs)

## Expected Result

Spring context boots → Playwright browser launches → tests actually interact with the app → ExtentReport generated → published to GitHub Pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)