### PR TITLE
[Story 19.1] Provider abstraction layer — pluggable auth, API, storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# Platform: "mock" | "aws-amplify" | "aws-cdk" | "aws-terraform" | "azure"
+VITE_PLATFORM=mock
+
 VITE_APPSYNC_ENDPOINT=
 VITE_COGNITO_USER_POOL_ID=
 VITE_COGNITO_CLIENT_ID=

--- a/src/lib/providers/mock/mock-api-provider.ts
+++ b/src/lib/providers/mock/mock-api-provider.ts
@@ -1,0 +1,54 @@
+import type { IApiProvider } from "../types";
+import * as hlmApi from "../../hlm-api";
+
+/**
+ * Mock API Provider — wraps the existing hlm-api.ts stub functions
+ * behind the IApiProvider interface. Pure delegation, no logic copied.
+ */
+export function createMockApiProvider(): IApiProvider {
+  return {
+    // Queries
+    listDevices: hlmApi.listDevices,
+    getDevice: hlmApi.getDevice,
+    searchDevices: hlmApi.searchDevices,
+    listFirmware: hlmApi.listFirmware,
+    getFirmware: hlmApi.getFirmware,
+    listServiceOrders: hlmApi.listServiceOrders,
+    listCompliance: hlmApi.listCompliance,
+    listVulnerabilities: hlmApi.listVulnerabilities,
+    listAuditLogs: hlmApi.listAuditLogs,
+    getAuditLogsByUser: hlmApi.getAuditLogsByUser,
+    getCustomer: hlmApi.getCustomer,
+    listNotifications: hlmApi.listNotifications,
+    getDeviceAggregations: hlmApi.getDeviceAggregations,
+    getDashboardMetrics: hlmApi.getDashboardMetrics,
+
+    // Mutations
+    createServiceOrder: hlmApi.createServiceOrder,
+    updateServiceOrder: hlmApi.updateServiceOrder,
+    uploadFirmware: hlmApi.uploadFirmware,
+    approveFirmware: hlmApi.approveFirmware,
+    submitComplianceReview: hlmApi.submitComplianceReview,
+    acknowledgeNotification: hlmApi.acknowledgeNotification,
+
+    // Telemetry
+    getDeviceTelemetry: hlmApi.getDeviceTelemetry,
+    getHeatmapAggregation: hlmApi.getHeatmapAggregation,
+    getBlastRadius: hlmApi.getBlastRadius,
+    getBlastRadiusHistory: hlmApi.getBlastRadiusHistory,
+    ingestTelemetry: hlmApi.ingestTelemetry,
+    runBlastRadiusSimulation: hlmApi.runBlastRadiusSimulation,
+    getTelemetryPipelineStatus: hlmApi.getTelemetryPipelineStatus,
+
+    // OpenSearch
+    searchGlobal: hlmApi.searchGlobal,
+    searchDevicesAdvanced: hlmApi.searchDevicesAdvanced,
+    searchVulnerabilities: hlmApi.searchVulnerabilities,
+    getAggregation: hlmApi.getAggregation,
+    searchDevicesByBounds: hlmApi.searchDevicesByBounds,
+    searchDevicesByDistance: hlmApi.searchDevicesByDistance,
+    getDeviceGeoClusters: hlmApi.getDeviceGeoClusters,
+    getOsisPipelineHealth: hlmApi.getOsisPipelineHealth,
+    triggerReindex: hlmApi.triggerReindex,
+  };
+}

--- a/src/lib/providers/mock/mock-auth-provider.ts
+++ b/src/lib/providers/mock/mock-auth-provider.ts
@@ -1,0 +1,5 @@
+/**
+ * Mock Auth Provider — re-exports the existing AuthProvider component.
+ * The existing auth-context.tsx IS the mock adapter. No logic is duplicated.
+ */
+export { AuthProvider as MockAuthProvider } from "../../auth-context";

--- a/src/lib/providers/mock/mock-storage-provider.ts
+++ b/src/lib/providers/mock/mock-storage-provider.ts
@@ -1,0 +1,13 @@
+import type { IStorageProvider } from "../types";
+
+/**
+ * Mock Storage Provider — delegates to browser localStorage.
+ * Future adapters can use sessionStorage, IndexedDB, or server-side storage.
+ */
+export function createMockStorageProvider(): IStorageProvider {
+  return {
+    getItem: (key) => localStorage.getItem(key),
+    setItem: (key, value) => localStorage.setItem(key, value),
+    removeItem: (key) => localStorage.removeItem(key),
+  };
+}

