### PR TITLE
Fix sidebar active item — light orange bg + dark text (AAA)

### DIFF
--- a/src/app/components/layouts/sidebar.tsx
+++ b/src/app/components/layouts/sidebar.tsx
@@ -193,19 +193,19 @@ export function Sidebar({ collapsed, onToggle }: SidebarProps) {
                         collapsed ? "h-[40px] justify-center px-0" : "h-[40px] px-3",
                         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-0",
                         isActive
-                          ? "bg-[#FFF7ED] font-semibold text-[#7c2d12] dark:bg-[#431407] dark:text-[#fed7aa]"
+                          ? "bg-[#FFF7ED] font-semibold text-foreground dark:bg-[#431407] dark:text-[#fed7aa]"
                           : "text-muted-foreground hover:bg-muted hover:text-foreground",
                       )}
                     >
                       {isActive && (
-                        <div className="absolute left-0 top-1/2 h-5 w-[3px] -translate-y-1/2 rounded-r-full bg-[#9a3412] dark:bg-[#fb923c]" />
+                        <div className="absolute left-0 top-1/2 h-5 w-[3px] -translate-y-1/2 rounded-r-full bg-accent" />
                       )}
                       <Icon
                         aria-hidden="true"
                         className={cn(
                           "h-[18px] w-[18px] shrink-0",
                           isActive
-                            ? "text-[#9a3412] dark:text-[#fed7aa]"
+                            ? "text-accent"
                             : "text-muted-foreground/60 group-hover:text-foreground",
                         )}
                       />


### PR DESCRIPTION
## Summary
Active sidebar menu item: light orange background + dark text + orange icon.

| Mode | Text | Background | Ratio | AAA |
|------|------|-----------|-------|-----|
| Light | `#111827` (gray-900) | `#FFF7ED` (orange-50) | **16.71:1** | PASS |
| Dark | `#fed7aa` (orange-200) | `#431407` (orange-950) | **11.56:1** | PASS |

Orange accent bar on left edge + orange icon color for active item.
Warm brand feel, fully accessible, consistent with app theme.

Closes part of #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)