### PR TITLE
[Refactor] Extract inventory table helpers (458→367 lines)

### DIFF
--- a/src/app/components/inventory.tsx
+++ b/src/app/components/inventory.tsx
@@ -1,19 +1,10 @@
 import { useState } from "react";
-import {
-  ChevronDown,
-  ChevronUp,
-  ChevronLeft,
-  ChevronRight,
-  ArrowUpDown,
-  Package,
-  Plus,
-} from "lucide-react";
+import { ChevronLeft, ChevronRight, Package, Plus } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { DeviceStatus } from "../../lib/types";
 import { useAuth } from "../../lib/use-auth";
 import { getPrimaryRole, canPerformAction } from "../../lib/rbac";
 import { useDeviceInventory } from "../../lib/hooks/use-device-inventory";
-import type { SortField, SortDir } from "../../lib/hooks/use-device-inventory";
 import { ALL_STATUSES, ALL_LOCATIONS, ALL_MODELS } from "../../lib/mock-data/inventory-data";
 import type { MockDevice } from "../../lib/mock-data/inventory-data";
 import { CreateDeviceModal } from "./dialogs/create-device-modal";
@@ -21,6 +12,7 @@ import { GeoLocationMap } from "./geo-location-map";
 import { ExportDropdown } from "./export-dropdown";
 import type { ExportColumn } from "../../lib/use-export";
 import { AdvancedDeviceSearch } from "./search/advanced-device-search";
+import { StatusBadge, HealthBar, SortHeader } from "./inventory/device-table-helpers";
 
 type Tab = "hardware" | "firmware" | "geo";
 
@@ -40,94 +32,6 @@ const DEVICE_EXPORT_COLUMNS: ExportColumn<MockDevice>[] = [
   { header: "Firmware", accessor: "firmware" },
   { header: "Last Seen", accessor: "lastSeen" },
 ];
-
-// ---------------------------------------------------------------------------
-// Sub-components
-// ---------------------------------------------------------------------------
-
-function StatusBadge({ status }: { status: string }) {
-  const config: Record<string, { dot: string; text: string; bg: string }> = {
-    [DeviceStatus.Online]: { dot: "bg-emerald-500", text: "text-emerald-700", bg: "bg-emerald-50" },
-    [DeviceStatus.Offline]: { dot: "bg-red-500", text: "text-red-700", bg: "bg-red-50" },
-    [DeviceStatus.Maintenance]: { dot: "bg-amber-500", text: "text-amber-700", bg: "bg-amber-50" },
-    [DeviceStatus.Decommissioned]: {
-      dot: "bg-gray-400",
-      text: "text-muted-foreground",
-      bg: "bg-muted",
-    },
-  };
-  const c = config[status] ?? { dot: "bg-gray-400", text: "text-muted-foreground", bg: "bg-muted" };
-  return (
-    <span
-      className={cn(
-        "inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-[13px] font-medium",
-        c.bg,
-        c.text,
-      )}
-    >
-      <span className={cn("h-1.5 w-1.5 rounded-full", c.dot)} />
-      {status}
-    </span>
-  );
-}
-
-function HealthBar({ value }: { value: number }) {
-  const color =
-    value >= 90
-      ? "bg-emerald-500"
-      : value >= 70
-        ? "bg-amber-500"
-        : value >= 50
-          ? "bg-orange-500"
-          : "bg-red-500";
-  return (
-    <div className="flex items-center gap-2">
-      <div className="h-1.5 w-20 rounded-full bg-muted">
-        <div
-          className={cn("h-full rounded-full transition-all", color)}
-          style={{ width: `${value}%` }}
-        />
-      </div>
-      <span className="text-[14px] font-mono tabular-nums text-muted-foreground">{value}%</span>
-    </div>
-  );
-}
-
-function SortHeader({
-  label,
-  field,
-  sortField,
-  sortDir,
-  onSort,
-}: {
-  label: string;
-  field: SortField;
-  sortField: SortField;
-  sortDir: SortDir;
-  onSort: (f: SortField) => void;
-}) {
-  const active = sortField === field;
-  return (
-    <th
-      scope="col"
-      className="px-4 py-3 text-left text-[13px] font-bold uppercase tracking-wider text-muted-foreground cursor-pointer select-none hover:text-foreground bg-table-header"
-      onClick={() => onSort(field)}
-    >
-      <div className="flex items-center gap-1">
-        {label}
-        {active ? (
-          sortDir === "asc" ? (
-            <ChevronUp className="h-3 w-3 text-accent-text" />
-          ) : (
-            <ChevronDown className="h-3 w-3 text-accent-text" />
-          )
-        ) : (
-          <ArrowUpDown className="h-3 w-3 text-muted-foreground" />
-        )}
-      </div>
-    </th>
-  );
-}
 
 // ---------------------------------------------------------------------------
 // Main Component

