### PR TITLE
[Story 19.6/19.7/19.8] Session management, API client, API versioning

### DIFF
--- a/Docs/decisions/006-api-versioning.md
+++ b/Docs/decisions/006-api-versioning.md
@@ -1,0 +1,79 @@
+# ADR-006: API Versioning Strategy
+
+**Status:** Accepted
+**Date:** 2026-04-01
+
+## Context
+
+IMS Gen2 is designed as a cloud-agnostic template. Different backend providers (AppSync, REST APIs, Azure Functions) may version their APIs differently. The frontend needs a consistent way to:
+
+1. Declare which API version it expects
+2. Detect when the server version has changed
+3. Degrade gracefully when endpoints are deprecated
+
+Without a strategy, version mismatches cause silent failures or breaking changes that are difficult to diagnose.
+
+## Decision
+
+Support **two versioning modes**, configurable per provider adapter:
+
+### 1. Header-Based (Default)
+
+Every request includes `X-API-Version: {version}` header. The server echoes back its version in the response. This is the recommended approach for GraphQL APIs (AppSync) where the URL is fixed.
+
+### 2. Path-Based
+
+The URL is prefixed with `/v{N}/` (e.g., `/v1/devices`, `/v2/devices`). This is the standard REST convention and is preferred for traditional REST APIs.
+
+### Version Mismatch Detection
+
+On every response, the client checks the server's `X-API-Version` header. If it differs from the client's expected version, a warning is surfaced via configurable callback. This can:
+
+- Show a toast: "A newer API version is available. Please refresh."
+- Log to monitoring (Sentry, CloudWatch)
+- Set a `deprecated` flag for UI indicators
+
+### Graceful Degradation
+
+When a mismatch is detected, the client continues operating on its current version. No automatic upgrade or redirect. The user can refresh at their convenience. This prevents mid-session disruption.
+
+## Implementation
+
+```
+src/lib/api-version.ts
+  ├── createApiVersionManager(config) → IApiVersionManager
+  ├── createVersionInterceptor(manager) → request interceptor
+  └── createVersionCheckInterceptor(manager) → response interceptor
+```
+
+The interceptors plug into `createApiClient()` from `src/lib/api-client.ts`. Each provider adapter configures its own versioning mode:
+
+```typescript
+const versionManager = createApiVersionManager({
+  version: "1",
+  mode: "header", // or "path" for REST APIs
+  onVersionMismatch: (client, server) => {
+    toast.info(`API updated to v${server}. Refresh for latest features.`);
+  },
+});
+
+const client = createApiClient({
+  requestInterceptors: [createVersionInterceptor(versionManager)],
+  responseInterceptors: [createVersionCheckInterceptor(versionManager)],
+});
+```
+
+## Alternatives Considered
+
+| Alternative                                               | Why Rejected                                                      |
+| --------------------------------------------------------- | ----------------------------------------------------------------- |
+| **Query parameter** (`?v=1`)                              | Pollutes cache keys, not standard for GraphQL                     |
+| **Accept header** (`Accept: application/vnd.ims.v1+json`) | Over-engineered for our use case, poor tooling support            |
+| **No versioning**                                         | Unacceptable for enterprise — breaking changes must be detectable |
+| **Auto-upgrade on mismatch**                              | Risky — could break mid-session forms or workflows                |
+
+## Consequences
+
+- **Positive:** Consistent versioning across all provider adapters. Mismatch detection prevents silent failures. Template adopters get versioning out of the box.
+- **Positive:** Both GraphQL (header) and REST (path) patterns supported.
+- **Negative:** Requires server cooperation — backend must echo `X-API-Version` header for mismatch detection to work. Without it, detection is a no-op (safe fallback).

