### PR TITLE
Fix sidebar menu contrast — WCAG AAA 7:1 ratio

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -20,7 +20,7 @@
   --color-secondary: #f5f6f8;
   --color-secondary-foreground: #111827;
   --color-muted: #f5f6f8;
-  --color-muted-foreground: #6b7280;
+  --color-muted-foreground: #4b5563;
   --color-accent: #ff7900;
   --color-accent-foreground: #ffffff;
   --color-destructive: #ef4444;
@@ -54,7 +54,7 @@
   --color-secondary: #1a1f35;
   --color-secondary-foreground: #f1f5f9;
   --color-muted: #1a1f35;
-  --color-muted-foreground: #94a3b8;
+  --color-muted-foreground: #cbd5e1;
   --color-accent: #ff7900;
   --color-accent-foreground: #ffffff;
   --color-destructive: #7f1d1d;


### PR DESCRIPTION
## Summary
UI expert flagged: menu text and background colors too similar.

| Mode | Before | After | AAA (7:1) |
|------|--------|-------|-----------|
| Light | #6b7280 (4.83:1) | **#4b5563 (7.56:1)** | PASS |
| Dark | #94a3b8 (6.34:1) | **#cbd5e1 (10.95:1)** | PASS |

Single CSS variable change — affects all muted text app-wide
(sidebar menu, breadcrumbs, secondary labels, timestamps).

Closes part of #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)