--- a/src/lib/providers/platform.config.ts
+++ b/src/lib/providers/platform.config.ts
@@ -1,0 +1,44 @@
+import type { PlatformConfig, PlatformId } from "./types";
+import { createMockApiProvider } from "./mock/mock-api-provider";
+import { createMockStorageProvider } from "./mock/mock-storage-provider";
+import { MockAuthProvider } from "./mock/mock-auth-provider";
+
+/**
+ * Detect which platform to use based on VITE_PLATFORM env var.
+ * Defaults to "mock" for local development.
+ */
+function detectPlatform(): PlatformId {
+  const platform = import.meta.env.VITE_PLATFORM as PlatformId | undefined;
+  return platform ?? "mock";
+}
+
+/**
+ * Create platform config with the appropriate adapters.
+ * Add new cases here as cloud adapters are implemented.
+ *
+ * @see Story #204 — AWS Amplify Gen2 adapter
+ * @see Story #205 — AWS CDK adapter
+ * @see Story #206 — Azure adapter
+ * @see Story #207 — Terraform adapter
+ */
+export function createPlatformConfig(): PlatformConfig {
+  const platform = detectPlatform();
+
+  switch (platform) {
+    case "aws-amplify":
+      throw new Error(`Platform "${platform}" is not yet implemented. See Story #204.`);
+    case "aws-cdk":
+      throw new Error(`Platform "${platform}" is not yet implemented. See Story #205.`);
+    case "aws-terraform":
+      throw new Error(`Platform "${platform}" is not yet implemented. See Story #207.`);
+    case "azure":
+      throw new Error(`Platform "${platform}" is not yet implemented. See Story #206.`);
+    case "mock":
+    default:
+      return {
+        api: createMockApiProvider(),
+        storage: createMockStorageProvider(),
+        AuthProvider: MockAuthProvider,
+      };
+  }
+}

--- a/src/lib/providers/registry.tsx
+++ b/src/lib/providers/registry.tsx
@@ -1,0 +1,59 @@
+import { createContext, useContext, type ReactNode, type ComponentType } from "react";
+import type { IApiProvider, IStorageProvider } from "./types";
+
+// =============================================================================
+// Context
+// =============================================================================
+
+interface ProviderRegistryValue {
+  api: IApiProvider;
+  storage: IStorageProvider;
+}
+
+const ProviderRegistryContext = createContext<ProviderRegistryValue | null>(null);
+
+// =============================================================================
+// Provider Component
+// =============================================================================
+
+interface ProviderRegistryProps {
+  api: IApiProvider;
+  storage: IStorageProvider;
+  AuthProvider: ComponentType<{ children: ReactNode }>;
+  children: ReactNode;
+}
+
+/**
+ * ProviderRegistry — wraps the app with all platform providers.
+ * AuthProvider is rendered as a component (it manages React state internally).
+ * API and Storage are plain object instances provided via context.
+ */
+export function ProviderRegistry({ api, storage, AuthProvider, children }: ProviderRegistryProps) {
+  return (
+    <ProviderRegistryContext.Provider value={{ api, storage }}>
+      <AuthProvider>{children}</AuthProvider>
+    </ProviderRegistryContext.Provider>
+  );
+}
+
+// =============================================================================
+// Consumer Hooks
+// =============================================================================
+
+function useProviders(): ProviderRegistryValue {
+  const ctx = useContext(ProviderRegistryContext);
+  if (!ctx) {
+    throw new Error("useProviders must be used within a <ProviderRegistry>");
+  }
+  return ctx;
+}
+
+/** Access the API provider for data operations */
+export function useApiProvider(): IApiProvider {
+  return useProviders().api;
+}
+
+/** Access the storage provider for key-value persistence */
+export function useStorageProvider(): IStorageProvider {
+  return useProviders().storage;
+}

