### PR TITLE
Fix: hide React Query DevTools in production

### DIFF
--- a/src/lib/providers/registry.tsx
+++ b/src/lib/providers/registry.tsx
@@ -1,7 +1,17 @@
-import { createContext, useContext, type ReactNode, type ComponentType } from "react";
+import {
+  lazy,
+  Suspense,
+  createContext,
+  useContext,
+  type ReactNode,
+  type ComponentType,
+} from "react";
 import { QueryClientProvider } from "@tanstack/react-query";
-import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { queryClient } from "../query-client";
+
+const ReactQueryDevtools = lazy(() =>
+  import("@tanstack/react-query-devtools").then((m) => ({ default: m.ReactQueryDevtools })),
+);
 import type { IApiProvider, IStorageProvider } from "./types";
 
 // =============================================================================
@@ -37,7 +47,11 @@ export function ProviderRegistry({ api, storage, AuthProvider, children }: Provi
       <ProviderRegistryContext.Provider value={{ api, storage }}>
         <AuthProvider>{children}</AuthProvider>
       </ProviderRegistryContext.Provider>
-      <ReactQueryDevtools initialIsOpen={false} />
+      {import.meta.env.DEV && (
+        <Suspense fallback={null}>
+          <ReactQueryDevtools initialIsOpen={false} buttonPosition="bottom-left" />
+        </Suspense>
+      )}
     </QueryClientProvider>
   );
 }


### PR DESCRIPTION
## Summary
- Lazy-load React Query DevTools (not bundled eagerly)
- Only render when `import.meta.env.DEV` is true (zero code in prod)
- Button moved to bottom-left to avoid overlapping UI elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)