### PR TITLE
[Story 19.2] TanStack Query for server state management

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "ims-gen2",
       "version": "0.1.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.96.0",
+        "@tanstack/react-query-devtools": "^5.96.0",
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
         "cmdk": "1.1.1",
@@ -2817,6 +2819,59 @@
       "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.96.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.96.0.tgz",
+      "integrity": "sha512-sfO3uQeol1BU7cRP6NYY7nAiX3GiNY20lI/dtSbKLwcIkYw/X+w/tEsQAkc544AfIhBX/IvH/QYtPHrPhyAKGw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.96.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.96.0.tgz",
+      "integrity": "sha512-MEdO1M/9ItB62OtTqVo8AIj/G6vJemA642N56bw8aIqpXKIj5VG/3xWgh2piw76NmoCIlapxjjWp1MMLmrvKJw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.96.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.96.0.tgz",
+      "integrity": "sha512-6qbjdm1K5kizVKv9TNqhIN3doq2anRhdF2XaFMFSn4m8L22S69RV+FilvlyVT4RoJyMxtPU5rs4RpdFa/PEC7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.96.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.96.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.96.0.tgz",
+      "integrity": "sha512-P0WFX0s3iYii4oZTSCK9T3/PBQ9uY/SVTzcZFbyzCo5ujeIAsqos3HjBWoF/lhJXWVe8UXkjAmgXr3TUD11q2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.96.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.96.0",
+        "react": "^18 || ^19"
+      }
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.96.0",
+    "@tanstack/react-query-devtools": "^5.96.0",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "cmdk": "1.1.1",

--- a/src/lib/providers/registry.tsx
+++ b/src/lib/providers/registry.tsx
@@ -1,4 +1,7 @@
 import { createContext, useContext, type ReactNode, type ComponentType } from "react";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { queryClient } from "../query-client";
 import type { IApiProvider, IStorageProvider } from "./types";
 
 // =============================================================================
@@ -30,9 +33,12 @@ interface ProviderRegistryProps {
  */
 export function ProviderRegistry({ api, storage, AuthProvider, children }: ProviderRegistryProps) {
   return (
-    <ProviderRegistryContext.Provider value={{ api, storage }}>
-      <AuthProvider>{children}</AuthProvider>
-    </ProviderRegistryContext.Provider>
+    <QueryClientProvider client={queryClient}>
+      <ProviderRegistryContext.Provider value={{ api, storage }}>
+        <AuthProvider>{children}</AuthProvider>
+      </ProviderRegistryContext.Provider>
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
   );
 }
 

--- a/src/lib/query-client.ts
+++ b/src/lib/query-client.ts
@@ -1,0 +1,23 @@
+import { QueryClient } from "@tanstack/react-query";
+
+/**
+ * Global QueryClient with enterprise defaults.
+ *
+ * - staleTime: 5 min — data considered fresh, no background refetch
+ * - gcTime: 30 min — unused cache entries garbage collected
+ * - retry: 2 attempts with exponential backoff
+ * - refetchOnWindowFocus: true — data stays fresh across tab switches
+ */
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 5 * 60 * 1000,
+      gcTime: 30 * 60 * 1000,
+      retry: 2,
+      refetchOnWindowFocus: true,
+    },
+    mutations: {
+      retry: 1,
+    },
+  },
+});

