### PR TITLE
[Quality] Unit test coverage — 199 new tests across auth, RBAC, security, hooks

### DIFF
--- a/src/__tests__/lib/device-schema.test.ts
+++ b/src/__tests__/lib/device-schema.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import { createDeviceSchema } from "../../lib/schemas/device.schema";
+
+describe("createDeviceSchema", () => {
+  const validDevice = {
+    name: "INV-3200A",
+    serial: "SN-4821",
+    model: "INV-3200",
+    firmware: "v4.0.0",
+    status: "Online" as const,
+    location: "Denver, CO",
+  };
+
+  it("accepts valid device data", () => {
+    const result = createDeviceSchema.safeParse(validDevice);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts device with optional lat/lng", () => {
+    const result = createDeviceSchema.safeParse({
+      ...validDevice,
+      lat: "39.74",
+      lng: "-104.99",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  // --- Name validation ---
+
+  it("rejects empty name", () => {
+    const result = createDeviceSchema.safeParse({ ...validDevice, name: "" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects name over 100 characters", () => {
+    const result = createDeviceSchema.safeParse({ ...validDevice, name: "A".repeat(101) });
+    expect(result.success).toBe(false);
+  });
+
+  // --- Serial validation ---
+
+  it("rejects empty serial", () => {
+    const result = createDeviceSchema.safeParse({ ...validDevice, serial: "" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects serial with special characters", () => {
+    const result = createDeviceSchema.safeParse({ ...validDevice, serial: "SN 4821!" });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts serial with dashes", () => {
+    const result = createDeviceSchema.safeParse({ ...validDevice, serial: "SN-4821-A" });
+    expect(result.success).toBe(true);
+  });
+
+  // --- Model validation ---
+
+  it("rejects empty model", () => {
+    const result = createDeviceSchema.safeParse({ ...validDevice, model: "" });
+    expect(result.success).toBe(false);
+  });
+
+  // --- Firmware validation ---
+
+  it("rejects empty firmware", () => {
+    const result = createDeviceSchema.safeParse({ ...validDevice, firmware: "" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid firmware format", () => {
+    const result = createDeviceSchema.safeParse({ ...validDevice, firmware: "latest" });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts firmware with v prefix", () => {
+    const result = createDeviceSchema.safeParse({ ...validDevice, firmware: "v1.2.3" });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts firmware without v prefix", () => {
+    const result = createDeviceSchema.safeParse({ ...validDevice, firmware: "1.2.3" });
+    expect(result.success).toBe(true);
+  });
+
+  // --- Status validation ---
+
+  it("accepts all valid status values", () => {
+    const statuses = ["Online", "Offline", "Maintenance", "Decommissioned"];
+    for (const status of statuses) {
+      const result = createDeviceSchema.safeParse({ ...validDevice, status });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it("rejects invalid status", () => {
+    const result = createDeviceSchema.safeParse({ ...validDevice, status: "Broken" });
+    expect(result.success).toBe(false);
+  });
+
+  // --- Location validation ---
+
+  it("rejects empty location", () => {
+    const result = createDeviceSchema.safeParse({ ...validDevice, location: "" });
+    expect(result.success).toBe(false);
+  });
+
+  // --- Missing required fields ---
+
+  it("rejects when required fields are missing", () => {
+    const result = createDeviceSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/__tests__/lib/hlm-api.test.ts
+++ b/src/__tests__/lib/hlm-api.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect } from "vitest";
+import {
+  getDefaultHeaders,
+  listDevices,
+  getDevice,
+  searchDevices,
+  listFirmware,
+  getFirmware,
+  listServiceOrders,
+  listCompliance,
+  listVulnerabilities,
+  listAuditLogs,
+  getAuditLogsByUser,
+  getCustomer,
+  listNotifications,
+  getDeviceAggregations,
+  getDashboardMetrics,
+  createServiceOrder,
+  updateServiceOrder,
+  uploadFirmware,
+  approveFirmware,
+  submitComplianceReview,
+  acknowledgeNotification,
+  getDeviceTelemetry,
+  getHeatmapAggregation,
+  getBlastRadius,
+  getBlastRadiusHistory,
+  ingestTelemetry,
+  runBlastRadiusSimulation,
+  getTelemetryPipelineStatus,
+  searchGlobal,
+  searchDevicesAdvanced,
+  searchVulnerabilities,
+  getAggregation,
+  searchDevicesByBounds,
+  searchDevicesByDistance,
+  getDeviceGeoClusters,
+  getOsisPipelineHealth,
+  triggerReindex,
+} from "../../lib/hlm-api";
+import { APP_BUILD_INFO } from "../../lib/app-version";
+
+// =============================================================================
+// getDefaultHeaders
+// =============================================================================
+
+describe("getDefaultHeaders", () => {
+  it("includes Content-Type application/json", () => {
+    const headers = getDefaultHeaders();
+    expect(headers["Content-Type"]).toBe("application/json");
+  });
+
+  it("includes X-App-Version header", () => {
+    const headers = getDefaultHeaders();
+    expect(headers["X-App-Version"]).toBe(APP_BUILD_INFO.full);
+  });
+});
+
+// =============================================================================
+// Query stubs — all return empty/mock data
+// =============================================================================
+
+describe("HLM API query stubs", () => {
+  it("listDevices returns empty paginated response", async () => {
+    const result = await listDevices();
+    expect(result).toEqual({ items: [], total: 0, page: 1, pageSize: 25, hasMore: false });
+  });
+
+  it("getDevice returns null", async () => {
+    const result = await getDevice("d1");
+    expect(result).toBeNull();
+  });
+
+  it("searchDevices returns empty search result", async () => {
+    const result = await searchDevices("test");
+    expect(result).toEqual({ hits: [], total: 0, took: 0, maxScore: 0 });
+  });
+
+  it("listFirmware returns empty paginated response", async () => {
+    const result = await listFirmware();
+    expect(result).toEqual({ items: [], total: 0, page: 1, pageSize: 25, hasMore: false });
+  });
+
+  it("getFirmware returns null", async () => {
+    const result = await getFirmware("fw1");
+    expect(result).toBeNull();
+  });
+
+  it("listServiceOrders returns empty paginated response", async () => {
+    const result = await listServiceOrders();
+    expect(result).toEqual({ items: [], total: 0, page: 1, pageSize: 25, hasMore: false });
+  });
+
+  it("listCompliance returns empty paginated response", async () => {
+    const result = await listCompliance();
+    expect(result).toEqual({ items: [], total: 0, page: 1, pageSize: 25, hasMore: false });
+  });
+
+  it("listVulnerabilities returns empty paginated response", async () => {
+    const result = await listVulnerabilities();
+    expect(result).toEqual({ items: [], total: 0, page: 1, pageSize: 25, hasMore: false });
+  });
+
+  it("listAuditLogs returns empty paginated response", async () => {
+    const result = await listAuditLogs("2026-01-01", "2026-12-31");
+    expect(result).toEqual({ items: [], total: 0, page: 1, pageSize: 25, hasMore: false });
+  });
+
+  it("getAuditLogsByUser returns empty array", async () => {
+    const result = await getAuditLogsByUser("usr-1");
+    expect(result).toEqual([]);
+  });
+
+  it("getCustomer returns null", async () => {
+    const result = await getCustomer("cust-1");
+    expect(result).toBeNull();
+  });
+
+  it("listNotifications returns empty array", async () => {
+    const result = await listNotifications();
+    expect(result).toEqual([]);
+  });
+
+  it("getDeviceAggregations returns empty array", async () => {
+    const result = await getDeviceAggregations();
+    expect(result).toEqual([]);
+  });
+
+  it("getDashboardMetrics returns zero-value metrics", async () => {
+    const result = await getDashboardMetrics();
+    expect(result).toEqual({
+      totalDevices: 0,
+      onlineDevices: 0,
+      activeDeployments: 0,
+      pendingApprovals: 0,
+      healthScore: 0,
+    });
+  });
+});
+
+// =============================================================================
+// Mutation stubs
+// =============================================================================
+
+describe("HLM API mutation stubs", () => {
+  it("createServiceOrder returns null", async () => {
+    const result = await createServiceOrder({});
+    expect(result).toBeNull();
+  });
+
+  it("updateServiceOrder returns null", async () => {
+    const result = await updateServiceOrder("so-1", {});
+    expect(result).toBeNull();
+  });
+
+  it("uploadFirmware returns null", async () => {
+    const result = await uploadFirmware({});
+    expect(result).toBeNull();
+  });
+
+  it("approveFirmware returns null", async () => {
+    const result = await approveFirmware("fw-1", "testing");
+    expect(result).toBeNull();
+  });
+
+  it("submitComplianceReview returns null", async () => {
+    const result = await submitComplianceReview("c-1");
+    expect(result).toBeNull();
+  });
+
+  it("acknowledgeNotification returns true", async () => {
+    const result = await acknowledgeNotification("n-1");
+    expect(result).toBe(true);
+  });
+});
+
+// =============================================================================
+// Telemetry stubs
+// =============================================================================
+
+describe("HLM API telemetry stubs", () => {
+  it("getDeviceTelemetry returns empty array", async () => {
+    const result = await getDeviceTelemetry("d1", "2026-01-01", "2026-12-31");
+    expect(result).toEqual([]);
+  });
+
+  it("getHeatmapAggregation returns empty aggregation", async () => {
+    const result = await getHeatmapAggregation();
+    expect(result).toEqual({ cells: [], totalDevices: 0 });
+  });
+
+  it("getBlastRadius returns null", async () => {
+    const result = await getBlastRadius(39.74, -104.99, 10);
+    expect(result).toBeNull();
+  });
+
+  it("getBlastRadiusHistory returns empty array", async () => {
+    const result = await getBlastRadiusHistory();
+    expect(result).toEqual([]);
+  });
+
+  it("ingestTelemetry returns null", async () => {
+    const result = await ingestTelemetry("d1", {});
+    expect(result).toBeNull();
+  });
+
+  it("runBlastRadiusSimulation returns null", async () => {
+    const result = await runBlastRadiusSimulation("d1", 10, "power_failure");
+    expect(result).toBeNull();
+  });
+
+  it("getTelemetryPipelineStatus returns healthy status", async () => {
+    const result = await getTelemetryPipelineStatus();
+    expect(result.health).toBe("healthy");
+    expect(result.recordsIngestedLastHour).toBe(0);
+    expect(result.lastSuccessfulIngestion).toBeDefined();
+  });
+});
+
+// =============================================================================
+// OpenSearch stubs
+// =============================================================================
+
+describe("HLM API OpenSearch stubs", () => {
+  it("searchGlobal returns empty response", async () => {
+    const result = await searchGlobal("test");
+    expect(result).toEqual({ total: 0, results: [] });
+  });
+
+  it("searchDevicesAdvanced returns empty search result", async () => {
+    const result = await searchDevicesAdvanced("test");
+    expect(result).toEqual({ hits: [], total: 0, took: 0, maxScore: 0 });
+  });
+
+  it("searchVulnerabilities returns empty search result", async () => {
+    const result = await searchVulnerabilities("CVE-2026-001");
+    expect(result).toEqual({ hits: [], total: 0, took: 0, maxScore: 0 });
+  });
+
+  it("getAggregation returns empty aggregation", async () => {
+    const result = await getAggregation("device_status");
+    expect(result).toEqual({ metric: "device_status", data: {} });
+  });
+
+  it("searchDevicesByBounds returns empty array", async () => {
+    const result = await searchDevicesByBounds({
+      topLeft: { lat: 40, lon: -105 },
+      bottomRight: { lat: 39, lon: -104 },
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("searchDevicesByDistance returns empty array", async () => {
+    const result = await searchDevicesByDistance({
+      center: { lat: 39.74, lon: -104.99 },
+      distance: "10km",
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("getDeviceGeoClusters returns empty array", async () => {
+    const result = await getDeviceGeoClusters();
+    expect(result).toEqual([]);
+  });
+
+  it("getOsisPipelineHealth returns running status", async () => {
+    const result = await getOsisPipelineHealth();
+    expect(result.state).toBe("Running");
+    expect(result.recordsSyncedLastHour).toBe(0);
+  });
+
+  it("triggerReindex returns true", async () => {
+    const result = await triggerReindex();
+    expect(result).toBe(true);
+  });
+});

--- a/src/__tests__/lib/hooks/use-analytics-data.test.ts
+++ b/src/__tests__/lib/hooks/use-analytics-data.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useAnalyticsData } from "../../../lib/hooks/use-analytics-data";
+
+// Mock sonner toast
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Mock URL.createObjectURL and URL.revokeObjectURL for export tests
+globalThis.URL.createObjectURL = vi.fn(() => "blob:mock-url");
+globalThis.URL.revokeObjectURL = vi.fn();
+
+describe("useAnalyticsData", () => {
+  it("initializes with default range of 30d", () => {
+    const { result } = renderHook(() => useAnalyticsData());
+    expect(result.current.range).toBe("30d");
+    expect(result.current.rangeLabel).toBe("Last 30 Days");
+  });
+
+  it("starts on page 1 with empty search", () => {
+    const { result } = renderHook(() => useAnalyticsData());
+    expect(result.current.currentPage).toBe(1);
+    expect(result.current.searchQuery).toBe("");
+  });
+
+  it("has audit log data available", () => {
+    const { result } = renderHook(() => useAnalyticsData());
+    expect(result.current.filteredAuditLogs.length).toBeGreaterThan(0);
+  });
+
+  // ===========================================================================
+  // Time range
+  // ===========================================================================
+
+  describe("time range", () => {
+    it("changes range and resets page", () => {
+      const { result } = renderHook(() => useAnalyticsData());
+
+      act(() => {
+        result.current.setCurrentPage(2);
+      });
+
+      act(() => {
+        result.current.handleRangeChange("7d");
+      });
+
+      expect(result.current.range).toBe("7d");
+      expect(result.current.currentPage).toBe(1);
+    });
+
+    it("updates range label", () => {
+      const { result } = renderHook(() => useAnalyticsData());
+
+      act(() => {
+        result.current.handleRangeChange("90d");
+      });
+
+      expect(result.current.rangeLabel).toBe("Last 90 Days");
+    });
+
+    it("handles ytd range", () => {
+      const { result } = renderHook(() => useAnalyticsData());
+
+      act(() => {
+        result.current.handleRangeChange("ytd");
+      });
+
+      expect(result.current.range).toBe("ytd");
+      expect(result.current.rangeLabel).toBe("Year to Date");
+    });
+  });
+
+  // ===========================================================================
+  // Search / filtering
+  // ===========================================================================
+
+  describe("search", () => {
+    it("filters audit logs by search query", () => {
+      const { result } = renderHook(() => useAnalyticsData());
+      const totalBefore = result.current.filteredAuditLogs.length;
+
+      act(() => {
+        result.current.handleSearchChange("Created");
+      });
+
+      expect(result.current.filteredAuditLogs.length).toBeLessThanOrEqual(totalBefore);
+      expect(
+        result.current.filteredAuditLogs.every(
+          (entry) =>
+            entry.user.toLowerCase().includes("created") ||
+            entry.action.toLowerCase().includes("created") ||
+            entry.entity.toLowerCase().includes("created") ||
+            entry.details.toLowerCase().includes("created"),
+        ),
+      ).toBe(true);
+    });
+
+    it("resets page to 1 when searching", () => {
+      const { result } = renderHook(() => useAnalyticsData());
+
+      act(() => {
+        result.current.setCurrentPage(2);
+      });
+
+      act(() => {
+        result.current.handleSearchChange("test");
+      });
+
+      expect(result.current.currentPage).toBe(1);
+    });
+
+    it("returns all logs for empty search", () => {
+      const { result } = renderHook(() => useAnalyticsData());
+      const allCount = result.current.filteredAuditLogs.length;
+
+      act(() => {
+        result.current.handleSearchChange("nonexistent-query-xyz");
+      });
+
+      act(() => {
+        result.current.handleSearchChange("");
+      });
+
+      expect(result.current.filteredAuditLogs.length).toBe(allCount);
+    });
+  });
+
+  // ===========================================================================
+  // Pagination
+  // ===========================================================================
+
+  describe("pagination", () => {
+    it("paginates logs (page size = 6)", () => {
+      const { result } = renderHook(() => useAnalyticsData());
+      expect(result.current.pageSize).toBe(6);
+      expect(result.current.paginatedLogs.length).toBeLessThanOrEqual(6);
+    });
+
+    it("calculates total pages correctly", () => {
+      const { result } = renderHook(() => useAnalyticsData());
+      const expectedPages = Math.max(
+        1,
+        Math.ceil(result.current.filteredAuditLogs.length / result.current.pageSize),
+      );
+      expect(result.current.totalPages).toBe(expectedPages);
+    });
+
+    it("navigates to different pages", () => {
+      const { result } = renderHook(() => useAnalyticsData());
+
+      if (result.current.totalPages > 1) {
+        act(() => {
+          result.current.setCurrentPage(2);
+        });
+        expect(result.current.currentPage).toBe(2);
+      }
+    });
+  });
+});

--- a/src/__tests__/lib/hooks/use-device-inventory.test.ts
+++ b/src/__tests__/lib/hooks/use-device-inventory.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useDeviceInventory } from "../../../lib/hooks/use-device-inventory";
+import { DeviceStatus } from "../../../lib/types";
+
+// Mock sonner toast
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("useDeviceInventory", () => {
+  it("initializes with default state", () => {
+    const { result } = renderHook(() => useDeviceInventory());
+
+    expect(result.current.devices.length).toBeGreaterThan(0);
+    expect(result.current.search).toBe("");
+    expect(result.current.sortField).toBe("name");
+    expect(result.current.sortDir).toBe("asc");
+    expect(result.current.page).toBe(1);
+  });
+
+  // ===========================================================================
+  // Search / filtering
+  // ===========================================================================
+
+  describe("search", () => {
+    it("filters devices by name", () => {
+      const { result } = renderHook(() => useDeviceInventory());
+      const totalBefore = result.current.filteredDevices.length;
+
+      act(() => {
+        result.current.setSearch("INV-3200A");
+      });
+
+      expect(result.current.filteredDevices.length).toBeLessThanOrEqual(totalBefore);
+      expect(result.current.filteredDevices.every((d) => d.name.includes("INV-3200A"))).toBe(true);
+    });
+
+    it("filters devices by serial number", () => {
+      const { result } = renderHook(() => useDeviceInventory());
+
+      act(() => {
+        result.current.setSearch("SN-4821");
+      });
+
+      expect(
+        result.current.filteredDevices.every((d) => d.serial.toLowerCase().includes("sn-4821")),
+      ).toBe(true);
+    });
+
+    it("filters by location", () => {
+      const { result } = renderHook(() => useDeviceInventory());
+
+      act(() => {
+        result.current.setSearch("Denver");
+      });
+
+      expect(
+        result.current.filteredDevices.every((d) => d.location.toLowerCase().includes("denver")),
+      ).toBe(true);
+    });
+
+    it("returns all devices for empty search", () => {
+      const { result } = renderHook(() => useDeviceInventory());
+      const allCount = result.current.filteredDevices.length;
+
+      act(() => {
+        result.current.setSearch("nonexistent-device-xyz");
+      });
+      expect(result.current.filteredDevices.length).toBe(0);
+
+      act(() => {
+        result.current.setSearch("");
+      });
+      expect(result.current.filteredDevices.length).toBe(allCount);
+    });
+  });
+
+  // ===========================================================================
+  // Advanced filters
+  // ===========================================================================
+
+  describe("advanced filters", () => {
+    it("filters by status", () => {
+      const { result } = renderHook(() => useDeviceInventory());
+
+      act(() => {
+        result.current.setAdvancedFilters({ status: DeviceStatus.Online });
+      });
+
+      expect(result.current.filteredDevices.every((d) => d.status === DeviceStatus.Online)).toBe(
+        true,
+      );
+    });
+
+    it("filters by health score range", () => {
+      const { result } = renderHook(() => useDeviceInventory());
+
+      act(() => {
+        result.current.setAdvancedFilters({ healthScoreMin: 90, healthScoreMax: 100 });
+      });
+
+      for (const d of result.current.filteredDevices) {
+        expect(d.health).toBeGreaterThanOrEqual(90);
+        expect(d.health).toBeLessThanOrEqual(100);
+      }
+    });
+  });
+
+  // ===========================================================================
+  // Sorting
+  // ===========================================================================
+
+  describe("sorting", () => {
+    it("toggles sort direction on same field", () => {
+      const { result } = renderHook(() => useDeviceInventory());
+
+      expect(result.current.sortDir).toBe("asc");
+
+      act(() => {
+        result.current.handleSort("name");
+      });
+      expect(result.current.sortDir).toBe("desc");
+
+      act(() => {
+        result.current.handleSort("name");
+      });
+      expect(result.current.sortDir).toBe("asc");
+    });
+
+    it("resets to asc when changing sort field", () => {
+      const { result } = renderHook(() => useDeviceInventory());
+
+      act(() => {
+        result.current.handleSort("name"); // toggle to desc
+      });
+      expect(result.current.sortDir).toBe("desc");
+
+      act(() => {
+        result.current.handleSort("health"); // new field → asc
+      });
+      expect(result.current.sortField).toBe("health");
+      expect(result.current.sortDir).toBe("asc");
+    });
+
+    it("sorts by health numerically", () => {
+      const { result } = renderHook(() => useDeviceInventory());
+
+      act(() => {
+        result.current.handleSort("health");
+      });
+
+      // In ascending order — set to health field, should be asc initially
+      // But handleSort toggles since default is "name", so first call sets field to "health" and dir to "asc"
+      const healthValues = result.current.filteredDevices.map((d) => d.health);
+      for (let i = 1; i < healthValues.length; i++) {
+        expect(healthValues[i]!).toBeGreaterThanOrEqual(healthValues[i - 1]!);
+      }
+    });
+  });
+
+  // ===========================================================================
+  // Pagination
+  // ===========================================================================
+
+  describe("pagination", () => {
+    it("paginates devices (page size = 6)", () => {
+      const { result } = renderHook(() => useDeviceInventory());
+
+      expect(result.current.paginatedDevices.length).toBeLessThanOrEqual(6);
+      expect(result.current.totalPages).toBeGreaterThanOrEqual(1);
+    });
+
+    it("changes page correctly", () => {
+      const { result } = renderHook(() => useDeviceInventory());
+
+      if (result.current.totalPages > 1) {
+        act(() => {
+          result.current.setPage(2);
+        });
+        expect(result.current.page).toBe(2);
+      }
+    });
+
+    it("clamps page to totalPages", () => {
+      const { result } = renderHook(() => useDeviceInventory());
+
+      act(() => {
+        result.current.setPage(999);
+      });
+      expect(result.current.page).toBeLessThanOrEqual(result.current.totalPages);
+    });
+  });
+
+  // ===========================================================================
+  // Status change
+  // ===========================================================================
+
+  describe("handleStatusChange", () => {
+    it("updates device status", () => {
+      const { result } = renderHook(() => useDeviceInventory());
+      const firstDevice = result.current.devices[0]!;
+
+      act(() => {
+        result.current.handleStatusChange(firstDevice.id, DeviceStatus.Maintenance);
+      });
+
+      const updated = result.current.devices.find((d) => d.id === firstDevice.id);
+      expect(updated?.status).toBe(DeviceStatus.Maintenance);
+    });
+
+    it("sets health to 0 when going offline", () => {
+      const { result } = renderHook(() => useDeviceInventory());
+      const device = result.current.devices.find((d) => d.status === DeviceStatus.Online);
+      if (!device) return;
+
+      act(() => {
+        result.current.handleStatusChange(device.id, DeviceStatus.Offline);
+      });
+
+      const updated = result.current.devices.find((d) => d.id === device.id);
+      expect(updated?.health).toBe(0);
+    });
+  });
+
+  // ===========================================================================
+  // Create device
+  // ===========================================================================
+
+  describe("handleCreateDevice", () => {
+    it("adds a new device to the list", () => {
+      const { result } = renderHook(() => useDeviceInventory());
+      const countBefore = result.current.devices.length;
+
+      act(() => {
+        result.current.handleCreateDevice({
+          name: "Test Device",
+          serial: "SN-TEST",
+          model: "TEST-100",
+          firmware: "v1.0.0",
+          status: DeviceStatus.Online,
+          location: "Test Location",
+        });
+      });
+
+      expect(result.current.devices.length).toBe(countBefore + 1);
+      expect(result.current.devices[0]?.name).toBe("Test Device");
+    });
+
+    it("assigns health 100 for online devices", () => {
+      const { result } = renderHook(() => useDeviceInventory());
+
+      act(() => {
+        result.current.handleCreateDevice({
+          name: "Online Device",
+          serial: "SN-ONLINE",
+          model: "TEST-100",
+          firmware: "v1.0.0",
+          status: DeviceStatus.Online,
+          location: "Test",
+        });
+      });
+
+      expect(result.current.devices[0]?.health).toBe(100);
+    });
+
+    it("assigns health 0 for offline devices", () => {
+      const { result } = renderHook(() => useDeviceInventory());
+
+      act(() => {
+        result.current.handleCreateDevice({
+          name: "Offline Device",
+          serial: "SN-OFFLINE",
+          model: "TEST-100",
+          firmware: "v1.0.0",
+          status: DeviceStatus.Offline,
+          location: "Test",
+        });
+      });
+
+      expect(result.current.devices[0]?.health).toBe(0);
+    });
+  });
+});

--- a/src/__tests__/lib/hooks/use-service-orders.test.ts
+++ b/src/__tests__/lib/hooks/use-service-orders.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useServiceOrders } from "../../../lib/hooks/use-service-orders";
+
+// Mock sonner toast
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("useServiceOrders", () => {
+  it("initializes with orders from INITIAL_ORDERS", () => {
+    const { result } = renderHook(() => useServiceOrders());
+    expect(result.current.orders.length).toBeGreaterThan(0);
+  });
+
+  it("starts with 'all' filters", () => {
+    const { result } = renderHook(() => useServiceOrders());
+    expect(result.current.statusFilter).toBe("all");
+    expect(result.current.priorityFilter).toBe("all");
+    expect(result.current.searchQuery).toBe("");
+  });
+
+  // ===========================================================================
+  // Filtering
+  // ===========================================================================
+
+  describe("filtering", () => {
+    it("filters by status", () => {
+      const { result } = renderHook(() => useServiceOrders());
+
+      act(() => {
+        result.current.setStatusFilter("Scheduled");
+      });
+
+      expect(result.current.filteredOrders.every((o) => o.status === "Scheduled")).toBe(true);
+    });
+
+    it("filters by priority", () => {
+      const { result } = renderHook(() => useServiceOrders());
+
+      act(() => {
+        result.current.setPriorityFilter("High");
+      });
+
+      expect(result.current.filteredOrders.every((o) => o.priority === "High")).toBe(true);
+    });
+
+    it("filters by search query", () => {
+      const { result } = renderHook(() => useServiceOrders());
+      const firstOrder = result.current.orders[0]!;
+
+      act(() => {
+        result.current.setSearchQuery(firstOrder.id);
+      });
+
+      expect(result.current.filteredOrders.some((o) => o.id === firstOrder.id)).toBe(true);
+    });
+
+    it("search matches technician name", () => {
+      const { result } = renderHook(() => useServiceOrders());
+
+      act(() => {
+        result.current.setSearchQuery("Martinez");
+      });
+
+      expect(
+        result.current.filteredOrders.every((o) => o.technician.toLowerCase().includes("martinez")),
+      ).toBe(true);
+    });
+
+    it("can combine status and priority filters", () => {
+      const { result } = renderHook(() => useServiceOrders());
+
+      act(() => {
+        result.current.setStatusFilter("Scheduled");
+        result.current.setPriorityFilter("High");
+      });
+
+      for (const order of result.current.filteredOrders) {
+        expect(order.status).toBe("Scheduled");
+        expect(order.priority).toBe("High");
+      }
+    });
+
+    it("clears all filters", () => {
+      const { result } = renderHook(() => useServiceOrders());
+      const totalCount = result.current.orders.length;
+
+      act(() => {
+        result.current.setStatusFilter("Scheduled");
+        result.current.setPriorityFilter("High");
+        result.current.setSearchQuery("test");
+      });
+
+      act(() => {
+        result.current.handleClearFilters();
+      });
+
+      expect(result.current.statusFilter).toBe("all");
+      expect(result.current.priorityFilter).toBe("all");
+      expect(result.current.searchQuery).toBe("");
+      expect(result.current.filteredOrders.length).toBe(totalCount);
+    });
+  });
+
+  // ===========================================================================
+  // Grouping by status
+  // ===========================================================================
+
+  describe("ordersByStatus", () => {
+    it("groups orders by status", () => {
+      const { result } = renderHook(() => useServiceOrders());
+
+      const grouped = result.current.ordersByStatus;
+      expect(grouped).toHaveProperty("Scheduled");
+      expect(grouped).toHaveProperty("InProgress");
+      expect(grouped).toHaveProperty("Completed");
+
+      const total = grouped.Scheduled.length + grouped.InProgress.length + grouped.Completed.length;
+      expect(total).toBe(result.current.filteredOrders.length);
+    });
+  });
+
+  // ===========================================================================
+  // Status transitions
+  // ===========================================================================
+
+  describe("handleMove", () => {
+    it("moves an order to a new status", () => {
+      const { result } = renderHook(() => useServiceOrders());
+      const scheduledOrder = result.current.orders.find((o) => o.status === "Scheduled");
+      if (!scheduledOrder) return;
+
+      act(() => {
+        result.current.handleMove(scheduledOrder.id, "InProgress");
+      });
+
+      const updated = result.current.orders.find((o) => o.id === scheduledOrder.id);
+      expect(updated?.status).toBe("InProgress");
+    });
+
+    it("moves to Completed status", () => {
+      const { result } = renderHook(() => useServiceOrders());
+      const order = result.current.orders[0]!;
+
+      act(() => {
+        result.current.handleMove(order.id, "Completed");
+      });
+
+      const updated = result.current.orders.find((o) => o.id === order.id);
+      expect(updated?.status).toBe("Completed");
+    });
+  });
+
+  // ===========================================================================
+  // Create order
+  // ===========================================================================
+
+  describe("handleCreate", () => {
+    it("creates a new order with auto-generated ID", () => {
+      const { result } = renderHook(() => useServiceOrders());
+      const countBefore = result.current.orders.length;
+
+      act(() => {
+        result.current.handleCreate({
+          id: "", // will be overridden
+          title: "New Test Order",
+          description: "Test description",
+          technician: "J. Martinez",
+          scheduledDate: "2026-04-10",
+          priority: "Medium",
+          serviceType: "Internal",
+          status: "Scheduled",
+          location: "Denver",
+          customer: "Test Customer",
+        });
+      });
+
+      expect(result.current.orders.length).toBe(countBefore + 1);
+      const newOrder = result.current.orders.find((o) => o.title === "New Test Order");
+      expect(newOrder).toBeDefined();
+      expect(newOrder!.id).toMatch(/^SO-\d+$/);
+    });
+  });
+});

--- a/src/__tests__/lib/location-coords.test.ts
+++ b/src/__tests__/lib/location-coords.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import {
+  getCityCoordinates,
+  getAllCities,
+  resolveDeviceCoordinates,
+} from "../../lib/location-coords";
+
+// =============================================================================
+// getCityCoordinates
+// =============================================================================
+
+describe("getCityCoordinates", () => {
+  it("returns coordinates for known cities", () => {
+    const denver = getCityCoordinates("Denver, CO");
+    expect(denver).toBeDefined();
+    expect(denver!.lat).toBeCloseTo(39.7392, 2);
+    expect(denver!.lng).toBeCloseTo(-104.9903, 2);
+  });
+
+  it("is case-insensitive", () => {
+    expect(getCityCoordinates("DENVER")).toBeDefined();
+    expect(getCityCoordinates("denver")).toBeDefined();
+    expect(getCityCoordinates("Denver")).toBeDefined();
+  });
+
+  it("trims whitespace", () => {
+    expect(getCityCoordinates("  denver  ")).toBeDefined();
+  });
+
+  it("returns undefined for unknown cities", () => {
+    expect(getCityCoordinates("Unknown City")).toBeUndefined();
+  });
+
+  it("supports international cities", () => {
+    const tokyo = getCityCoordinates("tokyo");
+    expect(tokyo).toBeDefined();
+    expect(tokyo!.lat).toBeCloseTo(35.6762, 2);
+
+    const london = getCityCoordinates("london");
+    expect(london).toBeDefined();
+    expect(london!.lat).toBeCloseTo(51.5074, 2);
+
+    const sydney = getCityCoordinates("sydney");
+    expect(sydney).toBeDefined();
+    expect(sydney!.lat).toBeCloseTo(-33.8688, 2);
+  });
+});
+
+// =============================================================================
+// getAllCities
+// =============================================================================
+
+describe("getAllCities", () => {
+  it("returns an array of city coordinates", () => {
+    const cities = getAllCities();
+    expect(Array.isArray(cities)).toBe(true);
+    expect(cities.length).toBeGreaterThan(0);
+  });
+
+  it("each city has lat, lng, and label", () => {
+    const cities = getAllCities();
+    for (const city of cities) {
+      expect(typeof city.lat).toBe("number");
+      expect(typeof city.lng).toBe("number");
+      expect(typeof city.label).toBe("string");
+    }
+  });
+});
+
+// =============================================================================
+// resolveDeviceCoordinates
+// =============================================================================
+
+describe("resolveDeviceCoordinates", () => {
+  it("uses explicit lat/lng when provided", () => {
+    const result = resolveDeviceCoordinates({ lat: 40.0, lng: -105.0 });
+    expect(result).toEqual({ lat: 40.0, lng: -105.0 });
+  });
+
+  it("ignores (0, 0) coordinates and falls back to location lookup", () => {
+    const result = resolveDeviceCoordinates({ lat: 0, lng: 0, location: "Denver" });
+    expect(result).toBeDefined();
+    expect(result!.lat).toBeCloseTo(39.7392, 2);
+  });
+
+  it("falls back to location name when no lat/lng", () => {
+    const result = resolveDeviceCoordinates({ location: "Houston, TX" });
+    expect(result).toBeDefined();
+    expect(result!.lat).toBeCloseTo(29.7604, 2);
+  });
+
+  it("returns null when neither coordinates nor known location", () => {
+    const result = resolveDeviceCoordinates({ location: "Unknown Place" });
+    expect(result).toBeNull();
+  });
+
+  it("returns null for empty device", () => {
+    const result = resolveDeviceCoordinates({});
+    expect(result).toBeNull();
+  });
+
+  it("prefers explicit coordinates over location name", () => {
+    const result = resolveDeviceCoordinates({ lat: 50.0, lng: -100.0, location: "Denver" });
+    expect(result).toEqual({ lat: 50.0, lng: -100.0 });
+  });
+});

--- a/src/__tests__/lib/query-keys.test.ts
+++ b/src/__tests__/lib/query-keys.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import { queryKeys } from "../../lib/query-keys";
+
+describe("queryKeys", () => {
+  describe("dashboard", () => {
+    it("has all key", () => {
+      expect(queryKeys.dashboard.all).toEqual(["dashboard"]);
+    });
+
+    it("metrics key includes dashboard prefix", () => {
+      expect(queryKeys.dashboard.metrics()).toEqual(["dashboard", "metrics"]);
+    });
+  });
+
+  describe("devices", () => {
+    it("has all key", () => {
+      expect(queryKeys.devices.all).toEqual(["devices"]);
+    });
+
+    it("list key includes filters", () => {
+      const filters = { status: "Online" };
+      expect(queryKeys.devices.list(filters)).toEqual(["devices", "list", filters]);
+    });
+
+    it("list key without filters", () => {
+      expect(queryKeys.devices.list()).toEqual(["devices", "list", undefined]);
+    });
+
+    it("detail key includes id", () => {
+      expect(queryKeys.devices.detail("d1")).toEqual(["devices", "detail", "d1"]);
+    });
+  });
+
+  describe("firmware", () => {
+    it("has all key", () => {
+      expect(queryKeys.firmware.all).toEqual(["firmware"]);
+    });
+
+    it("detail key includes id", () => {
+      expect(queryKeys.firmware.detail("fw-1")).toEqual(["firmware", "detail", "fw-1"]);
+    });
+  });
+
+  describe("serviceOrders", () => {
+    it("has all key", () => {
+      expect(queryKeys.serviceOrders.all).toEqual(["serviceOrders"]);
+    });
+
+    it("list key includes filters", () => {
+      expect(queryKeys.serviceOrders.list({ status: "Scheduled" })).toEqual([
+        "serviceOrders",
+        "list",
+        { status: "Scheduled" },
+      ]);
+    });
+  });
+
+  describe("incidents", () => {
+    it("has detail key", () => {
+      expect(queryKeys.incidents.detail("inc-1")).toEqual(["incidents", "detail", "inc-1"]);
+    });
+  });
+
+  describe("telemetry", () => {
+    it("has device key with id and range", () => {
+      const range = { start: "2026-01-01" };
+      expect(queryKeys.telemetry.device("d1", range)).toEqual(["telemetry", "device", "d1", range]);
+    });
+
+    it("pipeline key", () => {
+      expect(queryKeys.telemetry.pipeline()).toEqual(["telemetry", "pipeline"]);
+    });
+  });
+
+  describe("hierarchical invalidation", () => {
+    it("all keys start with domain prefix for hierarchical invalidation", () => {
+      const domains = [
+        queryKeys.dashboard.all,
+        queryKeys.devices.all,
+        queryKeys.firmware.all,
+        queryKeys.vulnerabilities.all,
+        queryKeys.compliance.all,
+        queryKeys.serviceOrders.all,
+        queryKeys.auditLogs.all,
+        queryKeys.sbom.all,
+        queryKeys.incidents.all,
+        queryKeys.telemetry.all,
+        queryKeys.notifications.all,
+      ];
+
+      for (const key of domains) {
+        expect(key.length).toBe(1);
+        expect(typeof key[0]).toBe("string");
+      }
+    });
+  });
+});

--- a/src/__tests__/lib/rbac.test.ts
+++ b/src/__tests__/lib/rbac.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect } from "vitest";
+import {
+  getPrimaryRole,
+  canAccessPage,
+  canPerformAction,
+  shouldFilterByCustomer,
+  getPermissions,
+  type Role,
+  type Action,
+} from "../../lib/rbac";
+
+// =============================================================================
+// getPrimaryRole
+// =============================================================================
+
+describe("getPrimaryRole", () => {
+  it("returns Admin when Admin is in groups", () => {
+    expect(getPrimaryRole(["Admin"])).toBe("Admin");
+  });
+
+  it("returns Manager when Manager is in groups", () => {
+    expect(getPrimaryRole(["Manager"])).toBe("Manager");
+  });
+
+  it("returns Technician when Technician is in groups", () => {
+    expect(getPrimaryRole(["Technician"])).toBe("Technician");
+  });
+
+  it("returns CustomerAdmin when CustomerAdmin is in groups", () => {
+    expect(getPrimaryRole(["CustomerAdmin"])).toBe("CustomerAdmin");
+  });
+
+  it("returns Viewer when Viewer is in groups", () => {
+    expect(getPrimaryRole(["Viewer"])).toBe("Viewer");
+  });
+
+  it("returns highest-priority role when multiple groups are present", () => {
+    expect(getPrimaryRole(["Viewer", "Admin", "Manager"])).toBe("Admin");
+    expect(getPrimaryRole(["Viewer", "Manager"])).toBe("Manager");
+    expect(getPrimaryRole(["CustomerAdmin", "Technician"])).toBe("Technician");
+  });
+
+  it("defaults to Viewer when no recognized groups", () => {
+    expect(getPrimaryRole([])).toBe("Viewer");
+    expect(getPrimaryRole(["UnknownRole"])).toBe("Viewer");
+  });
+});
+
+// =============================================================================
+// canAccessPage — full page matrix
+// =============================================================================
+
+describe("canAccessPage", () => {
+  const ALL_PAGES = [
+    "dashboard",
+    "inventory",
+    "deployment",
+    "compliance",
+    "sbom",
+    "account-service",
+    "analytics",
+    "telemetry",
+    "incidents",
+    "digital-twin",
+    "executive-summary",
+    "user-management",
+  ];
+
+  describe("Admin", () => {
+    it("can access all pages", () => {
+      for (const page of ALL_PAGES) {
+        expect(canAccessPage("Admin", page)).toBe(true);
+      }
+    });
+  });
+
+  describe("Manager", () => {
+    it("can access all pages except user-management", () => {
+      const managerPages = ALL_PAGES.filter((p) => p !== "user-management");
+      for (const page of managerPages) {
+        expect(canAccessPage("Manager", page)).toBe(true);
+      }
+      expect(canAccessPage("Manager", "user-management")).toBe(false);
+    });
+  });
+
+  describe("Technician", () => {
+    it("can access dashboard, inventory, and account-service only", () => {
+      expect(canAccessPage("Technician", "dashboard")).toBe(true);
+      expect(canAccessPage("Technician", "inventory")).toBe(true);
+      expect(canAccessPage("Technician", "account-service")).toBe(true);
+      expect(canAccessPage("Technician", "deployment")).toBe(false);
+      expect(canAccessPage("Technician", "compliance")).toBe(false);
+      expect(canAccessPage("Technician", "analytics")).toBe(false);
+    });
+  });
+
+  describe("Viewer", () => {
+    it("can access read-only pages but not user-management or executive-summary", () => {
+      expect(canAccessPage("Viewer", "dashboard")).toBe(true);
+      expect(canAccessPage("Viewer", "inventory")).toBe(true);
+      expect(canAccessPage("Viewer", "deployment")).toBe(true);
+      expect(canAccessPage("Viewer", "user-management")).toBe(false);
+      expect(canAccessPage("Viewer", "executive-summary")).toBe(false);
+    });
+  });
+
+  describe("CustomerAdmin", () => {
+    it("can access dashboard, inventory, and account-service only", () => {
+      expect(canAccessPage("CustomerAdmin", "dashboard")).toBe(true);
+      expect(canAccessPage("CustomerAdmin", "inventory")).toBe(true);
+      expect(canAccessPage("CustomerAdmin", "account-service")).toBe(true);
+      expect(canAccessPage("CustomerAdmin", "deployment")).toBe(false);
+      expect(canAccessPage("CustomerAdmin", "analytics")).toBe(false);
+    });
+  });
+
+  it("returns false for a non-existent page", () => {
+    expect(canAccessPage("Admin", "non-existent-page")).toBe(false);
+  });
+});
+
+// =============================================================================
+// canPerformAction — action permission matrix
+// =============================================================================
+
+describe("canPerformAction", () => {
+  const ALL_ACTIONS: Action[] = ["create", "edit", "delete", "approve"];
+
+  it("Admin can perform all actions", () => {
+    for (const action of ALL_ACTIONS) {
+      expect(canPerformAction("Admin", action)).toBe(true);
+    }
+  });
+
+  it("Manager can create, edit, approve but not delete", () => {
+    expect(canPerformAction("Manager", "create")).toBe(true);
+    expect(canPerformAction("Manager", "edit")).toBe(true);
+    expect(canPerformAction("Manager", "approve")).toBe(true);
+    expect(canPerformAction("Manager", "delete")).toBe(false);
+  });
+
+  it("Technician can create and edit but not delete or approve", () => {
+    expect(canPerformAction("Technician", "create")).toBe(true);
+    expect(canPerformAction("Technician", "edit")).toBe(true);
+    expect(canPerformAction("Technician", "delete")).toBe(false);
+    expect(canPerformAction("Technician", "approve")).toBe(false);
+  });
+
+  it("Viewer cannot perform any actions", () => {
+    for (const action of ALL_ACTIONS) {
+      expect(canPerformAction("Viewer", action)).toBe(false);
+    }
+  });
+
+  it("CustomerAdmin can create and edit but not delete or approve", () => {
+    expect(canPerformAction("CustomerAdmin", "create")).toBe(true);
+    expect(canPerformAction("CustomerAdmin", "edit")).toBe(true);
+    expect(canPerformAction("CustomerAdmin", "delete")).toBe(false);
+    expect(canPerformAction("CustomerAdmin", "approve")).toBe(false);
+  });
+});
+
+// =============================================================================
+// shouldFilterByCustomer
+// =============================================================================
+
+describe("shouldFilterByCustomer", () => {
+  it("returns true only for CustomerAdmin", () => {
+    const roles: Role[] = ["Admin", "Manager", "Technician", "Viewer", "CustomerAdmin"];
+    for (const role of roles) {
+      if (role === "CustomerAdmin") {
+        expect(shouldFilterByCustomer(role)).toBe(true);
+      } else {
+        expect(shouldFilterByCustomer(role)).toBe(false);
+      }
+    }
+  });
+});
+
+// =============================================================================
+// getPermissions
+// =============================================================================
+
+describe("getPermissions", () => {
+  it("returns complete permission object for each role", () => {
+    const roles: Role[] = ["Admin", "Manager", "Technician", "Viewer", "CustomerAdmin"];
+    for (const role of roles) {
+      const perms = getPermissions(role);
+      expect(perms).toHaveProperty("pages");
+      expect(perms).toHaveProperty("actions");
+      expect(perms).toHaveProperty("filterByCustomer");
+      expect(Array.isArray(perms.pages)).toBe(true);
+      expect(Array.isArray(perms.actions)).toBe(true);
+      expect(typeof perms.filterByCustomer).toBe("boolean");
+    }
+  });
+
+  it("Admin permissions include user-management page", () => {
+    const perms = getPermissions("Admin");
+    expect(perms.pages).toContain("user-management");
+  });
+
+  it("Admin permissions include delete action", () => {
+    const perms = getPermissions("Admin");
+    expect(perms.actions).toContain("delete");
+  });
+});

--- a/src/__tests__/lib/schemas.test.ts
+++ b/src/__tests__/lib/schemas.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from "vitest";
+import { createServiceOrderSchema } from "../../lib/schemas/service-order.schema";
+import { inviteUserSchema, editUserSchema } from "../../lib/schemas/user.schema";
+
+// =============================================================================
+// Service Order Schema
+// =============================================================================
+
+describe("createServiceOrderSchema", () => {
+  const validOrder = {
+    title: "Quarterly inspection",
+    description: "Routine check",
+    technician: "J. Martinez",
+    scheduledDate: "2026-04-10",
+    priority: "High" as const,
+    serviceType: "Internal" as const,
+    location: "Denver",
+    customer: "SolarEdge Corp",
+  };
+
+  it("accepts valid service order", () => {
+    const result = createServiceOrderSchema.safeParse(validOrder);
+    expect(result.success).toBe(true);
+  });
+
+  it("allows optional description", () => {
+    const { description: _description, ...withoutDesc } = validOrder;
+    const result = createServiceOrderSchema.safeParse(withoutDesc);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects empty title", () => {
+    const result = createServiceOrderSchema.safeParse({ ...validOrder, title: "" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects title over 200 characters", () => {
+    const result = createServiceOrderSchema.safeParse({ ...validOrder, title: "A".repeat(201) });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty technician", () => {
+    const result = createServiceOrderSchema.safeParse({ ...validOrder, technician: "" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid priority", () => {
+    const result = createServiceOrderSchema.safeParse({ ...validOrder, priority: "Urgent" });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts all valid priorities", () => {
+    for (const p of ["High", "Medium", "Low"]) {
+      const result = createServiceOrderSchema.safeParse({ ...validOrder, priority: p });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it("accepts valid service types", () => {
+    for (const st of ["Internal", "3rd Party"]) {
+      const result = createServiceOrderSchema.safeParse({ ...validOrder, serviceType: st });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it("rejects invalid service type", () => {
+    const result = createServiceOrderSchema.safeParse({ ...validOrder, serviceType: "External" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty location", () => {
+    const result = createServiceOrderSchema.safeParse({ ...validOrder, location: "" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty customer", () => {
+    const result = createServiceOrderSchema.safeParse({ ...validOrder, customer: "" });
+    expect(result.success).toBe(false);
+  });
+});
+
+// =============================================================================
+// User Invite Schema
+// =============================================================================
+
+describe("inviteUserSchema", () => {
+  const validUser = {
+    email: "new.user@company.com",
+    firstName: "John",
+    lastName: "Doe",
+    role: "Technician" as const,
+    department: "Engineering",
+  };
+
+  it("accepts valid user invitation", () => {
+    const result = inviteUserSchema.safeParse(validUser);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts optional customer field", () => {
+    const result = inviteUserSchema.safeParse({ ...validUser, customer: "Test Corp" });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid email", () => {
+    const result = inviteUserSchema.safeParse({ ...validUser, email: "not-an-email" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty email", () => {
+    const result = inviteUserSchema.safeParse({ ...validUser, email: "" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty first name", () => {
+    const result = inviteUserSchema.safeParse({ ...validUser, firstName: "" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects first name over 50 chars", () => {
+    const result = inviteUserSchema.safeParse({ ...validUser, firstName: "A".repeat(51) });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty last name", () => {
+    const result = inviteUserSchema.safeParse({ ...validUser, lastName: "" });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts all valid roles", () => {
+    for (const role of ["Admin", "Manager", "Technician", "Viewer", "CustomerAdmin"]) {
+      const result = inviteUserSchema.safeParse({ ...validUser, role });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it("rejects invalid role", () => {
+    const result = inviteUserSchema.safeParse({ ...validUser, role: "SuperAdmin" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty department", () => {
+    const result = inviteUserSchema.safeParse({ ...validUser, department: "" });
+    expect(result.success).toBe(false);
+  });
+});
+
+// =============================================================================
+// User Edit Schema
+// =============================================================================
+
+describe("editUserSchema", () => {
+  it("accepts valid edit input", () => {
+    const result = editUserSchema.safeParse({ role: "Manager", department: "Engineering" });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects empty department", () => {
+    const result = editUserSchema.safeParse({ role: "Manager", department: "" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid role", () => {
+    const result = editUserSchema.safeParse({ role: "Root", department: "Engineering" });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/__tests__/lib/security-csrf.test.ts
+++ b/src/__tests__/lib/security-csrf.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  getCsrfToken,
+  createCsrfInterceptor,
+  CSP_DIRECTIVES,
+  RECOMMENDED_SECURITY_HEADERS,
+} from "../../lib/security";
+
+// =============================================================================
+// CSRF Token Management
+// =============================================================================
+
+describe("getCsrfToken", () => {
+  beforeEach(() => {
+    // Clean up any existing meta tags
+    document.querySelectorAll('meta[name="csrf-token"]').forEach((el) => el.remove());
+    // Clear cookies
+    Object.defineProperty(document, "cookie", {
+      writable: true,
+      value: "",
+    });
+  });
+
+  it("reads token from meta tag", () => {
+    const meta = document.createElement("meta");
+    meta.setAttribute("name", "csrf-token");
+    meta.setAttribute("content", "abc123-csrf-token");
+    document.head.appendChild(meta);
+
+    expect(getCsrfToken()).toBe("abc123-csrf-token");
+
+    document.head.removeChild(meta);
+  });
+
+  it("reads token from cookie when no meta tag", () => {
+    Object.defineProperty(document, "cookie", {
+      writable: true,
+      value: "csrf-token=cookie-csrf-value; other-cookie=xyz",
+    });
+
+    expect(getCsrfToken()).toBe("cookie-csrf-value");
+  });
+
+  it("returns null when neither meta tag nor cookie exists", () => {
+    Object.defineProperty(document, "cookie", {
+      writable: true,
+      value: "other-cookie=xyz",
+    });
+
+    expect(getCsrfToken()).toBeNull();
+  });
+
+  it("prefers meta tag over cookie", () => {
+    const meta = document.createElement("meta");
+    meta.setAttribute("name", "csrf-token");
+    meta.setAttribute("content", "meta-token");
+    document.head.appendChild(meta);
+
+    Object.defineProperty(document, "cookie", {
+      writable: true,
+      value: "csrf-token=cookie-token",
+    });
+
+    expect(getCsrfToken()).toBe("meta-token");
+
+    document.head.removeChild(meta);
+  });
+});
+
+// =============================================================================
+// CSRF Interceptor
+// =============================================================================
+
+describe("createCsrfInterceptor", () => {
+  beforeEach(() => {
+    document.querySelectorAll('meta[name="csrf-token"]').forEach((el) => el.remove());
+    const meta = document.createElement("meta");
+    meta.setAttribute("name", "csrf-token");
+    meta.setAttribute("content", "test-csrf-token");
+    document.head.appendChild(meta);
+  });
+
+  it("adds X-CSRF-Token header to POST requests", () => {
+    const interceptor = createCsrfInterceptor();
+    const result = interceptor({ url: "/api/devices", method: "POST" });
+    expect(result.headers?.["X-CSRF-Token"]).toBe("test-csrf-token");
+  });
+
+  it("adds X-CSRF-Token header to PUT requests", () => {
+    const interceptor = createCsrfInterceptor();
+    const result = interceptor({ url: "/api/devices/1", method: "PUT" });
+    expect(result.headers?.["X-CSRF-Token"]).toBe("test-csrf-token");
+  });
+
+  it("adds X-CSRF-Token header to PATCH requests", () => {
+    const interceptor = createCsrfInterceptor();
+    const result = interceptor({ url: "/api/devices/1", method: "PATCH" });
+    expect(result.headers?.["X-CSRF-Token"]).toBe("test-csrf-token");
+  });
+
+  it("adds X-CSRF-Token header to DELETE requests", () => {
+    const interceptor = createCsrfInterceptor();
+    const result = interceptor({ url: "/api/devices/1", method: "DELETE" });
+    expect(result.headers?.["X-CSRF-Token"]).toBe("test-csrf-token");
+  });
+
+  it("does not add header to GET requests", () => {
+    const interceptor = createCsrfInterceptor();
+    const result = interceptor({ url: "/api/devices", method: "GET" });
+    expect(result.headers?.["X-CSRF-Token"]).toBeUndefined();
+  });
+
+  it("defaults method to GET when not specified", () => {
+    const interceptor = createCsrfInterceptor();
+    const result = interceptor({ url: "/api/devices" });
+    expect(result.headers?.["X-CSRF-Token"]).toBeUndefined();
+  });
+
+  it("preserves existing headers", () => {
+    const interceptor = createCsrfInterceptor();
+    const result = interceptor({
+      url: "/api/devices",
+      method: "POST",
+      headers: { Authorization: "Bearer token" },
+    });
+    expect(result.headers?.["Authorization"]).toBe("Bearer token");
+    expect(result.headers?.["X-CSRF-Token"]).toBe("test-csrf-token");
+  });
+});
+
+// =============================================================================
+// CSP Directives & Security Headers
+// =============================================================================
+
+describe("CSP_DIRECTIVES", () => {
+  it("has all required directives", () => {
+    expect(CSP_DIRECTIVES["default-src"]).toBe("'self'");
+    expect(CSP_DIRECTIVES["script-src"]).toBe("'self'");
+    expect(CSP_DIRECTIVES["frame-ancestors"]).toBe("'none'");
+    expect(CSP_DIRECTIVES["object-src"]).toBe("'none'");
+    expect(CSP_DIRECTIVES["base-uri"]).toBe("'self'");
+    expect(CSP_DIRECTIVES["form-action"]).toBe("'self'");
+  });
+});
+
+describe("RECOMMENDED_SECURITY_HEADERS", () => {
+  it("includes all critical security headers", () => {
+    expect(RECOMMENDED_SECURITY_HEADERS["X-Frame-Options"]).toBe("DENY");
+    expect(RECOMMENDED_SECURITY_HEADERS["X-Content-Type-Options"]).toBe("nosniff");
+    expect(RECOMMENDED_SECURITY_HEADERS["Referrer-Policy"]).toBe("strict-origin-when-cross-origin");
+    expect(RECOMMENDED_SECURITY_HEADERS["X-XSS-Protection"]).toBe("0");
+    expect(RECOMMENDED_SECURITY_HEADERS["Strict-Transport-Security"]).toContain("max-age=");
+  });
+
+  it("disables camera, microphone, geolocation via Permissions-Policy", () => {
+    expect(RECOMMENDED_SECURITY_HEADERS["Permissions-Policy"]).toContain("camera=()");
+    expect(RECOMMENDED_SECURITY_HEADERS["Permissions-Policy"]).toContain("microphone=()");
+    expect(RECOMMENDED_SECURITY_HEADERS["Permissions-Policy"]).toContain("geolocation=()");
+  });
+});

--- a/src/__tests__/lib/use-auth.test.tsx
+++ b/src/__tests__/lib/use-auth.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import { renderHook } from "@testing-library/react";
+import React from "react";
+import { useAuth } from "../../lib/use-auth";
+import { AuthContext } from "../../lib/auth-context-instance";
+import type { AuthState } from "../../lib/types";
+
+function createMockAuthState(overrides?: Partial<AuthState>): AuthState {
+  return {
+    user: null,
+    email: null,
+    groups: [],
+    isAuthenticated: false,
+    isLoading: false,
+    customerId: null,
+    signInError: null,
+    mfaRequired: false,
+    mfaEnabled: false,
+    sessionExpiring: false,
+    signIn: async () => {},
+    verifyMfa: async () => {},
+    setupMfa: async () => "",
+    confirmMfaSetup: async () => {},
+    signOut: () => {},
+    extendSession: async () => {},
+    ...overrides,
+  };
+}
+
+describe("useAuth", () => {
+  it("throws when used outside AuthProvider", () => {
+    expect(() => {
+      renderHook(() => useAuth());
+    }).toThrow("useAuth must be used within an AuthProvider");
+  });
+
+  it("returns auth state when used inside AuthProvider", () => {
+    const mockState = createMockAuthState({
+      isAuthenticated: true,
+      email: "admin@company.com",
+      groups: ["Admin"],
+    });
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <AuthContext.Provider value={mockState}>{children}</AuthContext.Provider>
+    );
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.email).toBe("admin@company.com");
+    expect(result.current.groups).toEqual(["Admin"]);
+  });
+
+  it("returns unauthenticated state correctly", () => {
+    const mockState = createMockAuthState();
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <AuthContext.Provider value={mockState}>{children}</AuthContext.Provider>
+    );
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.user).toBeNull();
+    expect(result.current.email).toBeNull();
+  });
+
+  it("exposes signIn, signOut, and MFA methods", () => {
+    const mockState = createMockAuthState();
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <AuthContext.Provider value={mockState}>{children}</AuthContext.Provider>
+    );
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    expect(typeof result.current.signIn).toBe("function");
+    expect(typeof result.current.signOut).toBe("function");
+    expect(typeof result.current.verifyMfa).toBe("function");
+    expect(typeof result.current.setupMfa).toBe("function");
+    expect(typeof result.current.confirmMfaSetup).toBe("function");
+    expect(typeof result.current.extendSession).toBe("function");
+  });
+
+  it("reflects session expiring state", () => {
+    const mockState = createMockAuthState({ sessionExpiring: true });
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <AuthContext.Provider value={mockState}>{children}</AuthContext.Provider>
+    );
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    expect(result.current.sessionExpiring).toBe(true);
+  });
+
+  it("reflects MFA required state", () => {
+    const mockState = createMockAuthState({ mfaRequired: true });
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <AuthContext.Provider value={mockState}>{children}</AuthContext.Provider>
+    );
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    expect(result.current.mfaRequired).toBe(true);
+  });
+});

--- a/src/__tests__/lib/utils-extended.test.ts
+++ b/src/__tests__/lib/utils-extended.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { formatDate, formatDateTime, formatRelativeTime } from "../../lib/utils";
+
+// =============================================================================
+// formatDate
+// =============================================================================
+
+describe("formatDate", () => {
+  it("formats a Date object", () => {
+    const result = formatDate(new Date("2026-03-28T00:00:00Z"));
+    expect(result).toContain("Mar");
+    expect(result).toContain("28");
+    expect(result).toContain("2026");
+  });
+
+  it("formats a date string", () => {
+    const result = formatDate("2026-01-15T12:00:00Z");
+    expect(result).toContain("Jan");
+    expect(result).toContain("15");
+    expect(result).toContain("2026");
+  });
+
+  it("handles ISO date strings", () => {
+    const result = formatDate("2025-12-25T00:00:00.000Z");
+    expect(result).toContain("Dec");
+    expect(result).toContain("25");
+    expect(result).toContain("2025");
+  });
+});
+
+// =============================================================================
+// formatDateTime
+// =============================================================================
+
+describe("formatDateTime", () => {
+  it("includes date and time components", () => {
+    const result = formatDateTime("2026-03-28T14:30:00Z");
+    expect(result).toContain("Mar");
+    expect(result).toContain("28");
+    expect(result).toContain("2026");
+    // Should contain a time component (hour/minute with AM/PM)
+    expect(result).toMatch(/\d{1,2}:\d{2}/);
+  });
+
+  it("formats Date objects", () => {
+    const date = new Date("2026-06-15T09:00:00Z");
+    const result = formatDateTime(date);
+    expect(result).toContain("Jun");
+    expect(result).toContain("15");
+    expect(result).toContain("2026");
+  });
+});
+
+// =============================================================================
+// formatRelativeTime
+// =============================================================================
+
+describe("formatRelativeTime", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns 'now' or 'seconds ago' for very recent dates", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-02T12:00:05Z"));
+    const result = formatRelativeTime("2026-04-02T12:00:00Z");
+    // Intl.RelativeTimeFormat returns something like "5 seconds ago"
+    expect(result).toMatch(/second/i);
+  });
+
+  it("returns minutes ago for recent dates", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-02T12:10:00Z"));
+    const result = formatRelativeTime("2026-04-02T12:00:00Z");
+    expect(result).toMatch(/10 minutes ago/i);
+  });
+
+  it("returns hours ago for same-day dates", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-02T15:00:00Z"));
+    const result = formatRelativeTime("2026-04-02T12:00:00Z");
+    expect(result).toMatch(/3 hours ago/i);
+  });
+
+  it("returns days ago for older dates", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-05T12:00:00Z"));
+    const result = formatRelativeTime("2026-04-02T12:00:00Z");
+    expect(result).toMatch(/3 days ago/i);
+  });
+
+  it("handles Date objects", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-02T12:30:00Z"));
+    const result = formatRelativeTime(new Date("2026-04-02T12:00:00Z"));
+    expect(result).toMatch(/30 minutes ago/i);
+  });
+});


### PR DESCRIPTION
## Summary
12 new test files with 199 tests:
- `rbac.test.ts` (22) — all 5 roles, page access matrix, action permissions
- `use-auth.test.tsx` (6) — hook context validation, state exposure
- `hlm-api.test.ts` (38) — all 35+ API endpoints, headers
- `security-csrf.test.ts` (14) — CSRF tokens, interceptor, CSP directives
- `utils-extended.test.ts` (10) — date formatting utilities
- `location-coords.test.ts` (13) — city lookup, coordinate resolution
- `query-keys.test.ts` (14) — query key factory, hierarchical invalidation
- `device-schema.test.ts` (16) — Zod device validation
- `schemas.test.ts` (24) — service order, user invite/edit schemas
- `use-device-inventory.test.ts` (18) — search, filters, sorting, pagination
- `use-service-orders.test.ts` (12) — filtering, status transitions
- `use-analytics-data.test.ts` (12) — time range, search, pagination

Total: 418 tests (199 new + 219 existing)

Closes #163

## Test plan
- [x] All 418 tests pass
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)