### PR TITLE
[Story 19.20] Standardized data export — CSV, JSON, PDF with reusable hook

### DIFF
--- a/src/__tests__/lib/use-export.test.ts
+++ b/src/__tests__/lib/use-export.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  escapeCsvField,
+  sanitizeFilename,
+  generateCsvContent,
+  generateJsonContent,
+  resolveAccessor,
+  triggerDownload,
+} from "../../lib/use-export";
+import type { ExportColumn } from "../../lib/use-export";
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+interface TestRow {
+  id: number;
+  name: string;
+  status: string;
+  score: number;
+}
+
+const COLUMNS: ExportColumn<TestRow>[] = [
+  { header: "ID", accessor: "id" },
+  { header: "Name", accessor: "name" },
+  { header: "Status", accessor: "status" },
+  { header: "Score", accessor: (r) => String(r.score) },
+];
+
+const SAMPLE_DATA: TestRow[] = [
+  { id: 1, name: "Alpha", status: "Online", score: 95 },
+  { id: 2, name: "Beta", status: "Offline", score: 42 },
+  { id: 3, name: "Gamma", status: "Maintenance", score: 78 },
+];
+
+// ---------------------------------------------------------------------------
+// escapeCsvField
+// ---------------------------------------------------------------------------
+
+describe("escapeCsvField()", () => {
+  it("returns plain value when no special characters", () => {
+    expect(escapeCsvField("hello")).toBe("hello");
+  });
+
+  it("wraps in double quotes when value contains a comma", () => {
+    expect(escapeCsvField("a,b")).toBe('"a,b"');
+  });
+
+  it("escapes double quotes by doubling them", () => {
+    expect(escapeCsvField('say "hi"')).toBe('"say ""hi"""');
+  });
+
+  it("wraps in double quotes when value contains a newline", () => {
+    expect(escapeCsvField("line1\nline2")).toBe('"line1\nline2"');
+  });
+
+  it("wraps in double quotes when value contains a carriage return", () => {
+    expect(escapeCsvField("line1\rline2")).toBe('"line1\rline2"');
+  });
+
+  it("handles combination of comma and quotes", () => {
+    expect(escapeCsvField('"yes",no')).toBe('"""yes"",no"');
+  });
+
+  it("returns empty string unchanged", () => {
+    expect(escapeCsvField("")).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sanitizeFilename
+// ---------------------------------------------------------------------------
+
+describe("sanitizeFilename()", () => {
+  it("passes through clean filenames unchanged", () => {
+    expect(sanitizeFilename("my-report")).toBe("my-report");
+  });
+
+  it("replaces unsafe characters with underscores", () => {
+    expect(sanitizeFilename("file<name>:test")).toBe("file_name_test");
+  });
+
+  it("collapses consecutive underscores", () => {
+    expect(sanitizeFilename("a***b")).toBe("a_b");
+  });
+
+  it("trims leading and trailing underscores", () => {
+    expect(sanitizeFilename("?hello?")).toBe("hello");
+  });
+
+  it("truncates to 200 characters", () => {
+    const longName = "a".repeat(250);
+    expect(sanitizeFilename(longName).length).toBeLessThanOrEqual(200);
+  });
+
+  it("replaces null bytes and control characters", () => {
+    expect(sanitizeFilename("file\x00name\x1f")).toBe("file_name");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveAccessor
+// ---------------------------------------------------------------------------
+
+describe("resolveAccessor()", () => {
+  const row: TestRow = { id: 1, name: "Test", status: "Online", score: 99 };
+
+  it("resolves a string key accessor", () => {
+    expect(resolveAccessor(row, "name")).toBe("Test");
+  });
+
+  it("resolves a function accessor", () => {
+    const fn = (r: TestRow) => String(r.score * 2);
+    expect(resolveAccessor(row, fn)).toBe("198");
+  });
+
+  it("returns empty string for null/undefined values", () => {
+    const partial = { id: 1, name: null, status: "ok", score: 0 } as unknown as TestRow;
+    expect(resolveAccessor(partial, "name")).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateCsvContent
+// ---------------------------------------------------------------------------
+
+describe("generateCsvContent()", () => {
+  it("generates CSV with headers and rows", async () => {
+    const csv = await generateCsvContent(SAMPLE_DATA, COLUMNS);
+    const lines = csv.trim().split("\n");
+    expect(lines[0]).toBe("ID,Name,Status,Score");
+    expect(lines[1]).toBe("1,Alpha,Online,95");
+    expect(lines[2]).toBe("2,Beta,Offline,42");
+    expect(lines[3]).toBe("3,Gamma,Maintenance,78");
+  });
+
+  it("returns header-only for empty data", async () => {
+    const csv = await generateCsvContent([], COLUMNS);
+    expect(csv.trim()).toBe("ID,Name,Status,Score");
+  });
+
+  it("properly escapes special characters in data", async () => {
+    const data: TestRow[] = [{ id: 1, name: 'O"Brien, Jr.', status: "line\ntwo", score: 50 }];
+    const csv = await generateCsvContent(data, COLUMNS);
+    expect(csv).toContain('"O""Brien, Jr."');
+    expect(csv).toContain('"line\ntwo"');
+  });
+
+  it("handles large datasets without error", async () => {
+    const largeData: TestRow[] = Array.from({ length: 1500 }, (_, i) => ({
+      id: i,
+      name: `Device-${i}`,
+      status: "Online",
+      score: Math.floor(Math.random() * 100),
+    }));
+    const csv = await generateCsvContent(largeData, COLUMNS);
+    const lines = csv.trim().split("\n");
+    // 1 header + 1500 data rows
+    expect(lines.length).toBe(1501);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateJsonContent
+// ---------------------------------------------------------------------------
+
+describe("generateJsonContent()", () => {
+  it("generates pretty-printed JSON array", () => {
+    const json = generateJsonContent(SAMPLE_DATA, COLUMNS);
+    const parsed = JSON.parse(json) as Record<string, string>[];
+    expect(parsed).toHaveLength(3);
+    expect(parsed[0]).toEqual({
+      ID: "1",
+      Name: "Alpha",
+      Status: "Online",
+      Score: "95",
+    });
+  });
+
+  it("returns empty array for empty data", () => {
+    const json = generateJsonContent([], COLUMNS);
+    expect(JSON.parse(json)).toEqual([]);
+  });
+
+  it("uses column headers as keys, not raw field names", () => {
+    const json = generateJsonContent(SAMPLE_DATA.slice(0, 1), COLUMNS);
+    const parsed = JSON.parse(json) as Record<string, string>[];
+    expect(Object.keys(parsed[0] ?? {})).toEqual(["ID", "Name", "Status", "Score"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// triggerDownload
+// ---------------------------------------------------------------------------
+
+describe("triggerDownload()", () => {
+  let clickSpy: ReturnType<typeof vi.fn>;
+  let originalCreateObjectURL: typeof URL.createObjectURL;
+  let originalRevokeObjectURL: typeof URL.revokeObjectURL;
+
+  beforeEach(() => {
+    clickSpy = vi.fn();
+    vi.spyOn(document, "createElement").mockReturnValue({
+      href: "",
+      download: "",
+      click: clickSpy,
+      style: {},
+    } as unknown as HTMLAnchorElement);
+
+    // jsdom does not provide URL.createObjectURL; define stubs directly
+    originalCreateObjectURL = URL.createObjectURL;
+    originalRevokeObjectURL = URL.revokeObjectURL;
+    URL.createObjectURL = vi.fn().mockReturnValue("blob:test");
+    URL.revokeObjectURL = vi.fn();
+  });
+
+  afterEach(() => {
+    URL.createObjectURL = originalCreateObjectURL;
+    URL.revokeObjectURL = originalRevokeObjectURL;
+    vi.restoreAllMocks();
+  });
+
+  it("creates a blob and triggers a click", () => {
+    triggerDownload("csv,data", "test.csv", "text/csv");
+    expect(URL.createObjectURL).toHaveBeenCalledOnce();
+    expect(clickSpy).toHaveBeenCalledOnce();
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:test");
+  });
+
+  it("sets the download filename correctly", () => {
+    const mockLink = {
+      href: "",
+      download: "",
+      click: vi.fn(),
+      style: {},
+    } as unknown as HTMLAnchorElement;
+    vi.spyOn(document, "createElement").mockReturnValue(mockLink);
+
+    triggerDownload("data", "report.json", "application/json");
+    expect(mockLink.download).toBe("report.json");
+  });
+});

--- a/src/app/components/account-service.tsx
+++ b/src/app/components/account-service.tsx
@@ -4,7 +4,6 @@ import {
   ChevronLeft,
   ChevronRight,
   Search,
-  Download,
   X,
   Calendar,
   LayoutGrid,
@@ -25,6 +24,20 @@ import type {
   ServiceType,
 } from "../../lib/mock-data/service-order-data";
 import { TECHNICIANS, STATUS_LABELS } from "../../lib/mock-data/service-order-data";
+import { ExportDropdown } from "./export-dropdown";
+import type { ExportColumn } from "../../lib/use-export";
+
+const SERVICE_ORDER_EXPORT_COLUMNS: ExportColumn<ServiceOrder>[] = [
+  { header: "ID", accessor: "id" },
+  { header: "Title", accessor: "title" },
+  { header: "Status", accessor: (o) => STATUS_LABELS[o.status] },
+  { header: "Priority", accessor: "priority" },
+  { header: "Technician", accessor: "technician" },
+  { header: "Location", accessor: "location" },
+  { header: "Scheduled Date", accessor: "scheduledDate" },
+  { header: "Service Type", accessor: "serviceType" },
+  { header: "Customer", accessor: "customer" },
+];
 
 type ViewMode = "kanban" | "calendar";
 
@@ -689,7 +702,7 @@ function FilterBar({
   onPriorityChange,
   onSearchChange,
   onClearAll,
-  onExport,
+  filteredOrders,
   filteredCount,
   totalCount,
 }: {
@@ -700,7 +713,7 @@ function FilterBar({
   onPriorityChange: (v: string) => void;
   onSearchChange: (v: string) => void;
   onClearAll: () => void;
-  onExport: () => void;
+  filteredOrders: ServiceOrder[];
   filteredCount: number;
   totalCount: number;
 }) {
@@ -767,15 +780,13 @@ function FilterBar({
         {filteredCount} of {totalCount} orders
       </span>
 
-      {/* CSV Export */}
-      <button
-        onClick={onExport}
-        className="flex items-center gap-1 rounded border border-border px-2.5 py-1.5 text-[13px] font-medium text-foreground hover:bg-muted transition-colors"
-        title="Export filtered results as CSV"
-      >
-        <Download className="h-3.5 w-3.5" />
-        Export CSV
-      </button>
+      {/* Standardized Export (Story 19.20) */}
+      <ExportDropdown
+        data={filteredOrders}
+        columns={SERVICE_ORDER_EXPORT_COLUMNS}
+        filename="service-orders"
+        title="Service Orders"
+      />
     </div>
   );
 }
@@ -805,7 +816,6 @@ export function AccountService() {
     handleMove,
     handleCreate: hookCreate,
     handleClearFilters,
-    handleExport,
   } = useServiceOrders();
 
   const handleCreate = (order: ServiceOrder) => {
@@ -874,7 +884,7 @@ export function AccountService() {
         onPriorityChange={setPriorityFilter}
         onSearchChange={setSearchQuery}
         onClearAll={handleClearFilters}
-        onExport={handleExport}
+        filteredOrders={filteredOrders}
         filteredCount={filteredOrders.length}
         totalCount={orders.length}
       />

--- a/src/app/components/analytics.tsx
+++ b/src/app/components/analytics.tsx
@@ -1,13 +1,4 @@
-import { useState } from "react";
-import {
-  TrendingUp,
-  TrendingDown,
-  Search,
-  Download,
-  ChevronLeft,
-  ChevronRight,
-  ChevronDown,
-} from "lucide-react";
+import { Search, TrendingUp, TrendingDown, ChevronLeft, ChevronRight } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { useAnalyticsData } from "../../lib/hooks/use-analytics-data";
 import type {
@@ -24,6 +15,19 @@ import {
   MONTHLY_DEPLOYMENTS,
   VULN_SEVERITY,
 } from "../../lib/mock-data/analytics-data";
+import { ExportDropdown } from "./export-dropdown";
+import type { ExportColumn } from "../../lib/use-export";
+
+const AUDIT_EXPORT_COLUMNS: ExportColumn<AnalyticsAuditEntry>[] = [
+  {
+    header: "Timestamp",
+    accessor: (e) => new Date(e.timestamp).toLocaleString("en-US"),
+  },
+  { header: "User", accessor: "user" },
+  { header: "Action", accessor: "action" },
+  { header: "Entity", accessor: "entity" },
+  { header: "Details", accessor: "details" },
+];
 
 // ---------------------------------------------------------------------------
 // Ring Chart Component (SVG donut)
@@ -277,7 +281,10 @@ export function Analytics() {
     handleExportJSON,
   } = useAnalyticsData();
 
-  const [exportOpen, setExportOpen] = useState(false);
+  // Legacy export handlers kept for backward compatibility; ExportDropdown
+  // now provides the primary UI, but the hook handlers are still available.
+  void handleExportCSV;
+  void handleExportJSON;
 
   return (
     <div className="space-y-6">
@@ -515,50 +522,13 @@ export function Analytics() {
               />
             </div>
 
-            {/* Export Dropdown (Story 7.6) */}
-            <div className="relative">
-              <button
-                onClick={() => setExportOpen(!exportOpen)}
-                disabled={filteredAuditLogs.length === 0}
-                className={cn(
-                  "flex h-8 items-center gap-1.5 rounded-lg border border-border bg-card px-3 text-[14px] font-medium text-muted-foreground cursor-pointer",
-                  "hover:bg-muted hover:text-foreground/80",
-                  "disabled:cursor-not-allowed disabled:opacity-60",
-                )}
-                title={filteredAuditLogs.length === 0 ? "No data to export" : "Export data"}
-              >
-                <Download className="h-3.5 w-3.5" />
-                Export
-                <ChevronDown className="h-3 w-3" />
-              </button>
-              {exportOpen && (
-                <>
-                  <div className="fixed inset-0 z-10" onClick={() => setExportOpen(false)} />
-                  <div className="absolute right-0 top-full z-20 mt-1 w-40 rounded-lg border border-border bg-card py-1 shadow-lg">
-                    <button
-                      onClick={() => {
-                        handleExportCSV();
-                        setExportOpen(false);
-                      }}
-                      className="flex w-full items-center gap-2 px-3 py-2 text-[14px] text-foreground/80 hover:bg-muted cursor-pointer"
-                    >
-                      <Download className="h-3.5 w-3.5 text-muted-foreground" />
-                      Export as CSV
-                    </button>
-                    <button
-                      onClick={() => {
-                        handleExportJSON();
-                        setExportOpen(false);
-                      }}
-                      className="flex w-full items-center gap-2 px-3 py-2 text-[14px] text-foreground/80 hover:bg-muted cursor-pointer"
-                    >
-                      <Download className="h-3.5 w-3.5 text-muted-foreground" />
-                      Export as JSON
-                    </button>
-                  </div>
-                </>
-              )}
-            </div>
+            {/* Export Dropdown (Story 7.6 → standardized via Story 19.20) */}
+            <ExportDropdown
+              data={filteredAuditLogs}
+              columns={AUDIT_EXPORT_COLUMNS}
+              filename="audit-log"
+              title="Audit Log"
+            />
           </div>
         </div>
 

--- a/src/app/components/export-dropdown.tsx
+++ b/src/app/components/export-dropdown.tsx
@@ -1,0 +1,130 @@
+/**
+ * ExportDropdown — Reusable export button with format menu (Story 19.20)
+ *
+ * Renders a compact "Export" dropdown with CSV, JSON, and PDF options.
+ * Uses the standardized useExport() hook for all downloads.
+ */
+import { useState, useRef, useEffect, useCallback } from "react";
+import { Download, ChevronDown, Loader2 } from "lucide-react";
+import { cn } from "../../lib/utils";
+import { useExport } from "../../lib/use-export";
+import type { ExportFormat, ExportColumn } from "../../lib/use-export";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface ExportDropdownProps<T> {
+  /** Data rows to export */
+  data: T[];
+  /** Column definitions for all export formats */
+  columns: ExportColumn<T>[];
+  /** Base filename (without extension or date suffix) */
+  filename: string;
+  /** Title for the PDF header; defaults to filename if omitted */
+  title?: string;
+  /** Disable the button (e.g. when no data is loaded yet) */
+  disabled?: boolean;
+  /** Additional CSS classes on the trigger button */
+  className?: string;
+}
+
+const FORMATS: { value: ExportFormat; label: string }[] = [
+  { value: "csv", label: "Export CSV" },
+  { value: "json", label: "Export JSON" },
+  { value: "pdf", label: "Export PDF" },
+];
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function ExportDropdown<T>({
+  data,
+  columns,
+  filename,
+  title,
+  disabled,
+  className,
+}: ExportDropdownProps<T>) {
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const { exportData, isExporting } = useExport();
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [open]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return;
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [open]);
+
+  const handleExport = useCallback(
+    async (format: ExportFormat) => {
+      setOpen(false);
+      await exportData({ data, columns, filename, format, title });
+    },
+    [data, columns, filename, title, exportData],
+  );
+
+  const isDisabled = disabled || data.length === 0 || isExporting;
+
+  return (
+    <div className="relative" ref={menuRef}>
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        disabled={isDisabled}
+        aria-haspopup="true"
+        aria-expanded={open}
+        title={data.length === 0 ? "No data to export" : "Export data"}
+        className={cn(
+          "flex h-8 items-center gap-1.5 rounded-lg border border-border bg-card px-3 text-[14px] font-medium text-muted-foreground cursor-pointer",
+          "hover:bg-muted hover:text-foreground/80",
+          "disabled:cursor-not-allowed disabled:opacity-60",
+          className,
+        )}
+      >
+        {isExporting ? (
+          <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+        ) : (
+          <Download className="h-3.5 w-3.5" aria-hidden="true" />
+        )}
+        Export
+        <ChevronDown className="h-3 w-3" aria-hidden="true" />
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 top-full z-20 mt-1 w-40 rounded-lg border border-border bg-card py-1 shadow-lg"
+        >
+          {FORMATS.map(({ value, label }) => (
+            <button
+              key={value}
+              role="menuitem"
+              onClick={() => handleExport(value)}
+              className="flex w-full items-center gap-2 px-3 py-2 text-[14px] text-foreground/80 hover:bg-muted cursor-pointer"
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/components/inventory.tsx
+++ b/src/app/components/inventory.tsx
@@ -7,7 +7,6 @@ import {
   ArrowUpDown,
   Package,
   Plus,
-  Download,
 } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { DeviceStatus } from "../../lib/types";
@@ -16,8 +15,11 @@ import { getPrimaryRole, canPerformAction } from "../../lib/rbac";
 import { useDeviceInventory } from "../../lib/hooks/use-device-inventory";
 import type { SortField, SortDir } from "../../lib/hooks/use-device-inventory";
 import { ALL_STATUSES, ALL_LOCATIONS, ALL_MODELS } from "../../lib/mock-data/inventory-data";
+import type { MockDevice } from "../../lib/mock-data/inventory-data";
 import { CreateDeviceModal } from "./dialogs/create-device-modal";
 import { GeoLocationMap } from "./geo-location-map";
+import { ExportDropdown } from "./export-dropdown";
+import type { ExportColumn } from "../../lib/use-export";
 import { AdvancedDeviceSearch } from "./search/advanced-device-search";
 
 type Tab = "hardware" | "firmware" | "geo";
@@ -26,6 +28,17 @@ const TABS: { id: Tab; label: string }[] = [
   { id: "hardware", label: "Hardware Inventory" },
   { id: "firmware", label: "Firmware Status" },
   { id: "geo", label: "Geo Location" },
+];
+
+const DEVICE_EXPORT_COLUMNS: ExportColumn<MockDevice>[] = [
+  { header: "Device Name", accessor: "name" },
+  { header: "Serial Number", accessor: "serial" },
+  { header: "Model", accessor: "model" },
+  { header: "Status", accessor: "status" },
+  { header: "Location", accessor: "location" },
+  { header: "Health Score", accessor: (d) => String(d.health) },
+  { header: "Firmware", accessor: "firmware" },
+  { header: "Last Seen", accessor: "lastSeen" },
 ];
 
 // ---------------------------------------------------------------------------
@@ -37,7 +50,11 @@ function StatusBadge({ status }: { status: string }) {
     [DeviceStatus.Online]: { dot: "bg-emerald-500", text: "text-emerald-700", bg: "bg-emerald-50" },
     [DeviceStatus.Offline]: { dot: "bg-red-500", text: "text-red-700", bg: "bg-red-50" },
     [DeviceStatus.Maintenance]: { dot: "bg-amber-500", text: "text-amber-700", bg: "bg-amber-50" },
-    [DeviceStatus.Decommissioned]: { dot: "bg-gray-400", text: "text-muted-foreground", bg: "bg-muted" },
+    [DeviceStatus.Decommissioned]: {
+      dot: "bg-gray-400",
+      text: "text-muted-foreground",
+      bg: "bg-muted",
+    },
   };
   const c = config[status] ?? { dot: "bg-gray-400", text: "text-muted-foreground", bg: "bg-muted" };
   return (
@@ -137,7 +154,6 @@ export function Inventory() {
     handleSort,
     handleStatusChange,
     handleCreateDevice,
-    exportCsv,
     page: safeCurrentPage,
     setPage,
     totalPages,
@@ -184,18 +200,13 @@ export function Inventory() {
 
             {/* Action buttons */}
             <div className="flex items-center gap-2 justify-end">
-              <button
-                onClick={exportCsv}
-                disabled={filteredDevices.length === 0}
-                className={cn(
-                  "flex h-10 cursor-pointer items-center gap-2 rounded-lg border border-border bg-card px-3 text-[14px] font-medium text-foreground/80 shrink-0",
-                  "hover:bg-muted",
-                  "disabled:cursor-not-allowed disabled:opacity-60",
-                )}
-              >
-                <Download className="h-4 w-4" aria-hidden="true" />
-                Export CSV
-              </button>
+              <ExportDropdown
+                data={filteredDevices}
+                columns={DEVICE_EXPORT_COLUMNS}
+                filename="inventory-export"
+                title="Hardware Inventory"
+                className="h-10"
+              />
 
               {canCreate && (
                 <button

--- a/src/lib/use-export.ts
+++ b/src/lib/use-export.ts
@@ -1,0 +1,264 @@
+/**
+ * useExport — Standardized data export hook (Story 19.20)
+ *
+ * Supports CSV, JSON, and PDF export with proper escaping,
+ * chunked processing for large datasets, and browser download triggers.
+ *
+ * XLSX is not supported — requires a third-party library (e.g. SheetJS).
+ */
+import { useState, useCallback } from "react";
+import { toast } from "sonner";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ExportFormat = "csv" | "json" | "pdf";
+
+export interface ExportColumn<T> {
+  /** Display header in the exported file */
+  header: string;
+  /** Key on the data object, or a function that extracts the value */
+  accessor: keyof T | ((item: T) => string | number);
+  /** Optional column width hint (used by PDF layout) */
+  width?: number;
+}
+
+export interface ExportOptions<T> {
+  data: T[];
+  columns: ExportColumn<T>[];
+  filename: string;
+  format: ExportFormat;
+  /** Title displayed in the PDF header */
+  title?: string;
+}
+
+export interface UseExportReturn {
+  exportData: <T>(options: ExportOptions<T>) => Promise<void>;
+  isExporting: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers (pure, testable)
+// ---------------------------------------------------------------------------
+
+/** Resolve a column accessor to a string value */
+export function resolveAccessor<T>(item: T, accessor: ExportColumn<T>["accessor"]): string {
+  if (typeof accessor === "function") {
+    return String(accessor(item));
+  }
+  const raw = item[accessor];
+  if (raw === null || raw === undefined) return "";
+  return String(raw);
+}
+
+/** Escape a single CSV field per RFC 4180 */
+export function escapeCsvField(value: string): string {
+  if (value.includes(",") || value.includes('"') || value.includes("\n") || value.includes("\r")) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+/** Sanitize a filename — strip characters that are unsafe on common OS */
+export function sanitizeFilename(name: string): string {
+  return (
+    name
+      // eslint-disable-next-line no-control-regex
+      .replace(/[<>:"/\\|?*\x00-\x1f]/g, "_")
+      .replace(/_{2,}/g, "_")
+      .replace(/^_|_$/g, "")
+      .slice(0, 200)
+  );
+}
+
+/**
+ * Generate CSV content from typed data + column definitions.
+ * Processes in chunks to avoid blocking the main thread on large datasets.
+ */
+export async function generateCsvContent<T>(
+  data: T[],
+  columns: ExportColumn<T>[],
+): Promise<string> {
+  const CHUNK_SIZE = 500;
+  const headerRow = columns.map((c) => escapeCsvField(c.header)).join(",");
+  const lines: string[] = [headerRow];
+
+  for (let i = 0; i < data.length; i += CHUNK_SIZE) {
+    const chunk = data.slice(i, i + CHUNK_SIZE);
+    for (const item of chunk) {
+      const fields = columns.map((col) => escapeCsvField(resolveAccessor(item, col.accessor)));
+      lines.push(fields.join(","));
+    }
+    // Yield to the event loop between chunks so the UI stays responsive
+    if (i + CHUNK_SIZE < data.length) {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 0);
+      });
+    }
+  }
+
+  return lines.join("\n") + "\n";
+}
+
+/**
+ * Generate pretty-printed JSON from typed data + column definitions.
+ */
+export function generateJsonContent<T>(data: T[], columns: ExportColumn<T>[]): string {
+  const rows = data.map((item) => {
+    const row: Record<string, string | number> = {};
+    for (const col of columns) {
+      const val = resolveAccessor(item, col.accessor);
+      row[col.header] = val;
+    }
+    return row;
+  });
+  return JSON.stringify(rows, null, 2);
+}
+
+/**
+ * Trigger a browser file download from in-memory content.
+ */
+export function triggerDownload(content: string, filename: string, mimeType: string): void {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  link.click();
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Generate a printable PDF via a hidden iframe using window.print().
+ * No third-party dependency required.
+ */
+function generatePdfViaPrint<T>(data: T[], columns: ExportColumn<T>[], title: string): void {
+  const headerCells = columns
+    .map(
+      (c) =>
+        `<th style="border:1px solid #d1d5db;padding:6px 10px;text-align:left;font-size:12px;background:#f1f5f9;white-space:nowrap">${escapeHtml(c.header)}</th>`,
+    )
+    .join("");
+
+  const bodyRows = data
+    .map((item) => {
+      const cells = columns
+        .map(
+          (col) =>
+            `<td style="border:1px solid #d1d5db;padding:5px 10px;font-size:11px">${escapeHtml(resolveAccessor(item, col.accessor))}</td>`,
+        )
+        .join("");
+      return `<tr>${cells}</tr>`;
+    })
+    .join("");
+
+  const html = `<!DOCTYPE html>
+<html><head><title>${escapeHtml(title)}</title>
+<style>
+  body{font-family:system-ui,-apple-system,sans-serif;margin:20px;color:#0f172a}
+  h1{font-size:16px;margin-bottom:4px}
+  p{font-size:11px;color:#64748b;margin-bottom:12px}
+  table{border-collapse:collapse;width:100%}
+  @media print{body{margin:10mm}}
+</style></head><body>
+<h1>${escapeHtml(title)}</h1>
+<p>Exported ${data.length} records on ${new Date().toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" })}</p>
+<table><thead><tr>${headerCells}</tr></thead><tbody>${bodyRows}</tbody></table>
+</body></html>`;
+
+  const iframe = document.createElement("iframe");
+  iframe.style.position = "fixed";
+  iframe.style.left = "-9999px";
+  iframe.style.top = "-9999px";
+  iframe.style.width = "0";
+  iframe.style.height = "0";
+  document.body.appendChild(iframe);
+
+  const iframeDoc = iframe.contentDocument ?? iframe.contentWindow?.document;
+  if (!iframeDoc) {
+    document.body.removeChild(iframe);
+    toast.error("PDF export failed — unable to create print frame");
+    return;
+  }
+
+  iframeDoc.open();
+  iframeDoc.write(html);
+  iframeDoc.close();
+
+  // Wait for content to render before printing
+  setTimeout(() => {
+    iframe.contentWindow?.print();
+    // Clean up after a delay to let the print dialog finish
+    setTimeout(() => {
+      document.body.removeChild(iframe);
+    }, 1000);
+  }, 250);
+}
+
+/** Minimal HTML entity escaping for generated markup */
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useExport(): UseExportReturn {
+  const [isExporting, setIsExporting] = useState(false);
+
+  const exportData = useCallback(async <T>(options: ExportOptions<T>) => {
+    const { data, columns, filename, format, title } = options;
+
+    if (data.length === 0) {
+      toast.error("No data to export");
+      return;
+    }
+
+    setIsExporting(true);
+
+    try {
+      const safeName = sanitizeFilename(filename);
+      const dateStr = new Date().toISOString().split("T")[0];
+
+      switch (format) {
+        case "csv": {
+          const csv = await generateCsvContent(data, columns);
+          triggerDownload(csv, `${safeName}-${dateStr}.csv`, "text/csv;charset=utf-8;");
+          toast.success(`Exported ${data.length} records to CSV`);
+          break;
+        }
+
+        case "json": {
+          const json = generateJsonContent(data, columns);
+          triggerDownload(json, `${safeName}-${dateStr}.json`, "application/json");
+          toast.success(`Exported ${data.length} records to JSON`);
+          break;
+        }
+
+        case "pdf": {
+          generatePdfViaPrint(data, columns, title ?? safeName);
+          toast.success("PDF print dialog opened");
+          break;
+        }
+
+        default: {
+          const _exhaustive: never = format;
+          toast.error(`Unsupported export format: ${String(_exhaustive)}`);
+        }
+      }
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Unknown export error";
+      toast.error(`Export failed: ${message}`);
+    } finally {
+      setIsExporting(false);
+    }
+  }, []);
+
+  return { exportData, isExporting };
+}


### PR DESCRIPTION
## Summary
- `useExport()` hook supporting CSV (RFC 4180), JSON, and PDF (print-based, zero deps)
- `ExportDropdown` component with loading spinner, keyboard dismissal, ARIA attributes
- Integrated into Inventory, Analytics, and Service Orders pages (replaced inline CSV exports)
- 25 unit tests for CSV escaping, filename sanitization, accessor resolution, generation
- XLSX noted as future (requires SheetJS dependency)

Closes #194

## Test plan
- [x] `npm run build` passes
- [x] 25 new unit tests pass
- [ ] Export CSV from Inventory page — verify proper escaping
- [ ] Export JSON from Analytics — verify pretty-printed output
- [ ] Export PDF from Service Orders — verify print dialog opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)