--- a/src/lib/providers/types.ts
+++ b/src/lib/providers/types.ts
@@ -1,0 +1,189 @@
+/**
+ * IMS Gen 2 — Provider Interfaces
+ *
+ * These interfaces define the contracts that cloud adapters must implement.
+ * Swap adapters in platform.config.ts to switch between AWS, Azure, mock, etc.
+ */
+
+import type { ComponentType, ReactNode } from "react";
+import type {
+  AuthState,
+  Device,
+  Firmware,
+  ServiceOrder,
+  Compliance,
+  Vulnerability,
+  AuditLog,
+  Customer,
+  Notification,
+  PaginatedResponse,
+  SearchResult,
+  AggregationResult,
+  TelemetryReading,
+  HeatmapAggregation,
+  BlastRadiusResult,
+  TelemetryPipelineStatus,
+  FailureType,
+} from "../types";
+import type {
+  GlobalSearchResponse,
+  DeviceSearchFilters,
+  AggregationMetric,
+  AggregationResponse,
+  TimeRange,
+  GeoBoundingBox,
+  GeoDistanceQuery,
+  GeoDeviceResult,
+  GeoCluster,
+  PipelineHealthStatus,
+} from "../opensearch-types";
+
+// =============================================================================
+// Auth Provider
+// =============================================================================
+
+/**
+ * Auth provider interface — identical to AuthState.
+ * The existing useAuth() hook returns this shape. Future adapters (Cognito,
+ * Azure AD, Auth0) must provide a React component that populates AuthContext
+ * with this exact shape.
+ */
+export type IAuthProvider = AuthState;
+
+// =============================================================================
+// API Provider
+// =============================================================================
+
+/** Dashboard metrics shape */
+export interface DashboardMetrics {
+  totalDevices: number;
+  onlineDevices: number;
+  activeDeployments: number;
+  pendingApprovals: number;
+  healthScore: number;
+}
+
+/** Heatmap bounds parameter */
+export interface HeatmapBounds {
+  northLat: number;
+  southLat: number;
+  eastLng: number;
+  westLng: number;
+}
+
+/**
+ * API provider interface — all data operations the app needs.
+ * Each method matches the corresponding function in hlm-api.ts.
+ */
+export interface IApiProvider {
+  // --- Queries ---
+  listDevices(
+    page?: number,
+    pageSize?: number,
+    filters?: Record<string, string>,
+  ): Promise<PaginatedResponse<Device>>;
+  getDevice(id: string): Promise<Device | null>;
+  searchDevices(query: string): Promise<SearchResult<Device>>;
+  listFirmware(page?: number, pageSize?: number): Promise<PaginatedResponse<Firmware>>;
+  getFirmware(id: string): Promise<Firmware | null>;
+  listServiceOrders(
+    page?: number,
+    pageSize?: number,
+    status?: string,
+  ): Promise<PaginatedResponse<ServiceOrder>>;
+  listCompliance(status?: string, certType?: string): Promise<PaginatedResponse<Compliance>>;
+  listVulnerabilities(severity?: string): Promise<PaginatedResponse<Vulnerability>>;
+  listAuditLogs(
+    startDate: string,
+    endDate: string,
+    limit?: number,
+    nextToken?: string,
+  ): Promise<PaginatedResponse<AuditLog>>;
+  getAuditLogsByUser(userId: string): Promise<AuditLog[]>;
+  getCustomer(id: string): Promise<Customer | null>;
+  listNotifications(): Promise<Notification[]>;
+  getDeviceAggregations(): Promise<AggregationResult[]>;
+  getDashboardMetrics(): Promise<DashboardMetrics>;
+
+  // --- Mutations ---
+  createServiceOrder(input: Partial<ServiceOrder>): Promise<ServiceOrder | null>;
+  updateServiceOrder(id: string, input: Partial<ServiceOrder>): Promise<ServiceOrder | null>;
+  uploadFirmware(input: Partial<Firmware>): Promise<Firmware | null>;
+  approveFirmware(id: string, stage: string): Promise<Firmware | null>;
+  submitComplianceReview(id: string): Promise<Compliance | null>;
+  acknowledgeNotification(id: string): Promise<boolean>;
+
+  // --- Telemetry & Environmental Monitoring ---
+  getDeviceTelemetry(
+    deviceId: string,
+    startDate: string,
+    endDate: string,
+  ): Promise<TelemetryReading[]>;
+  getHeatmapAggregation(
+    bounds?: HeatmapBounds,
+    precision?: number,
+    riskThreshold?: number,
+  ): Promise<HeatmapAggregation>;
+  getBlastRadius(
+    lat: number,
+    lng: number,
+    radiusKm: number,
+    includeOffline?: boolean,
+  ): Promise<BlastRadiusResult | null>;
+  getBlastRadiusHistory(deviceId?: string): Promise<BlastRadiusResult[]>;
+  ingestTelemetry(
+    deviceId: string,
+    metrics: Partial<TelemetryReading>,
+  ): Promise<TelemetryReading | null>;
+  runBlastRadiusSimulation(
+    deviceId: string,
+    radiusKm: number,
+    failureType: FailureType,
+    severity?: number,
+  ): Promise<BlastRadiusResult | null>;
+  getTelemetryPipelineStatus(): Promise<TelemetryPipelineStatus>;
+
+  // --- OpenSearch / Global Search ---
+  searchGlobal(
+    query: string,
+    entityTypes?: string[],
+    limit?: number,
+  ): Promise<GlobalSearchResponse>;
+  searchDevicesAdvanced(
+    query: string,
+    filters?: DeviceSearchFilters,
+  ): Promise<SearchResult<Device>>;
+  searchVulnerabilities(query: string, severity?: string): Promise<SearchResult<Vulnerability>>;
+  getAggregation(metric: AggregationMetric, timeRange?: TimeRange): Promise<AggregationResponse>;
+  searchDevicesByBounds(bounds: GeoBoundingBox, status?: string): Promise<GeoDeviceResult[]>;
+  searchDevicesByDistance(params: GeoDistanceQuery): Promise<GeoDeviceResult[]>;
+  getDeviceGeoClusters(bounds?: GeoBoundingBox, precision?: number): Promise<GeoCluster[]>;
+  getOsisPipelineHealth(): Promise<PipelineHealthStatus>;
+  triggerReindex(): Promise<boolean>;
+}
+
+// =============================================================================
+// Storage Provider
+// =============================================================================
+
+/**
+ * Storage provider interface — key-value persistence abstraction.
+ * Current implementation: localStorage. Future: sessionStorage, IndexedDB, etc.
+ */
+export interface IStorageProvider {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+// =============================================================================
+// Platform Config
+// =============================================================================
+
+export type PlatformId = "mock" | "aws-amplify" | "aws-cdk" | "aws-terraform" | "azure";
+
+export interface PlatformConfig {
+  api: IApiProvider;
+  storage: IStorageProvider;
+  AuthProvider: ComponentType<{ children: ReactNode }>;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,17 +3,24 @@ import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router";
 import { ThemeProvider } from "next-themes";
 import { Toaster } from "sonner";
-import { AuthProvider } from "./lib/auth-context";
+import { ProviderRegistry } from "./lib/providers/registry";
+import { createPlatformConfig } from "./lib/providers/platform.config";
 import { ErrorBoundary } from "./components/error-boundary";
 import App from "./App";
 import "./index.css";
+
+const platform = createPlatformConfig();
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <ErrorBoundary>
       <BrowserRouter>
         <ThemeProvider attribute="class" defaultTheme="system" storageKey="ims-theme" enableSystem>
-          <AuthProvider>
+          <ProviderRegistry
+            api={platform.api}
+            storage={platform.storage}
+            AuthProvider={platform.AuthProvider}
+          >
             <App />
             <Toaster
               position="bottom-right"
@@ -21,7 +28,7 @@ createRoot(document.getElementById("root")!).render(
                 className: "font-sans text-sm",
               }}
             />
-          </AuthProvider>
+          </ProviderRegistry>
         </ThemeProvider>
       </BrowserRouter>
     </ErrorBoundary>


### PR DESCRIPTION
## Summary
- Created **provider abstraction layer** in `src/lib/providers/` — the foundation for Epic 19 (Enterprise React Template)
- **3 interfaces**: `IApiProvider` (35 methods), `IStorageProvider`, `PlatformConfig`
- **3 mock adapters**: wrap existing auth, API stubs, and localStorage — zero behavior change
- **ProviderRegistry** context at app root replaces direct `AuthProvider` import
- **Platform config** (`VITE_PLATFORM` env var) — switch between mock/aws/azure/terraform

### Architecture
```
src/lib/providers/
├── types.ts              # IApiProvider, IStorageProvider, PlatformConfig
├── registry.tsx          # ProviderRegistry context + consumer hooks
├── platform.config.ts    # Adapter selection via VITE_PLATFORM
└── mock/
    ├── mock-auth-provider.ts     # Re-exports existing AuthProvider
    ├── mock-api-provider.ts      # Wraps hlm-api.ts stubs
    └── mock-storage-provider.ts  # Wraps localStorage
```

### How to add a new cloud adapter (future stories)
1. Create `src/lib/providers/aws/` (or `azure/`)
2. Implement `IApiProvider` and `IStorageProvider`
3. Create an `AuthProvider` component that populates `AuthContext`
4. Add a case to `platform.config.ts`
5. Set `VITE_PLATFORM=aws-amplify` in `.env`

Closes #175

## Test plan
- [x] `npm run build` — 0 errors
- [x] `npm run lint` — 0 errors
- [x] App loads, login works, all pages identical to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)