### PR TITLE
[Bug Fix] Fix CSS print:hidden pseudo-class warning

### DIFF
--- a/src/app/components/executive/executive-summary-page.tsx
+++ b/src/app/components/executive/executive-summary-page.tsx
@@ -259,7 +259,7 @@ export function ExecutiveSummaryPage() {
             {dateStr} | Last updated {lastRefresh.toLocaleTimeString()}
           </p>
         </div>
-        <div className="flex items-center gap-3 print:hidden">
+        <div className="flex items-center gap-3 print-hidden">
           {/* Time Range Selector (AC2) */}
           <div
             className="flex rounded-lg border border-border bg-muted/50 p-0.5"
@@ -342,7 +342,7 @@ export function ExecutiveSummaryPage() {
           <h3 className="text-base font-semibold text-foreground mb-4">Device Status</h3>
           <PieChart segments={DEVICE_STATUS} />
           {/* Accessible data table alternative (Story 16.6 AC4) */}
-          <details className="mt-3 print:hidden">
+          <details className="mt-3 print-hidden">
             <summary className="text-[13px] text-muted-foreground cursor-pointer hover:text-foreground">
               View as table
             </summary>
@@ -398,7 +398,7 @@ export function ExecutiveSummaryPage() {
             label="Compliance status: Approved, Pending, Deprecated counts"
           />
           {/* Accessible table */}
-          <details className="mt-3 print:hidden">
+          <details className="mt-3 print-hidden">
             <summary className="text-[13px] text-muted-foreground cursor-pointer hover:text-foreground">
               View as table
             </summary>
@@ -433,7 +433,7 @@ export function ExecutiveSummaryPage() {
             color="#FF7900"
             label="Weekly deployment counts"
           />
-          <details className="mt-3 print:hidden">
+          <details className="mt-3 print-hidden">
             <summary className="text-[13px] text-muted-foreground cursor-pointer hover:text-foreground">
               View as table
             </summary>

--- a/src/index.css
+++ b/src/index.css
@@ -226,6 +226,10 @@ body {
 
 /* Print styles for Executive Summary (Story 16.4) */
 @media print {
+  .print-hidden {
+    display: none !important;
+  }
+
   body {
     background: white !important;
     color: #111827 !important;


### PR DESCRIPTION
## Summary
- Replaced Tailwind `print:hidden` variant with custom `.print-hidden` class in `@media print` block
- Fixed 4 occurrences in `executive-summary-page.tsx`
- Root cause: Vite's Lightning CSS optimizer misinterpreting `print\:hidden` as a pseudo-class

Closes #235

## Test plan
- [x] `npm run build` produces zero CSS warnings
- [ ] Print preview still hides navigation/action elements
- [ ] No regression in print stylesheet behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)