### PR TITLE
Fix: hide devtools by default — opt-in via VITE_SHOW_DEVTOOLS

### DIFF
--- a/src/lib/providers/registry.tsx
+++ b/src/lib/providers/registry.tsx
@@ -47,7 +47,7 @@ export function ProviderRegistry({ api, storage, AuthProvider, children }: Provi
       <ProviderRegistryContext.Provider value={{ api, storage }}>
         <AuthProvider>{children}</AuthProvider>
       </ProviderRegistryContext.Provider>
-      {import.meta.env.DEV && (
+      {import.meta.env.VITE_SHOW_DEVTOOLS === "true" && (
         <Suspense fallback={null}>
           <ReactQueryDevtools initialIsOpen={false} buttonPosition="bottom-left" />
         </Suspense>


### PR DESCRIPTION
DevTools button hidden by default. To enable for debugging:
add `VITE_SHOW_DEVTOOLS=true` to `.env.local`

🤖 Generated with [Claude Code](https://claude.com/claude-code)