### PR TITLE
[Quality] Pre-commit hooks — husky, lint-staged, file size check, console.log block

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Force LF line endings for shell scripts (required for husky hooks on all platforms)
+.husky/* text eol=lf
+*.sh text eol=lf

--- a/SPEC/rulebooks/code-quality-rulebook.md
+++ b/SPEC/rulebooks/code-quality-rulebook.md
@@ -138,6 +138,38 @@ Every async operation must handle: loading → success → error.
 
 ---
 
+## Type Safety
+
+- **No `any` type** — use `unknown` and narrow with type guards
+- Enforced by `@typescript-eslint/no-explicit-any: "error"` in ESLint
+- Pre-commit hook blocks commits containing `any`
+
+---
+
+## Console Logging
+
+- **No `console.log`** in production code — use structured logging
+- `console.warn` and `console.error` are permitted
+- Enforced by `no-console: "error"` in ESLint (allows `warn`, `error`)
+
+---
+
+## Import Ordering
+
+Imports should follow this order, separated by blank lines:
+
+1. **External packages** — `react`, `react-router`, third-party libs
+2. **Internal aliases** — `@/lib/`, `@/app/components/`
+3. **Relative imports** — `./`, `../` (only within the same module)
+
+### No Barrel Exports
+
+- Do NOT create `index.ts` files that re-export from other files
+- Import directly from the source file: `import { Device } from '@/lib/types'`
+- Barrel exports create circular dependency risks and slow builds
+
+---
+
 ## Naming
 
 - Files: `kebab-case.tsx`
@@ -145,3 +177,4 @@ Every async operation must handle: loading → success → error.
 - Hooks: `use-{name}.ts` → `useName()`
 - Types: `PascalCase` in `src/lib/types.ts`
 - Shared components: `src/app/components/shared/`
+- Constants: `UPPER_SNAKE_CASE`

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -47,7 +47,7 @@ export default tseslint.config(
       "jsx-a11y/tabindex-no-positive": "error",
       // Code quality
       "@typescript-eslint/no-explicit-any": "error",
-      "no-console": ["warn", { allow: ["warn", "error"] }],
+      "no-console": ["error", { allow: ["warn", "error"] }],
     },
   }
 );

--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
   "lint-staged": {
     "*.{ts,tsx}": [
       "eslint --fix",
-      "prettier --write"
+      "prettier --write",
+      "node scripts/check-file-length.js"
     ],
     "*.{json,css,md}": [
       "prettier --write"

--- a/scripts/check-file-length.js
+++ b/scripts/check-file-length.js
@@ -1,0 +1,40 @@
+/**
+ * File Length Checker for lint-staged
+ *
+ * Enforces file size limits on staged .ts/.tsx files:
+ * - >400 lines: warning (printed to stderr)
+ * - >600 lines: error (exits with code 1, blocks commit)
+ *
+ * Usage: node scripts/check-file-length.js <file1> <file2> ...
+ * Called automatically by lint-staged on pre-commit.
+ */
+
+import { readFileSync } from "fs";
+import { relative } from "path";
+
+const WARN_THRESHOLD = 400;
+const ERROR_THRESHOLD = 600;
+
+const files = process.argv.slice(2);
+let hasError = false;
+
+for (const file of files) {
+  const content = readFileSync(file, "utf-8");
+  const lineCount = content.split("\n").length;
+  const relativePath = relative(process.cwd(), file);
+
+  if (lineCount > ERROR_THRESHOLD) {
+    console.error(
+      `ERROR: ${relativePath} has ${lineCount} lines (max ${ERROR_THRESHOLD}). Refactor before committing.`
+    );
+    hasError = true;
+  } else if (lineCount > WARN_THRESHOLD) {
+    console.error(
+      `WARNING: ${relativePath} has ${lineCount} lines (recommended max ${WARN_THRESHOLD}). Consider splitting.`
+    );
+  }
+}
+
+if (hasError) {
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- Upgraded `no-console` ESLint rule from warn → error (allows console.warn/error)
- Added `scripts/check-file-length.js` — warns >400 lines, blocks >600 lines
- Integrated file length check into lint-staged pipeline
- Extended code quality rulebook with type safety, console logging, import ordering sections
- Fixed `.husky/` scripts CRLF → LF via `.gitattributes` (cross-platform fix)

Note: 10 pre-existing `no-console` errors in logging providers — not fixed in this PR (separate cleanup)

Closes #164

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` config valid
- [ ] Stage a file >600 lines → commit blocked
- [ ] Stage a `console.log` → ESLint blocks commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)