--- a/src/app/components/inventory/device-table-helpers.tsx
+++ b/src/app/components/inventory/device-table-helpers.tsx
@@ -1,0 +1,100 @@
+import { ChevronDown, ChevronUp, ArrowUpDown } from "lucide-react";
+import { cn } from "../../../lib/utils";
+import { DeviceStatus } from "../../../lib/types";
+import type { SortField, SortDir } from "../../../lib/hooks/use-device-inventory";
+
+// ---------------------------------------------------------------------------
+// StatusBadge
+// ---------------------------------------------------------------------------
+
+export function StatusBadge({ status }: { status: string }) {
+  const config: Record<string, { dot: string; text: string; bg: string }> = {
+    [DeviceStatus.Online]: { dot: "bg-emerald-500", text: "text-emerald-700", bg: "bg-emerald-50" },
+    [DeviceStatus.Offline]: { dot: "bg-red-500", text: "text-red-700", bg: "bg-red-50" },
+    [DeviceStatus.Maintenance]: { dot: "bg-amber-500", text: "text-amber-700", bg: "bg-amber-50" },
+    [DeviceStatus.Decommissioned]: {
+      dot: "bg-gray-400",
+      text: "text-muted-foreground",
+      bg: "bg-muted",
+    },
+  };
+  const c = config[status] ?? { dot: "bg-gray-400", text: "text-muted-foreground", bg: "bg-muted" };
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-[13px] font-medium",
+        c.bg,
+        c.text,
+      )}
+    >
+      <span className={cn("h-1.5 w-1.5 rounded-full", c.dot)} />
+      {status}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// HealthBar
+// ---------------------------------------------------------------------------
+
+export function HealthBar({ value }: { value: number }) {
+  const color =
+    value >= 90
+      ? "bg-emerald-500"
+      : value >= 70
+        ? "bg-amber-500"
+        : value >= 50
+          ? "bg-orange-500"
+          : "bg-red-500";
+  return (
+    <div className="flex items-center gap-2">
+      <div className="h-1.5 w-20 rounded-full bg-muted">
+        <div
+          className={cn("h-full rounded-full transition-all", color)}
+          style={{ width: `${value}%` }}
+        />
+      </div>
+      <span className="text-[14px] font-mono tabular-nums text-muted-foreground">{value}%</span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SortHeader
+// ---------------------------------------------------------------------------
+
+export function SortHeader({
+  label,
+  field,
+  sortField,
+  sortDir,
+  onSort,
+}: {
+  label: string;
+  field: SortField;
+  sortField: SortField;
+  sortDir: SortDir;
+  onSort: (f: SortField) => void;
+}) {
+  const active = sortField === field;
+  return (
+    <th
+      scope="col"
+      className="px-4 py-3 text-left text-[13px] font-bold uppercase tracking-wider text-muted-foreground cursor-pointer select-none hover:text-foreground bg-table-header"
+      onClick={() => onSort(field)}
+    >
+      <div className="flex items-center gap-1">
+        {label}
+        {active ? (
+          sortDir === "asc" ? (
+            <ChevronUp className="h-3 w-3 text-accent-text" />
+          ) : (
+            <ChevronDown className="h-3 w-3 text-accent-text" />
+          )
+        ) : (
+          <ArrowUpDown className="h-3 w-3 text-muted-foreground" />
+        )}
+      </div>
+    </th>
+  );
+}


### PR DESCRIPTION
## Summary
- Extracted `inventory/device-table-helpers.tsx` (104 lines) containing StatusBadge, HealthBar, SortHeader
- `inventory.tsx` reduced from 458 → 367 lines (under 400-line warning threshold)
- Cleaned up unused imports
- Pure refactor — zero logic or UI changes

Relates to #164

## Test plan
- [x] `npm run build` passes
- [x] Pre-commit hooks pass
- [ ] Inventory page renders identically
- [ ] Sorting, status badges, health bars work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)