--- a/src/__tests__/lib/api-client.test.ts
+++ b/src/__tests__/lib/api-client.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { createApiClient, type IApiClient } from "../../lib/api-client";
+
+// Mock fetch
+const mockFetch = vi.fn();
+globalThis.fetch = mockFetch;
+
+function jsonResponse(data: unknown, status = 200, headers: Record<string, string> = {}) {
+  const headerMap = new Map(Object.entries(headers));
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? "OK" : `Error ${status}`,
+    json: () => Promise.resolve(data),
+    headers: {
+      forEach: (cb: (value: string, key: string) => void) => headerMap.forEach(cb),
+      get: (key: string) => headerMap.get(key) ?? null,
+    },
+  };
+}
+
+describe("ApiClient", () => {
+  let client: IApiClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    client = createApiClient({
+      baseUrl: "https://api.test.com",
+      baseDelayMs: 10,
+      maxDelayMs: 50,
+      maxRetries: { query: 2, mutation: 1, upload: 0 },
+      timeouts: { query: 5000, mutation: 10000, upload: 60000 },
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("executes a successful GET request", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ items: [1, 2, 3] }));
+
+    const response = await client.execute({ url: "/devices" });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    expect(response.data).toEqual({ items: [1, 2, 3] });
+    expect(response.status).toBe(200);
+  });
+
+  it("adds Content-Type header by default", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({}));
+
+    await client.execute({ url: "/test" });
+
+    const callArgs = mockFetch.mock.calls[0]!;
+    expect(callArgs[1].headers["Content-Type"]).toBe("application/json");
+  });
+
+  it("retries on 503 with exponential backoff", async () => {
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse(null, 503))
+      .mockResolvedValueOnce(jsonResponse(null, 503))
+      .mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+    const response = await client.execute({ url: "/devices", type: "query" });
+
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(response.data).toEqual({ ok: true });
+  });
+
+  it("does not retry mutations more than once", async () => {
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse(null, 503))
+      .mockResolvedValueOnce(jsonResponse(null, 503));
+
+    await expect(
+      client.execute({ url: "/orders", type: "mutation", method: "POST" }),
+    ).rejects.toMatchObject({ code: "HTTP_503" });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry uploads", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(null, 503));
+
+    await expect(
+      client.execute({ url: "/upload", type: "upload", method: "POST" }),
+    ).rejects.toMatchObject({ code: "HTTP_503" });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws non-retryable errors immediately", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(null, 404));
+
+    await expect(client.execute({ url: "/missing" })).rejects.toHaveProperty("status", 404);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  describe("circuit breaker", () => {
+    it("opens after consecutive failures", async () => {
+      const cbClient = createApiClient({
+        baseUrl: "https://api.test.com",
+        circuitBreakerThreshold: 3,
+        circuitBreakerCooldownMs: 5000,
+        baseDelayMs: 1,
+        maxRetries: { query: 0, mutation: 0, upload: 0 },
+      });
+
+      // Trigger 3 failures
+      mockFetch.mockResolvedValue(jsonResponse(null, 500));
+      for (let i = 0; i < 3; i++) {
+        await cbClient.execute({ url: "/fail" }).catch(() => {});
+      }
+
+      expect(cbClient.getCircuitState()).toBe("open");
+
+      // Next request should fail immediately without calling fetch
+      const fetchCountBefore = mockFetch.mock.calls.length;
+      await expect(cbClient.execute({ url: "/blocked" })).rejects.toMatchObject({
+        code: "CIRCUIT_OPEN",
+      });
+      expect(mockFetch.mock.calls.length).toBe(fetchCountBefore);
+    });
+
+    it("resets on successful request", async () => {
+      const cbClient = createApiClient({
+        baseUrl: "https://api.test.com",
+        circuitBreakerThreshold: 3,
+        baseDelayMs: 1,
+        maxRetries: { query: 0, mutation: 0, upload: 0 },
+      });
+
+      mockFetch.mockResolvedValueOnce(jsonResponse(null, 500));
+      await cbClient.execute({ url: "/fail" }).catch(() => {});
+
+      mockFetch.mockResolvedValueOnce(jsonResponse({ ok: true }));
+      await cbClient.execute({ url: "/ok" });
+
+      expect(cbClient.getCircuitState()).toBe("closed");
+    });
+
+    it("can be manually reset", async () => {
+      const cbClient = createApiClient({
+        baseUrl: "https://api.test.com",
+        circuitBreakerThreshold: 2,
+        baseDelayMs: 1,
+        maxRetries: { query: 0, mutation: 0, upload: 0 },
+      });
+
+      mockFetch.mockResolvedValue(jsonResponse(null, 500));
+      await cbClient.execute({ url: "/fail" }).catch(() => {});
+      await cbClient.execute({ url: "/fail" }).catch(() => {});
+
+      expect(cbClient.getCircuitState()).toBe("open");
+
+      cbClient.resetCircuit();
+      expect(cbClient.getCircuitState()).toBe("closed");
+    });
+  });
+
+  describe("interceptors", () => {
+    it("applies request interceptors", async () => {
+      const authClient = createApiClient({
+        baseUrl: "https://api.test.com",
+        requestInterceptors: [
+          (req) => ({
+            ...req,
+            headers: { ...req.headers, Authorization: "Bearer token-123" },
+          }),
+        ],
+      });
+
+      mockFetch.mockResolvedValueOnce(jsonResponse({}));
+      await authClient.execute({ url: "/secure" });
+
+      const headers = mockFetch.mock.calls[0]![1].headers;
+      expect(headers["Authorization"]).toBe("Bearer token-123");
+    });
+  });
+});

