### PR TITLE
Fix light text contrast + responsive tablet layout

### DIFF
--- a/src/app/components/account-service.tsx
+++ b/src/app/components/account-service.tsx
@@ -881,7 +881,7 @@ export function AccountService() {
 
       {/* Content */}
       {view === "kanban" ? (
-        <div className="grid grid-cols-3 gap-3">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
           {COLUMN_ORDER.map((status) => (
             <KanbanColumn
               key={status}

--- a/src/app/components/blast-radius/blast-radius-panel.tsx
+++ b/src/app/components/blast-radius/blast-radius-panel.tsx
@@ -345,7 +345,7 @@ export function BlastRadiusPanel({
           </div>
           {affectedDevices.length === 0 ? (
             <div className="py-8 text-center">
-              <Activity className="mx-auto h-8 w-8 text-gray-300 mb-2" />
+              <Activity className="mx-auto h-8 w-8 text-gray-500 mb-2" />
               <p className="text-[14px] text-gray-500">No devices within radius</p>
             </div>
           ) : (

--- a/src/app/components/compliance.tsx
+++ b/src/app/components/compliance.tsx
@@ -488,7 +488,7 @@ function ComplianceTab({
                 <tr>
                   <td colSpan={8} className="px-3 py-12 text-center">
                     <div className="flex flex-col items-center gap-2">
-                      <Shield className="h-8 w-8 text-gray-300" />
+                      <Shield className="h-8 w-8 text-gray-500" />
                       <p className="text-sm text-gray-500">No compliance items found</p>
                       <p className="text-sm text-gray-500">
                         Try adjusting your filters or search criteria

--- a/src/app/components/dashboard.tsx
+++ b/src/app/components/dashboard.tsx
@@ -184,7 +184,7 @@ function KpiSkeleton() {
 function SectionError({ message, onRetry }: { message: string; onRetry: () => void }) {
   return (
     <div className="card-elevated flex flex-col items-center justify-center py-12 px-5">
-      <RefreshCw className="h-8 w-8 text-muted-foreground/40 mb-3" />
+      <RefreshCw className="h-8 w-8 text-muted-foreground/70 mb-3" />
       <p className="text-[15px] font-medium text-foreground/80">{message}</p>
       <button
         onClick={onRetry}
@@ -481,7 +481,7 @@ export function Dashboard() {
         <div className="flex items-center gap-3">
           <span className="text-[14px] text-muted-foreground/70">{dateStr}</span>
           {dashData?.lastUpdated && (
-            <span className="text-[13px] text-muted-foreground/40">
+            <span className="text-[13px] text-muted-foreground/70">
               Updated {dashData.lastUpdated.toLocaleTimeString()}
             </span>
           )}
@@ -543,7 +543,7 @@ export function Dashboard() {
         {/* Quick Actions */}
         <div className="card-elevated px-5 py-4">
           <h3 className="text-[15px] font-semibold text-foreground mb-3">Quick Actions</h3>
-          <div className="grid grid-cols-3 gap-2.5">
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-2.5">
             {QUICK_ACTIONS.map((action) => {
               const Icon = action.icon;
               return (
@@ -837,7 +837,7 @@ export function Dashboard() {
                     <p className="text-[15px] font-medium text-foreground">{item.title}</p>
                     <p className="text-[14px] text-muted-foreground/70 truncate">{item.subtitle}</p>
                   </div>
-                  <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground/40" />
+                  <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground/70" />
                 </div>
               );
             })}

--- a/src/app/components/deployment.tsx
+++ b/src/app/components/deployment.tsx
@@ -311,7 +311,7 @@ export function Deployment() {
 
           {filteredFirmware.length === 0 ? (
             <div className="flex flex-col items-center justify-center rounded-sm border border-dashed border-border bg-gray-50 py-16">
-              <Package className="mb-3 h-10 w-10 text-muted-foreground/50" />
+              <Package className="mb-3 h-10 w-10 text-muted-foreground/70" />
               <p className="text-sm font-medium text-muted-foreground">
                 {firmware.length === 0
                   ? "No firmware packages found"
@@ -804,7 +804,7 @@ export function Deployment() {
 
           {!reportGenerated && (
             <div className="flex flex-col items-center justify-center rounded-sm border border-dashed border-border bg-muted/20 py-16">
-              <FileText className="mb-3 h-10 w-10 text-muted-foreground/40" />
+              <FileText className="mb-3 h-10 w-10 text-muted-foreground/70" />
               <p className="text-sm font-medium text-muted-foreground">
                 Select a report type and click Generate
               </p>

--- a/src/app/components/deployment/approval-stage-indicator.tsx
+++ b/src/app/components/deployment/approval-stage-indicator.tsx
@@ -58,8 +58,8 @@ export function ApprovalStageIndicator({
                   "flex h-5 w-5 items-center justify-center rounded-full text-[11px] font-bold transition-all duration-200",
                   isCompleted && "bg-emerald-500 text-white",
                   isCurrent && "bg-blue-600 text-white animate-pulse",
-                  isFuture && "border border-gray-300 bg-white text-gray-400",
-                  isDeprecated && "border border-gray-200 bg-gray-100 text-gray-300",
+                  isFuture && "border border-gray-300 bg-white text-gray-500",
+                  isDeprecated && "border border-gray-200 bg-gray-100 text-gray-500",
                 )}
               >
                 {isCompleted ? <Check className="h-2.5 w-2.5" /> : i + 1}
@@ -89,11 +89,11 @@ export function ApprovalStageIndicator({
                 i > 0 && "ml-1",
                 isCompleted && "text-emerald-600",
                 isCurrent && "text-blue-600",
-                !isCompleted && !isCurrent && "text-gray-400",
-                isDeprecated && "text-gray-300 line-through",
+                !isCompleted && !isCurrent && "text-gray-500",
+                isDeprecated && "text-gray-500 line-through",
               )}
             >
-              {i > 0 && <span className="text-gray-300 mr-1">/</span>}
+              {i > 0 && <span className="text-gray-500 mr-1">/</span>}
               {stage.label}
             </span>
           );

--- a/src/app/components/digital-twin/digital-twin-page.tsx
+++ b/src/app/components/digital-twin/digital-twin-page.tsx
@@ -1166,7 +1166,7 @@ function ConfigDriftPanel({ twin, onClose }: { twin: DigitalTwin; onClose: () =>
                 </div>
                 <ChevronRight
                   className={cn(
-                    "h-4 w-4 text-gray-300 transition-transform",
+                    "h-4 w-4 text-gray-500 transition-transform",
                     selectedItem?.configKey === item.configKey && "rotate-90",
                   )}
                 />
@@ -1641,7 +1641,7 @@ function TwinDetailView({ twin, onBack }: { twin: DigitalTwin; onBack: () => voi
                   "flex items-center gap-1.5 rounded-lg px-3 py-2 text-[14px] font-medium cursor-pointer",
                   selectedSnapIds.length >= 2
                     ? "bg-[#FF7900] text-white hover:bg-[#e66d00]"
-                    : "bg-gray-100 text-gray-400 cursor-not-allowed",
+                    : "bg-gray-100 text-gray-500 cursor-not-allowed",
                 )}
               >
                 <GitCompare className="h-3.5 w-3.5" /> Compare
@@ -1671,7 +1671,7 @@ function TwinDetailView({ twin, onBack }: { twin: DigitalTwin; onBack: () => voi
             </button>
           </div>
           <div className="rounded-lg border border-gray-200 bg-gray-50 p-6 flex flex-col items-center">
-            <Cpu className="h-10 w-10 text-gray-300 mb-3" />
+            <Cpu className="h-10 w-10 text-gray-500 mb-3" />
             <p className="text-[15px] font-medium text-gray-600">
               Run a firmware upgrade simulation
             </p>
@@ -1746,7 +1746,7 @@ function TwinCard({ twin, onClick }: { twin: DigitalTwin; onClick: () => void })
               </span>
             </div>
           )}
-          <p className="mt-1 text-[12px] text-gray-300 tabular-nums">
+          <p className="mt-1 text-[12px] text-gray-500 tabular-nums">
             Synced {new Date(twin.lastSyncedAt).toLocaleTimeString()}
           </p>
         </div>
@@ -1763,7 +1763,7 @@ function TwinCard({ twin, onClick }: { twin: DigitalTwin; onClick: () => void })
           >
             {twin.configDriftStatus === "InSync" ? "In Sync" : twin.configDriftStatus}
           </span>
-          <ChevronRight className="h-4 w-4 text-gray-300" />
+          <ChevronRight className="h-4 w-4 text-gray-500" />
         </div>
       </div>
     </div>
@@ -1911,7 +1911,7 @@ export function DigitalTwinPage() {
 
       {filteredTwins.length === 0 && (
         <div className="card-elevated flex flex-col items-center justify-center py-12 px-5">
-          <Search className="h-8 w-8 text-gray-300 mb-3" />
+          <Search className="h-8 w-8 text-gray-500 mb-3" />
           <p className="text-[15px] font-medium text-gray-700">No devices match your filters</p>
           <p className="text-[14px] text-gray-500 mt-1">
             Try adjusting your search or filter criteria

--- a/src/app/components/geo-location-map.tsx
+++ b/src/app/components/geo-location-map.tsx
@@ -744,7 +744,7 @@ function MapSkeleton() {
       <Skeleton className="h-full w-full" />
       <div className="absolute inset-0 flex items-center justify-center">
         <div className="flex flex-col items-center gap-2">
-          <MapPin className="h-8 w-8 text-gray-300 animate-pulse" />
+          <MapPin className="h-8 w-8 text-gray-500 animate-pulse" />
           <span className="text-[14px] text-gray-500">Loading map...</span>
         </div>
       </div>

--- a/src/app/components/incidents/incident-detail-panel.tsx
+++ b/src/app/components/incidents/incident-detail-panel.tsx
@@ -235,7 +235,7 @@ export function IncidentDetailPanel({
               />
             ) : (
               <div className="flex flex-col items-center justify-center py-12 text-center">
-                <BookOpen className="h-10 w-10 text-gray-300 mb-3" />
+                <BookOpen className="h-10 w-10 text-gray-500 mb-3" />
                 <p className="text-[15px] font-medium text-gray-700">No playbook attached</p>
                 <p className="text-[14px] text-gray-500 mt-1">
                   Attach a playbook to track response steps

--- a/src/app/components/incidents/incident-list-tab.tsx
+++ b/src/app/components/incidents/incident-list-tab.tsx
@@ -181,14 +181,14 @@ export function IncidentListTab({
                   {formatRelativeTime(inc.createdAt)}
                 </td>
                 <td className="px-2">
-                  <ChevronRight className="h-4 w-4 text-gray-300" />
+                  <ChevronRight className="h-4 w-4 text-gray-500" />
                 </td>
               </tr>
             ))}
             {filtered.length === 0 && (
               <tr>
                 <td colSpan={8} className="py-12 text-center">
-                  <AlertTriangle className="mx-auto h-8 w-8 text-gray-300 mb-2" />
+                  <AlertTriangle className="mx-auto h-8 w-8 text-gray-500 mb-2" />
                   <p className="text-[15px] font-medium text-gray-600">No incidents found</p>
                   <p className="text-[14px] text-gray-500">
                     Adjust your filters or create a new incident

--- a/src/app/components/incidents/network-topology-graph.tsx
+++ b/src/app/components/incidents/network-topology-graph.tsx
@@ -263,7 +263,7 @@ export function NetworkTopologyGraph({
             {status}
           </span>
         ))}
-        <span className="mx-1 text-gray-300">|</span>
+        <span className="mx-1 text-gray-500">|</span>
         {Object.entries(edgeTypeLabels).map(([type, label]) => (
           <span key={type} className="flex items-center gap-1.5">
             <span className="h-0.5 w-4" style={{ backgroundColor: edgeTypeColors[type] }} />

--- a/src/app/components/inventory.tsx
+++ b/src/app/components/inventory.tsx
@@ -105,7 +105,7 @@ function SortHeader({
             <ChevronDown className="h-3 w-3 text-[#FF7900]" />
           )
         ) : (
-          <ArrowUpDown className="h-3 w-3 text-gray-300" />
+          <ArrowUpDown className="h-3 w-3 text-gray-500" />
         )}
       </div>
     </th>

--- a/src/app/components/layouts/protected-layout.tsx
+++ b/src/app/components/layouts/protected-layout.tsx
@@ -54,7 +54,7 @@ function LayoutSkeleton() {
             </div>
             <Skeleton className="h-9 w-9 rounded-lg" />
           </div>
-          <div className="grid grid-cols-4 gap-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
             {Array.from({ length: 4 }).map((_, i) => (
               <div key={i} className="card-elevated p-5 space-y-3">
                 <Skeleton className="h-10 w-10 rounded-xl" />
@@ -93,7 +93,7 @@ export function ProtectedLayout() {
           <ConnectivityStatusBar connectivity={connectivity} />
           <main
             id="main-content"
-            className="page-enter flex-1 overflow-y-auto scroll-smooth p-6"
+            className="page-enter flex-1 overflow-y-auto scroll-smooth px-4 py-5 sm:px-5 md:px-6 lg:p-6"
             role="main"
             tabIndex={-1}
           >

--- a/src/app/components/layouts/sidebar.tsx
+++ b/src/app/components/layouts/sidebar.tsx
@@ -118,7 +118,8 @@ export function Sidebar({ collapsed, onToggle }: SidebarProps) {
   return (
     <aside
       className={cn(
-        "flex h-full flex-col bg-card border-r border-border shrink-0 transition-[width] duration-200 ease-in-out overflow-hidden",
+        "h-full flex-col bg-card border-r border-border shrink-0 transition-[width] duration-200 ease-in-out overflow-hidden",
+        "hidden md:flex",
         collapsed ? "w-[68px]" : "w-[240px]",
       )}
       aria-label="Primary navigation"

--- a/src/app/components/mfa-setup.tsx
+++ b/src/app/components/mfa-setup.tsx
@@ -76,9 +76,9 @@ export function MfaSetup({ onClose }: MfaSetupProps) {
   const qrPlaceholder = totpUri ? (
     <div className="flex h-[180px] w-[180px] items-center justify-center rounded-xl border-2 border-dashed border-gray-200 bg-gray-50">
       <div className="text-center">
-        <ShieldCheck className="mx-auto h-10 w-10 text-gray-300" />
+        <ShieldCheck className="mx-auto h-10 w-10 text-gray-500" />
         <p className="mt-2 text-[13px] text-gray-500">QR Code</p>
-        <p className="text-[12px] text-gray-300">Scan with authenticator</p>
+        <p className="text-[12px] text-gray-500">Scan with authenticator</p>
       </div>
     </div>
   ) : null;

--- a/src/app/components/risk-simulation/risk-simulation-dialog.tsx
+++ b/src/app/components/risk-simulation/risk-simulation-dialog.tsx
@@ -288,7 +288,7 @@ function SimulationHistory({
   if (history.length === 0) {
     return (
       <div className="py-12 text-center">
-        <History className="mx-auto h-8 w-8 text-gray-300 mb-2" />
+        <History className="mx-auto h-8 w-8 text-gray-500 mb-2" />
         <p className="text-[14px] text-gray-500">No simulation history</p>
       </div>
     );
@@ -581,7 +581,7 @@ export function RiskSimulationDialog({
               <SimulationResultsPanel result={result} />
             ) : (
               <div className="py-12 text-center">
-                <AlertTriangle className="mx-auto h-8 w-8 text-gray-300 mb-2" />
+                <AlertTriangle className="mx-auto h-8 w-8 text-gray-500 mb-2" />
                 <p className="text-[14px] text-gray-500">Configure parameters and click Simulate</p>
               </div>
             )

--- a/src/app/components/sbom/component-explorer-tab.tsx
+++ b/src/app/components/sbom/component-explorer-tab.tsx
@@ -154,7 +154,7 @@ export function ComponentExplorerTab({
 
         {pagination.total === 0 && (
           <div className="flex flex-col items-center justify-center py-12">
-            <Package className="mb-2 h-8 w-8 text-gray-300" />
+            <Package className="mb-2 h-8 w-8 text-gray-500" />
             <p className="text-[14px] text-gray-500">No components found</p>
           </div>
         )}

--- a/src/app/components/sbom/cve-dashboard-tab.tsx
+++ b/src/app/components/sbom/cve-dashboard-tab.tsx
@@ -72,7 +72,7 @@ export function CVEDashboardTab({
   return (
     <div>
       {/* Severity summary cards */}
-      <div className="mb-5 grid grid-cols-4 gap-4">
+      <div className="mb-5 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
         {(["Critical", "High", "Medium", "Low"] as SeverityLevel[]).map((sev) => {
           const cfg = SEVERITY_CONFIG[sev];
           return (
@@ -186,7 +186,7 @@ export function CVEDashboardTab({
 
         {pagination.total === 0 && (
           <div className="flex flex-col items-center justify-center py-12">
-            <Shield className="mb-2 h-8 w-8 text-gray-300" />
+            <Shield className="mb-2 h-8 w-8 text-gray-500" />
             <p className="text-[14px] text-gray-500">
               No vulnerabilities match the current filters
             </p>

--- a/src/app/components/sbom/sbom-management-tab.tsx
+++ b/src/app/components/sbom/sbom-management-tab.tsx
@@ -91,7 +91,7 @@ export function SBOMManagementTab({
 
       {filtered.length === 0 && (
         <div className="flex flex-col items-center justify-center py-16">
-          <FileBox className="mb-3 h-10 w-10 text-gray-300" />
+          <FileBox className="mb-3 h-10 w-10 text-gray-500" />
           <p className="text-[15px] font-medium text-gray-500">No SBOMs found</p>
           <p className="text-[14px] text-gray-500">Upload an SBOM to get started</p>
         </div>

--- a/src/app/components/sbom/sbom-utils.tsx
+++ b/src/app/components/sbom/sbom-utils.tsx
@@ -48,7 +48,7 @@ export function PaginationControls({
           className={cn(
             "rounded-lg px-2.5 py-1 cursor-pointer",
             pagination.currentPage === 1
-              ? "text-gray-300 cursor-not-allowed"
+              ? "text-gray-500 cursor-not-allowed"
               : "text-gray-600 hover:bg-gray-100",
           )}
         >
@@ -74,7 +74,7 @@ export function PaginationControls({
           className={cn(
             "rounded-lg px-2.5 py-1 cursor-pointer",
             pagination.currentPage === pagination.totalPages
-              ? "text-gray-300 cursor-not-allowed"
+              ? "text-gray-500 cursor-not-allowed"
               : "text-gray-600 hover:bg-gray-100",
           )}
         >

--- a/src/app/components/search/vulnerability-search.tsx
+++ b/src/app/components/search/vulnerability-search.tsx
@@ -117,7 +117,7 @@ const SEVERITY_COLORS: Record<string, { bg: string; text: string; dot: string }>
   },
   Info: {
     bg: "bg-gray-50 dark:bg-gray-800",
-    text: "text-gray-600 dark:text-gray-400",
+    text: "text-gray-600 dark:text-gray-500",
     dot: "bg-gray-400",
   },
 };

--- a/src/app/components/telemetry/device-telemetry-chart.tsx
+++ b/src/app/components/telemetry/device-telemetry-chart.tsx
@@ -354,7 +354,7 @@ export function DeviceTelemetryChart({ deviceId, deviceName }: DeviceTelemetryCh
   if (!latestReading) {
     return (
       <div className="card-elevated p-8 text-center">
-        <Activity className="mx-auto h-10 w-10 text-gray-300 mb-3" />
+        <Activity className="mx-auto h-10 w-10 text-gray-500 mb-3" />
         <p className="text-[15px] font-medium text-gray-600">No telemetry data available</p>
         <p className="mt-1 text-[14px] text-gray-500">
           Telemetry data will appear here once the device begins reporting
@@ -460,7 +460,7 @@ export function DeviceTelemetryChart({ deviceId, deviceName }: DeviceTelemetryCh
                     ) : trend === "down" ? (
                       <TrendingDown className="h-2.5 w-2.5 text-emerald-400" />
                     ) : (
-                      <Minus className="h-2.5 w-2.5 text-gray-300" />
+                      <Minus className="h-2.5 w-2.5 text-gray-500" />
                     )}
                   </div>
                 </div>

--- a/src/app/components/telemetry/telemetry-heatmap-page.tsx
+++ b/src/app/components/telemetry/telemetry-heatmap-page.tsx
@@ -192,7 +192,7 @@ function OverviewTab({ onNavigateHeatmap }: { onNavigateHeatmap: () => void }) {
               {riskTrend.toFixed(1)}%
             </span>
             <span className="text-[12px] text-gray-500">vs last 24h</span>
-            <ChevronRight className="ml-auto h-3.5 w-3.5 text-gray-300" />
+            <ChevronRight className="ml-auto h-3.5 w-3.5 text-gray-500" />
           </div>
         </button>
 
@@ -266,7 +266,7 @@ function OverviewTab({ onNavigateHeatmap }: { onNavigateHeatmap: () => void }) {
 
           {recentResults.length === 0 ? (
             <div className="py-6 text-center">
-              <Target className="mx-auto h-8 w-8 text-gray-300 mb-2" />
+              <Target className="mx-auto h-8 w-8 text-gray-500 mb-2" />
               <p className="text-[14px] text-gray-500">No recent impact analyses</p>
               <button className="mt-2 text-[14px] font-medium text-[#FF7900] hover:underline cursor-pointer">
                 Run Simulation

--- a/src/app/components/user-management.tsx
+++ b/src/app/components/user-management.tsx
@@ -383,7 +383,7 @@ export function UserManagement() {
                           <span
                             className={cn(
                               "text-[15px] font-medium",
-                              user.status === "Disabled" ? "text-gray-400" : "text-gray-900",
+                              user.status === "Disabled" ? "text-gray-500" : "text-gray-900",
                             )}
                           >
                             {user.name}


### PR DESCRIPTION
## Summary

### Light text contrast
- `text-gray-400` → `text-gray-500` (2.54:1 → 4.83:1)
- `text-gray-300` → `text-gray-500` (1.47:1 → 4.83:1)
- `muted-foreground/40` → `muted-foreground/70`
- Fixes: date text, subtitle text, helper descriptions

### Responsive tablet layout
- Sidebar hidden below `md` (768px) — content gets full width
- Main content padding: responsive `px-4 sm:px-5 md:px-6`
- Fixed `grid-cols-3/4` → responsive breakpoints on key pages
- Grids stack properly on small screens

Closes part of #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)