--- a/src/lib/query-keys.ts
+++ b/src/lib/query-keys.ts
@@ -1,0 +1,90 @@
+/**
+ * Centralized query key factory.
+ *
+ * Convention: [domain, scope, ...params]
+ * - queryKeys.dashboard.metrics() → ["dashboard", "metrics"]
+ * - queryKeys.devices.list({ status: "Online" }) → ["devices", "list", { status: "Online" }]
+ * - queryKeys.devices.detail("d1") → ["devices", "detail", "d1"]
+ *
+ * Benefits:
+ * - Type-safe invalidation: queryClient.invalidateQueries({ queryKey: queryKeys.devices.all })
+ * - Hierarchical: invalidating "devices" invalidates all device queries
+ */
+export const queryKeys = {
+  // Dashboard
+  dashboard: {
+    all: ["dashboard"] as const,
+    metrics: () => [...queryKeys.dashboard.all, "metrics"] as const,
+  },
+
+  // Devices / Inventory
+  devices: {
+    all: ["devices"] as const,
+    list: (filters?: Record<string, unknown>) =>
+      [...queryKeys.devices.all, "list", filters] as const,
+    detail: (id: string) => [...queryKeys.devices.all, "detail", id] as const,
+  },
+
+  // Firmware / Deployment
+  firmware: {
+    all: ["firmware"] as const,
+    list: (filters?: Record<string, unknown>) =>
+      [...queryKeys.firmware.all, "list", filters] as const,
+    detail: (id: string) => [...queryKeys.firmware.all, "detail", id] as const,
+  },
+
+  // Vulnerabilities
+  vulnerabilities: {
+    all: ["vulnerabilities"] as const,
+    list: (filters?: Record<string, unknown>) =>
+      [...queryKeys.vulnerabilities.all, "list", filters] as const,
+  },
+
+  // Compliance
+  compliance: {
+    all: ["compliance"] as const,
+    list: (filters?: Record<string, unknown>) =>
+      [...queryKeys.compliance.all, "list", filters] as const,
+  },
+
+  // Service Orders
+  serviceOrders: {
+    all: ["serviceOrders"] as const,
+    list: (filters?: Record<string, unknown>) =>
+      [...queryKeys.serviceOrders.all, "list", filters] as const,
+  },
+
+  // Audit Logs
+  auditLogs: {
+    all: ["auditLogs"] as const,
+    list: (filters?: Record<string, unknown>) =>
+      [...queryKeys.auditLogs.all, "list", filters] as const,
+  },
+
+  // SBOM
+  sbom: {
+    all: ["sbom"] as const,
+    list: (filters?: Record<string, unknown>) => [...queryKeys.sbom.all, "list", filters] as const,
+  },
+
+  // Incidents
+  incidents: {
+    all: ["incidents"] as const,
+    list: (filters?: Record<string, unknown>) =>
+      [...queryKeys.incidents.all, "list", filters] as const,
+    detail: (id: string) => [...queryKeys.incidents.all, "detail", id] as const,
+  },
+
+  // Telemetry
+  telemetry: {
+    all: ["telemetry"] as const,
+    device: (deviceId: string, range?: Record<string, unknown>) =>
+      [...queryKeys.telemetry.all, "device", deviceId, range] as const,
+    pipeline: () => [...queryKeys.telemetry.all, "pipeline"] as const,
+  },
+
+  // Notifications
+  notifications: {
+    all: ["notifications"] as const,
+  },
+};

--- a/src/lib/use-dashboard-data.ts
+++ b/src/lib/use-dashboard-data.ts
@@ -1,4 +1,6 @@
-import { useState, useEffect, useCallback } from "react";
+import { useCallback } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { queryKeys } from "./query-keys";
 
 export type FetchState = "loading" | "success" | "error";
 
@@ -78,23 +80,18 @@ async function fetchDashboardData(): Promise<DashboardData> {
 }
 
 export function useDashboardData() {
-  const [data, setData] = useState<DashboardData | null>(null);
-  const [state, setState] = useState<FetchState>("loading");
+  const { data, status, refetch } = useQuery({
+    queryKey: queryKeys.dashboard.metrics(),
+    queryFn: fetchDashboardData,
+  });
+
+  // Map TanStack Query status to FetchState for backward compatibility
+  const state: FetchState =
+    status === "pending" ? "loading" : status === "error" ? "error" : "success";
 
   const refresh = useCallback(async () => {
-    setState("loading");
-    try {
-      const result = await fetchDashboardData();
-      setData(result);
-      setState("success");
-    } catch {
-      setState("error");
-    }
-  }, []);
+    await refetch();
+  }, [refetch]);
 
-  useEffect(() => {
-    refresh();
-  }, [refresh]);
-
-  return { data, state, refresh };
+  return { data: data ?? null, state, refresh };
 }


### PR DESCRIPTION
## Summary
- Installed `@tanstack/react-query` + devtools
- Created **QueryClient** with enterprise defaults (5min stale, 30min gc, 2 retries)
- Created **query key factory** (`query-keys.ts`) for all 10 domains
- Added **QueryClientProvider** to ProviderRegistry
- Migrated **`useDashboardData`** from manual useState/useEffect to `useQuery`
- Same return shape `{ data, state, refresh }` — dashboard component unchanged

### What TanStack Query gives us
- Automatic caching (no duplicate requests)
- Background revalidation on window focus
- Retry with exponential backoff
- React Query DevTools in development
- Foundation for all future API integrations

Closes #176

## Test plan
- [x] `npm run build` — 0 errors
- [x] Dashboard: skeleton → data loads, refresh button works, error retry works
- [x] React Query DevTools visible in dev (bottom-right flower icon)
- [x] All other pages unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)