--- a/src/__tests__/lib/api-version.test.ts
+++ b/src/__tests__/lib/api-version.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  createApiVersionManager,
+  createVersionInterceptor,
+  createVersionCheckInterceptor,
+} from "../../lib/api-version";
+
+describe("ApiVersionManager", () => {
+  describe("header mode", () => {
+    it("adds version header to requests", () => {
+      const manager = createApiVersionManager({ version: "2", mode: "header" });
+      const result = manager.applyVersion("/devices");
+
+      expect(result.url).toBe("/devices");
+      expect(result.headers["X-API-Version"]).toBe("2");
+    });
+
+    it("preserves existing headers", () => {
+      const manager = createApiVersionManager({ version: "1", mode: "header" });
+      const result = manager.applyVersion("/test", { Authorization: "Bearer x" });
+
+      expect(result.headers["Authorization"]).toBe("Bearer x");
+      expect(result.headers["X-API-Version"]).toBe("1");
+    });
+  });
+
+  describe("path mode", () => {
+    it("prefixes URL with version", () => {
+      const manager = createApiVersionManager({ version: "2", mode: "path" });
+      const result = manager.applyVersion("/devices");
+
+      expect(result.url).toBe("/v2/devices");
+      expect(result.headers["X-API-Version"]).toBeUndefined();
+    });
+
+    it("does not double-prefix", () => {
+      const manager = createApiVersionManager({ version: "1", mode: "path" });
+      const result = manager.applyVersion("/v1/devices");
+
+      expect(result.url).toBe("/v1/devices");
+    });
+  });
+
+  describe("version mismatch detection", () => {
+    it("detects when server version differs", () => {
+      const onMismatch = vi.fn();
+      const manager = createApiVersionManager({
+        version: "1",
+        onVersionMismatch: onMismatch,
+      });
+
+      manager.checkResponseVersion({ "x-api-version": "2" });
+
+      expect(onMismatch).toHaveBeenCalledWith("1", "2");
+      expect(manager.isDeprecated()).toBe(true);
+    });
+
+    it("does not trigger when versions match", () => {
+      const onMismatch = vi.fn();
+      const manager = createApiVersionManager({
+        version: "1",
+        onVersionMismatch: onMismatch,
+      });
+
+      manager.checkResponseVersion({ "x-api-version": "1" });
+
+      expect(onMismatch).not.toHaveBeenCalled();
+      expect(manager.isDeprecated()).toBe(false);
+    });
+
+    it("does not trigger when no version header in response", () => {
+      const onMismatch = vi.fn();
+      const manager = createApiVersionManager({
+        version: "1",
+        onVersionMismatch: onMismatch,
+      });
+
+      manager.checkResponseVersion({ "content-type": "application/json" });
+
+      expect(onMismatch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getVersion", () => {
+    it("returns configured version", () => {
+      const manager = createApiVersionManager({ version: "3" });
+      expect(manager.getVersion()).toBe("3");
+    });
+
+    it("defaults to version 1", () => {
+      const manager = createApiVersionManager();
+      expect(manager.getVersion()).toBe("1");
+    });
+  });
+
+  describe("interceptor factories", () => {
+    it("createVersionInterceptor applies version to request", () => {
+      const manager = createApiVersionManager({ version: "2", mode: "header" });
+      const interceptor = createVersionInterceptor(manager);
+
+      const request = interceptor({ url: "/test", headers: {} });
+      expect(request.headers!["X-API-Version"]).toBe("2");
+    });
+
+    it("createVersionCheckInterceptor checks response version", () => {
+      const onMismatch = vi.fn();
+      const manager = createApiVersionManager({
+        version: "1",
+        onVersionMismatch: onMismatch,
+      });
+      const interceptor = createVersionCheckInterceptor(manager);
+
+      interceptor({ headers: { "x-api-version": "3" } });
+      expect(onMismatch).toHaveBeenCalledWith("1", "3");
+    });
+  });
+});

--- a/src/app/components/layouts/protected-layout.tsx
+++ b/src/app/components/layouts/protected-layout.tsx
@@ -6,6 +6,7 @@ import { Header } from "./header";
 import { Breadcrumbs } from "./breadcrumbs";
 import { SkipToContent } from "./skip-to-content";
 import { CommandPalette } from "./command-palette";
+import { SessionTimeoutWarning } from "../session-timeout-warning";
 import { ConnectivityStatusBar } from "../connectivity/connectivity-status-bar";
 import { useConnectivityMonitor } from "../connectivity/use-connectivity-monitor";
 import { Skeleton } from "../../../components/skeleton";
@@ -103,6 +104,7 @@ export function ProtectedLayout() {
         </div>
       </div>
       <CommandPalette />
+      <SessionTimeoutWarning />
     </>
   );
 }

--- a/src/app/components/session-timeout-warning.tsx
+++ b/src/app/components/session-timeout-warning.tsx
@@ -1,0 +1,54 @@
+import { useAuth } from "../../lib/use-auth";
+import { AlertTriangle } from "lucide-react";
+
+/**
+ * Modal shown when the session is about to expire.
+ * Allows the user to extend their session or sign out.
+ */
+export function SessionTimeoutWarning() {
+  const { sessionExpiring, extendSession, signOut } = useAuth();
+
+  if (!sessionExpiring) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby="session-warning-title"
+      aria-describedby="session-warning-desc"
+    >
+      <div className="card-elevated mx-4 w-full max-w-md p-6 shadow-xl">
+        <div className="flex items-start gap-4">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-amber-100 dark:bg-amber-900/30">
+            <AlertTriangle className="h-5 w-5 text-amber-600 dark:text-amber-400" />
+          </div>
+          <div className="flex-1">
+            <h2 id="session-warning-title" className="text-base font-semibold text-foreground">
+              Session Expiring Soon
+            </h2>
+            <p id="session-warning-desc" className="mt-1 text-sm text-muted-foreground">
+              Your session will expire shortly. Would you like to stay signed in?
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-6 flex justify-end gap-3">
+          <button
+            onClick={() => signOut()}
+            className="rounded-lg border border-border px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted"
+          >
+            Sign Out
+          </button>
+          <button
+            onClick={() => extendSession()}
+            className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+            autoFocus
+          >
+            Keep Me Signed In
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -1,0 +1,347 @@
+/**
+ * IMS Gen 2 — Resilient API Client
+ *
+ * Cloud-agnostic HTTP client wrapper with:
+ * - Exponential backoff with jitter
+ * - Circuit breaker (stop calling after N consecutive failures)
+ * - Rate limit awareness (respect 429 + Retry-After)
+ * - Request/response interceptors (auth headers, logging, error normalization)
+ * - Configurable timeouts per request type
+ *
+ * Works with any API provider adapter. Does NOT import cloud SDKs.
+ *
+ * @see Story #181 — API client retry, backoff, circuit breaker
+ */
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type RequestType = "query" | "mutation" | "upload";
+
+export interface ApiClientConfig {
+  /** Base URL for API calls (default: from VITE_API_URL or empty for relative) */
+  baseUrl?: string;
+  /** Max retry attempts per request type */
+  maxRetries?: Partial<Record<RequestType, number>>;
+  /** Base delay in ms for exponential backoff (default: 300) */
+  baseDelayMs?: number;
+  /** Max delay cap in ms (default: 10000) */
+  maxDelayMs?: number;
+  /** Timeout per request type in ms */
+  timeouts?: Partial<Record<RequestType, number>>;
+  /** Circuit breaker: consecutive failures before opening (default: 5) */
+  circuitBreakerThreshold?: number;
+  /** Circuit breaker: cooldown in ms before half-open retry (default: 30000) */
+  circuitBreakerCooldownMs?: number;
+  /** Request interceptors — run before every request */
+  requestInterceptors?: RequestInterceptor[];
+  /** Response interceptors — run after every response */
+  responseInterceptors?: ResponseInterceptor[];
+}
+
+export interface ApiRequest {
+  url: string;
+  method?: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+  type?: RequestType;
+  signal?: AbortSignal;
+}
+
+export interface ApiResponse<T = unknown> {
+  data: T;
+  status: number;
+  headers: Record<string, string>;
+  duration: number;
+}
+
+export interface ApiError {
+  message: string;
+  status?: number;
+  code: string;
+  retryable: boolean;
+  original?: unknown;
+}
+
+export type RequestInterceptor = (request: ApiRequest) => ApiRequest | Promise<ApiRequest>;
+export type ResponseInterceptor = (response: ApiResponse) => ApiResponse | Promise<ApiResponse>;
+
+// =============================================================================
+// Circuit Breaker
+// =============================================================================
+
+type CircuitState = "closed" | "open" | "half-open";
+
+interface CircuitBreaker {
+  state: CircuitState;
+  failures: number;
+  lastFailureAt: number;
+  threshold: number;
+  cooldownMs: number;
+}
+
+function createCircuitBreaker(threshold: number, cooldownMs: number): CircuitBreaker {
+  return {
+    state: "closed",
+    failures: 0,
+    lastFailureAt: 0,
+    threshold,
+    cooldownMs,
+  };
+}
+
+function shouldAllowRequest(cb: CircuitBreaker): boolean {
+  if (cb.state === "closed") return true;
+  if (cb.state === "open") {
+    // Check if cooldown has elapsed → move to half-open
+    if (Date.now() - cb.lastFailureAt >= cb.cooldownMs) {
+      cb.state = "half-open";
+      return true;
+    }
+    return false;
+  }
+  // half-open — allow one probe request
+  return true;
+}
+
+function recordSuccess(cb: CircuitBreaker): void {
+  cb.failures = 0;
+  cb.state = "closed";
+}
+
+function recordFailure(cb: CircuitBreaker): void {
+  cb.failures++;
+  cb.lastFailureAt = Date.now();
+  if (cb.failures >= cb.threshold) {
+    cb.state = "open";
+  }
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Exponential backoff with full jitter. */
+function getBackoffDelay(attempt: number, baseMs: number, maxMs: number): number {
+  const exponential = baseMs * Math.pow(2, attempt);
+  const capped = Math.min(exponential, maxMs);
+  return Math.random() * capped;
+}
+
+function isRetryableStatus(status: number): boolean {
+  return status === 429 || status === 502 || status === 503 || status === 504;
+}
+
+function parseRetryAfter(headers: Record<string, string>): number | null {
+  const value = headers["retry-after"];
+  if (!value) return null;
+  const seconds = Number(value);
+  if (!isNaN(seconds)) return seconds * 1000;
+  const date = Date.parse(value);
+  if (!isNaN(date)) return Math.max(0, date - Date.now());
+  return null;
+}
+
+function normalizeError(err: unknown, status?: number): ApiError {
+  if (err instanceof DOMException && err.name === "AbortError") {
+    return {
+      message: "Request timed out",
+      status,
+      code: "TIMEOUT",
+      retryable: true,
+      original: err,
+    };
+  }
+  if (err instanceof TypeError && err.message.includes("fetch")) {
+    return {
+      message: "Network error",
+      status: 0,
+      code: "NETWORK_ERROR",
+      retryable: true,
+      original: err,
+    };
+  }
+  if (err instanceof Error) {
+    return {
+      message: err.message,
+      status,
+      code: status ? `HTTP_${status}` : "UNKNOWN",
+      retryable: status ? isRetryableStatus(status) : false,
+      original: err,
+    };
+  }
+  return { message: String(err), code: "UNKNOWN", retryable: false, original: err };
+}
+
+// =============================================================================
+// Default Config
+// =============================================================================
+
+const DEFAULT_MAX_RETRIES: Record<RequestType, number> = {
+  query: 3,
+  mutation: 1,
+  upload: 0,
+};
+
+const DEFAULT_TIMEOUTS: Record<RequestType, number> = {
+  query: 10_000,
+  mutation: 30_000,
+  upload: 5 * 60_000,
+};
+
+// =============================================================================
+// API Client
+// =============================================================================
+
+export interface IApiClient {
+  /** Execute an API request with retry, backoff, and circuit breaker. */
+  execute<T = unknown>(request: ApiRequest): Promise<ApiResponse<T>>;
+  /** Get current circuit breaker state (for monitoring/debugging). */
+  getCircuitState(): CircuitState;
+  /** Reset circuit breaker (e.g., after network recovery). */
+  resetCircuit(): void;
+}
+
+export function createApiClient(config: ApiClientConfig = {}): IApiClient {
+  const baseUrl = config.baseUrl ?? "";
+  const baseDelayMs = config.baseDelayMs ?? 300;
+  const maxDelayMs = config.maxDelayMs ?? 10_000;
+  const maxRetries = { ...DEFAULT_MAX_RETRIES, ...config.maxRetries };
+  const timeouts = { ...DEFAULT_TIMEOUTS, ...config.timeouts };
+  const requestInterceptors = config.requestInterceptors ?? [];
+  const responseInterceptors = config.responseInterceptors ?? [];
+
+  const circuit = createCircuitBreaker(
+    config.circuitBreakerThreshold ?? 5,
+    config.circuitBreakerCooldownMs ?? 30_000,
+  );
+
+  async function execute<T = unknown>(request: ApiRequest): Promise<ApiResponse<T>> {
+    const type = request.type ?? "query";
+    const retries = maxRetries[type];
+    const timeout = timeouts[type];
+
+    // Circuit breaker check
+    if (!shouldAllowRequest(circuit)) {
+      throw {
+        message: "Circuit breaker is open — API temporarily unavailable",
+        code: "CIRCUIT_OPEN",
+        retryable: false,
+      } satisfies ApiError;
+    }
+
+    // Apply request interceptors
+    let req = { ...request };
+    for (const interceptor of requestInterceptors) {
+      req = await interceptor(req);
+    }
+
+    let lastError: ApiError | null = null;
+
+    for (let attempt = 0; attempt <= retries; attempt++) {
+      // Backoff delay (skip on first attempt)
+      if (attempt > 0) {
+        const backoff = getBackoffDelay(attempt - 1, baseDelayMs, maxDelayMs);
+        await delay(backoff);
+      }
+
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), timeout);
+      const start = performance.now();
+
+      try {
+        const url = baseUrl + req.url;
+        const fetchResponse = await fetch(url, {
+          method: req.method ?? "GET",
+          headers: {
+            "Content-Type": "application/json",
+            ...req.headers,
+          },
+          body: req.body ? JSON.stringify(req.body) : undefined,
+          signal: req.signal ?? controller.signal,
+        });
+
+        clearTimeout(timeoutId);
+        const duration = performance.now() - start;
+
+        const responseHeaders: Record<string, string> = {};
+        fetchResponse.headers.forEach((v, k) => {
+          responseHeaders[k] = v;
+        });
+
+        if (!fetchResponse.ok) {
+          const status = fetchResponse.status;
+
+          // Rate limited — respect Retry-After
+          if (status === 429) {
+            const retryAfter = parseRetryAfter(responseHeaders);
+            if (retryAfter && attempt < retries) {
+              await delay(retryAfter);
+              continue;
+            }
+          }
+
+          if (isRetryableStatus(status) && attempt < retries) {
+            recordFailure(circuit);
+            lastError = normalizeError(new Error(`HTTP ${status}`), status);
+            continue;
+          }
+
+          recordFailure(circuit);
+          throw normalizeError(new Error(`HTTP ${status}: ${fetchResponse.statusText}`), status);
+        }
+
+        // Success
+        recordSuccess(circuit);
+        const data = (await fetchResponse.json()) as T;
+
+        let response: ApiResponse<T> = {
+          data,
+          status: fetchResponse.status,
+          headers: responseHeaders,
+          duration,
+        };
+
+        // Apply response interceptors
+        for (const interceptor of responseInterceptors) {
+          response = (await interceptor(response as ApiResponse)) as ApiResponse<T>;
+        }
+
+        return response;
+      } catch (err) {
+        clearTimeout(timeoutId);
+
+        // Already-normalized ApiError — rethrow as-is
+        if (typeof err === "object" && err !== null && "code" in err && "retryable" in err) {
+          const apiErr = err as ApiError;
+          if (!apiErr.retryable || attempt >= retries) throw apiErr;
+          lastError = apiErr;
+          continue;
+        }
+
+        lastError = normalizeError(err);
+        if (!lastError.retryable || attempt >= retries) {
+          recordFailure(circuit);
+          throw lastError;
+        }
+        recordFailure(circuit);
+      }
+    }
+
+    throw lastError ?? normalizeError(new Error("Request failed after retries"));
+  }
+
+  return {
+    execute,
+    getCircuitState: () => circuit.state,
+    resetCircuit: () => {
+      circuit.state = "closed";
+      circuit.failures = 0;
+    },
+  };
+}

--- a/src/lib/api-version.ts
+++ b/src/lib/api-version.ts
@@ -1,0 +1,122 @@
+/**
+ * IMS Gen 2 — API Versioning Strategy
+ *
+ * Supports two versioning modes (configured per provider):
+ * - Header-based: sends X-API-Version header with every request
+ * - Path-based: prefixes URL with /v1/, /v2/, etc.
+ *
+ * Includes version mismatch detection — if the server responds with a
+ * different version than expected, a warning is surfaced.
+ *
+ * @see ADR-006 for the rationale behind this design.
+ * @see Story #182 — API versioning strategy
+ */
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type VersioningMode = "header" | "path";
+
+export interface ApiVersionConfig {
+  /** Current client API version (default: "1") */
+  version: string;
+  /** Versioning mode: "header" sends X-API-Version, "path" prefixes /v{N}/ */
+  mode: VersioningMode;
+  /** Header name for server-reported version in responses (default: "X-API-Version") */
+  versionHeader: string;
+  /** Called when server version doesn't match client version */
+  onVersionMismatch?: (clientVersion: string, serverVersion: string) => void;
+}
+
+export interface VersionedRequest {
+  url: string;
+  headers: Record<string, string>;
+}
+
+// =============================================================================
+// Defaults
+// =============================================================================
+
+const DEFAULT_CONFIG: ApiVersionConfig = {
+  version: "1",
+  mode: "header",
+  versionHeader: "X-API-Version",
+};
+
+// =============================================================================
+// API Version Manager
+// =============================================================================
+
+export interface IApiVersionManager {
+  /** Apply versioning to a request (add header or rewrite URL). */
+  applyVersion(url: string, headers?: Record<string, string>): VersionedRequest;
+  /** Check response headers for version mismatch. */
+  checkResponseVersion(responseHeaders: Record<string, string>): void;
+  /** Get current client version. */
+  getVersion(): string;
+  /** Whether a deprecation warning has been detected. */
+  isDeprecated(): boolean;
+}
+
+export function createApiVersionManager(config?: Partial<ApiVersionConfig>): IApiVersionManager {
+  const resolved: ApiVersionConfig = { ...DEFAULT_CONFIG, ...config };
+  let deprecated = false;
+
+  return {
+    applyVersion(url: string, headers: Record<string, string> = {}): VersionedRequest {
+      if (resolved.mode === "header") {
+        return {
+          url,
+          headers: { ...headers, [resolved.versionHeader]: resolved.version },
+        };
+      }
+
+      // Path-based: prefix /v{N}/ if not already present
+      const versionPrefix = `/v${resolved.version}`;
+      const prefixedUrl = url.startsWith(versionPrefix) ? url : `${versionPrefix}${url}`;
+      return { url: prefixedUrl, headers };
+    },
+
+    checkResponseVersion(responseHeaders: Record<string, string>): void {
+      const serverVersion =
+        responseHeaders[resolved.versionHeader.toLowerCase()] ??
+        responseHeaders[resolved.versionHeader];
+      if (!serverVersion) return;
+
+      if (serverVersion !== resolved.version) {
+        deprecated = true;
+        resolved.onVersionMismatch?.(resolved.version, serverVersion);
+      }
+    },
+
+    getVersion(): string {
+      return resolved.version;
+    },
+
+    isDeprecated(): boolean {
+      return deprecated;
+    },
+  };
+}
+
+/**
+ * Request interceptor factory — plugs into createApiClient().
+ * Adds version headers/path to every outgoing request.
+ */
+export function createVersionInterceptor(manager: IApiVersionManager) {
+  return (request: { url: string; headers?: Record<string, string> }) => {
+    const versioned = manager.applyVersion(request.url, request.headers);
+    return { ...request, url: versioned.url, headers: versioned.headers };
+  };
+}
+
+/**
+ * Response interceptor factory — checks server version on every response.
+ */
+export function createVersionCheckInterceptor(manager: IApiVersionManager) {
+  return (response: { headers: Record<string, string> }) => {
+    manager.checkResponseVersion(response.headers);
+    return response;
+  };
+}

--- a/src/lib/providers/auth-adapter.ts
+++ b/src/lib/providers/auth-adapter.ts
@@ -92,4 +92,7 @@ export interface IAuthAdapter {
 
   /** Refresh the token when it has fewer than this many ms remaining. */
   readonly refreshThresholdMs: number;
+
+  /** Show session expiry warning when fewer than this many ms remain. */
+  readonly sessionWarningMs: number;
 }

--- a/src/lib/providers/auth-provider.tsx
+++ b/src/lib/providers/auth-provider.tsx
@@ -2,12 +2,7 @@
  * IMS Gen 2 — Generic Auth Provider
  *
  * Cloud-agnostic React component that manages auth state using any IAuthAdapter.
- * Components consume auth via the existing useAuth() hook — they never know
- * which IdP is behind the adapter.
- *
- * Usage:
- *   const MyAuthProvider = createAuthProvider(myAdapter);
- *   <MyAuthProvider>{children}</MyAuthProvider>
+ * Features: silent token refresh, session expiry warnings, multi-tab sync.
  */
 
 import {
@@ -22,9 +17,12 @@ import { toast } from "sonner";
 import { AuthContext } from "../auth-context-instance";
 import type { IAuthAdapter, AuthSession } from "./auth-adapter";
 
+const BROADCAST_CHANNEL_NAME = "ims-auth-sync";
+
+type AuthSyncMessage = { type: "SIGN_OUT" } | { type: "SESSION_UPDATED"; session: AuthSession };
+
 /**
  * Factory that creates an AuthProvider component bound to a specific adapter.
- * The adapter instance is captured in closure — one per platform.
  */
 export function createAuthProvider(adapter: IAuthAdapter): ComponentType<{ children: ReactNode }> {
   function AuthProvider({ children }: { children: ReactNode }) {
@@ -33,9 +31,31 @@ export function createAuthProvider(adapter: IAuthAdapter): ComponentType<{ child
     const [signInError, setSignInError] = useState<string | null>(null);
     const [mfaRequired, setMfaRequired] = useState(false);
     const [mfaEnabled, setMfaEnabled] = useState(false);
+    const [sessionExpiring, setSessionExpiring] = useState(false);
 
     const sessionRef = useRef<AuthSession | null>(null);
     const refreshIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    const channelRef = useRef<BroadcastChannel | null>(null);
+
+    // --- BroadcastChannel for multi-tab sync ---
+
+    const getBroadcastChannel = useCallback(() => {
+      if (!channelRef.current && typeof BroadcastChannel !== "undefined") {
+        channelRef.current = new BroadcastChannel(BROADCAST_CHANNEL_NAME);
+      }
+      return channelRef.current;
+    }, []);
+
+    const broadcastMessage = useCallback(
+      (msg: AuthSyncMessage) => {
+        try {
+          getBroadcastChannel()?.postMessage(msg);
+        } catch {
+          // BroadcastChannel not supported — single-tab fallback
+        }
+      },
+      [getBroadcastChannel],
+    );
 
     // --- Refresh loop ---
 
@@ -47,18 +67,22 @@ export function createAuthProvider(adapter: IAuthAdapter): ComponentType<{ child
     }, []);
 
     const forceLogout = useCallback(
-      (message?: string) => {
+      (message?: string, broadcast = true) => {
         stopRefreshLoop();
         adapter.clearSession();
         sessionRef.current = null;
         setUser(null);
         setMfaRequired(false);
         setSignInError(null);
+        setSessionExpiring(false);
+        if (broadcast) {
+          broadcastMessage({ type: "SIGN_OUT" });
+        }
         if (message) {
           toast.warning(message);
         }
       },
-      [stopRefreshLoop],
+      [stopRefreshLoop, broadcastMessage],
     );
 
     const checkAndRefreshToken = useCallback(async () => {
@@ -73,6 +97,14 @@ export function createAuthProvider(adapter: IAuthAdapter): ComponentType<{ child
       }
 
       const timeLeft = session.accessTokenExpiresAt - now;
+
+      // Session expiry warning
+      if (timeLeft <= adapter.sessionWarningMs && timeLeft > 0) {
+        setSessionExpiring(true);
+      } else {
+        setSessionExpiring(false);
+      }
+
       if (timeLeft > adapter.refreshThresholdMs) return;
 
       try {
@@ -83,15 +115,39 @@ export function createAuthProvider(adapter: IAuthAdapter): ComponentType<{ child
         }
         adapter.saveSession(updated);
         sessionRef.current = updated;
+        setSessionExpiring(false);
+        broadcastMessage({ type: "SESSION_UPDATED", session: updated });
       } catch {
         toast.warning("Unable to refresh session");
       }
-    }, [forceLogout]);
+    }, [forceLogout, broadcastMessage]);
 
     const startRefreshLoop = useCallback(() => {
       stopRefreshLoop();
       refreshIntervalRef.current = setInterval(checkAndRefreshToken, adapter.refreshIntervalMs);
     }, [checkAndRefreshToken, stopRefreshLoop]);
+
+    // --- Extend session (user clicks "Keep me signed in") ---
+
+    const extendSession = useCallback(async () => {
+      const session = sessionRef.current ?? adapter.loadSession();
+      if (!session) return;
+
+      try {
+        const updated = await adapter.refreshToken(session);
+        if (!updated) {
+          forceLogout("Unable to extend session. Please sign in again.");
+          return;
+        }
+        adapter.saveSession(updated);
+        sessionRef.current = updated;
+        setSessionExpiring(false);
+        broadcastMessage({ type: "SESSION_UPDATED", session: updated });
+        toast.success("Session extended");
+      } catch {
+        toast.warning("Unable to extend session");
+      }
+    }, [forceLogout, broadcastMessage]);
 
     // --- Restore session on mount ---
 
@@ -129,6 +185,39 @@ export function createAuthProvider(adapter: IAuthAdapter): ComponentType<{ child
       setIsLoading(false);
     }, []);
 
+    // --- Multi-tab sync listener ---
+
+    useEffect(() => {
+      const channel = getBroadcastChannel();
+      if (!channel) return;
+
+      const handleMessage = (event: MessageEvent<AuthSyncMessage>) => {
+        const msg = event.data;
+        if (msg.type === "SIGN_OUT") {
+          // Another tab signed out — mirror locally without re-broadcasting
+          stopRefreshLoop();
+          adapter.clearSession();
+          sessionRef.current = null;
+          setUser(null);
+          setMfaRequired(false);
+          setSignInError(null);
+          setSessionExpiring(false);
+          toast.info("Signed out from another tab");
+        } else if (msg.type === "SESSION_UPDATED") {
+          // Another tab refreshed — update our local state
+          adapter.saveSession(msg.session);
+          sessionRef.current = msg.session;
+          setUser(msg.session.user);
+          setSessionExpiring(false);
+        }
+      };
+
+      channel.addEventListener("message", handleMessage);
+      return () => {
+        channel.removeEventListener("message", handleMessage);
+      };
+    }, [getBroadcastChannel, stopRefreshLoop]);
+
     // --- Start/stop refresh loop based on auth state ---
 
     useEffect(() => {
@@ -140,49 +229,66 @@ export function createAuthProvider(adapter: IAuthAdapter): ComponentType<{ child
       return stopRefreshLoop;
     }, [user, startRefreshLoop, stopRefreshLoop]);
 
+    // --- Cleanup BroadcastChannel on unmount ---
+
+    useEffect(() => {
+      return () => {
+        channelRef.current?.close();
+        channelRef.current = null;
+      };
+    }, []);
+
     // --- Auth actions ---
 
-    const signIn = useCallback(async (email: string, password: string) => {
-      setSignInError(null);
-      setMfaRequired(false);
-
-      try {
-        const result = await adapter.signIn(email, password);
-
-        if (result.mfaRequired) {
-          setMfaRequired(true);
-          return;
-        }
-
-        if (result.session) {
-          adapter.saveSession(result.session);
-          sessionRef.current = result.session;
-          setUser(result.session.user);
-          setMfaEnabled(adapter.isMfaEnabled(email));
-        }
-      } catch (err) {
-        const message = err instanceof Error ? err.message : "Sign-in failed. Please try again.";
-        setSignInError(message);
-        throw err;
-      }
-    }, []);
-
-    const verifyMfa = useCallback(async (code: string) => {
-      setSignInError(null);
-
-      try {
-        const session = await adapter.verifyMfa(code);
-        adapter.saveSession(session);
-        sessionRef.current = session;
-        setUser(session.user);
+    const signIn = useCallback(
+      async (email: string, password: string) => {
+        setSignInError(null);
         setMfaRequired(false);
-        setMfaEnabled(true);
-      } catch (err) {
-        const message = err instanceof Error ? err.message : "Invalid verification code.";
-        setSignInError(message);
-        throw err;
-      }
-    }, []);
+
+        try {
+          const result = await adapter.signIn(email, password);
+
+          if (result.mfaRequired) {
+            setMfaRequired(true);
+            return;
+          }
+
+          if (result.session) {
+            adapter.saveSession(result.session);
+            sessionRef.current = result.session;
+            setUser(result.session.user);
+            setMfaEnabled(adapter.isMfaEnabled(email));
+            broadcastMessage({ type: "SESSION_UPDATED", session: result.session });
+          }
+        } catch (err) {
+          const message = err instanceof Error ? err.message : "Sign-in failed. Please try again.";
+          setSignInError(message);
+          throw err;
+        }
+      },
+      [broadcastMessage],
+    );
+
+    const verifyMfa = useCallback(
+      async (code: string) => {
+        setSignInError(null);
+
+        try {
+          const session = await adapter.verifyMfa(code);
+          adapter.saveSession(session);
+          sessionRef.current = session;
+          setUser(session.user);
+          setMfaRequired(false);
+          setMfaEnabled(true);
+          broadcastMessage({ type: "SESSION_UPDATED", session });
+        } catch (err) {
+          const message = err instanceof Error ? err.message : "Invalid verification code.";
+          setSignInError(message);
+          throw err;
+        }
+      },
+      [broadcastMessage],
+    );
 
     const setupMfa = useCallback(async () => {
       const email = user?.email ?? "user@company.com";
@@ -207,7 +313,9 @@ export function createAuthProvider(adapter: IAuthAdapter): ComponentType<{ child
       setUser(null);
       setMfaRequired(false);
       setSignInError(null);
-    }, [stopRefreshLoop]);
+      setSessionExpiring(false);
+      broadcastMessage({ type: "SIGN_OUT" });
+    }, [stopRefreshLoop, broadcastMessage]);
 
     return (
       <AuthContext.Provider
@@ -221,11 +329,13 @@ export function createAuthProvider(adapter: IAuthAdapter): ComponentType<{ child
           signInError,
           mfaRequired,
           mfaEnabled,
+          sessionExpiring,
           signIn,
           verifyMfa,
           setupMfa,
           confirmMfaSetup,
           signOut,
+          extendSession,
         }}
       >
         {children}

--- a/src/lib/providers/cognito/cognito-auth-adapter.ts
+++ b/src/lib/providers/cognito/cognito-auth-adapter.ts
@@ -26,6 +26,7 @@ const STORAGE_KEY = "ims-auth";
 const ACCESS_TOKEN_TTL_MS = 60 * 60 * 1000; // Cognito default: 1 hour
 const REFRESH_CHECK_INTERVAL_MS = 30 * 1000;
 const REFRESH_THRESHOLD_MS = 5 * 60 * 1000; // refresh 5 min before expiry
+const SESSION_WARNING_MS = 2 * 60 * 1000; // warn user at T-2 minutes
 
 // =============================================================================
 // Helpers
@@ -87,6 +88,7 @@ export function createCognitoAuthAdapter(options: CognitoAuthAdapterOptions): IA
   const adapter: IAuthAdapter = {
     refreshIntervalMs: REFRESH_CHECK_INTERVAL_MS,
     refreshThresholdMs: REFRESH_THRESHOLD_MS,
+    sessionWarningMs: SESSION_WARNING_MS,
 
     async signIn(email: string, password: string): Promise<SignInResult> {
       // Real implementation:

--- a/src/lib/providers/mock/mock-auth-adapter.ts
+++ b/src/lib/providers/mock/mock-auth-adapter.ts
@@ -19,6 +19,7 @@ const ACCESS_TOKEN_TTL_MS = 15 * 60 * 1000; // 15 minutes
 const REFRESH_TOKEN_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 const REFRESH_CHECK_INTERVAL_MS = 30 * 1000; // check every 30s
 const REFRESH_THRESHOLD_MS = 60 * 1000; // refresh when <1 min left
+const SESSION_WARNING_MS = 2 * 60 * 1000; // warn at T-2 minutes
 
 const MOCK_TOTP_SECRET = "JBSWY3DPEHPK3PXP";
 
@@ -112,6 +113,7 @@ export function createMockAuthAdapter(options?: MockAuthAdapterOptions): IAuthAd
     // --- Config ---
     refreshIntervalMs: REFRESH_CHECK_INTERVAL_MS,
     refreshThresholdMs: REFRESH_THRESHOLD_MS,
+    sessionWarningMs: SESSION_WARNING_MS,
 
     // --- Core Auth ---
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -319,9 +319,13 @@ export interface AuthState {
   signInError: string | null;
   mfaRequired: boolean;
   mfaEnabled: boolean;
+  /** True when session is about to expire (T-2 min). Show a warning modal. */
+  sessionExpiring: boolean;
   signIn: (email: string, password: string) => Promise<void>;
   verifyMfa: (code: string) => Promise<void>;
   setupMfa: () => Promise<string>;
   confirmMfaSetup: (code: string) => Promise<void>;
   signOut: () => void;
+  /** Extend the current session (dismisses the expiry warning). */
+  extendSession: () => Promise<void>;
 }


### PR DESCRIPTION
## Summary
Three P0 template stories in one batch:

### #180 — Session Management
- **Session expiry warning** modal at T-2 min with "Keep Me Signed In" / "Sign Out" buttons
- **Multi-tab sync** via BroadcastChannel API — sign-out in one tab signs out all tabs
- **extendSession()** action forces token refresh and dismisses warning
- `sessionExpiring` boolean on AuthState for UI consumption

### #181 — Resilient API Client
- **Exponential backoff** with full jitter (configurable per request type: query=3, mutation=1, upload=0)
- **Circuit breaker** — opens after N consecutive failures, auto-recovers via half-open probe
- **Rate limit awareness** — respects 429 status + Retry-After header
- **Request/response interceptors** for auth headers, logging, versioning
- **Configurable timeouts** per type (query: 10s, mutation: 30s, upload: 5min)

### #182 — API Versioning
- **Header-based** (`X-API-Version`) or **path-based** (`/v1/`) modes
- **Version mismatch detection** with configurable callback
- **Interceptor factories** that plug into the API client
- **ADR-006** documenting the strategy and alternatives considered

## Files Changed
| Area | Files |
|------|-------|
| Session | `auth-provider.tsx`, `auth-adapter.ts`, `types.ts`, `session-timeout-warning.tsx`, `protected-layout.tsx`, `mock-auth-adapter.ts`, `cognito-auth-adapter.ts` |
| API Client | `api-client.ts` (new) |
| Versioning | `api-version.ts` (new), `Docs/decisions/006-api-versioning.md` (new) |
| Tests | `api-client.test.ts` (10 tests), `api-version.test.ts` (11 tests) |

## Test plan
- [x] 101 tests passing (21 new + 80 existing)
- [x] Build passes (tsc + Vite)
- [x] Lint passes (0 errors)
- [x] No breaking changes — useAuth() backward compatible (new fields are additive)

Closes #180, closes #181, closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)