### PR TITLE
[Epic 21] State management — useReducer, ConfirmDialog, route error boundaries

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
-import { lazy, Suspense } from "react";
+import { lazy, Suspense, type ReactNode } from "react";
 import { Routes, Route, Navigate } from "react-router";
 import { ErrorBoundary } from "./components/error-boundary";
+import { RouteErrorBoundary } from "./components/route-error-boundary";
 import { ProtectedLayout } from "./app/components/layouts/protected-layout";
 import { PageLoader } from "./app/components/page-loader";
 
@@ -60,6 +61,17 @@ const SecureDownloadPage = lazy(() =>
 );
 
 // ---------------------------------------------------------------------------
+// Story 21.3: Route wrapper with per-route error boundary
+// ---------------------------------------------------------------------------
+function RouteElement({ name, children }: { name: string; children: ReactNode }) {
+  return (
+    <RouteErrorBoundary routeName={name}>
+      <Suspense fallback={<PageLoader />}>{children}</Suspense>
+    </RouteErrorBoundary>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // App Router
 // ---------------------------------------------------------------------------
 export default function App() {
@@ -68,118 +80,117 @@ export default function App() {
       <Suspense fallback={<PageLoader />}>
         <Routes>
           <Route path="/login" element={<SignIn />} />
-          {/* Secure download — outside ProtectedLayout; has own auth check (#358) */}
           <Route
             path="/download/:tokenGuid"
             element={
-              <Suspense fallback={<PageLoader />}>
+              <RouteElement name="secure-download">
                 <SecureDownloadPage />
-              </Suspense>
+              </RouteElement>
             }
           />
           <Route element={<ProtectedLayout />}>
             <Route
               path="/"
               element={
-                <Suspense fallback={<PageLoader />}>
+                <RouteElement name="dashboard">
                   <Dashboard />
-                </Suspense>
+                </RouteElement>
               }
             />
             <Route
               path="/inventory"
               element={
-                <Suspense fallback={<PageLoader />}>
+                <RouteElement name="inventory">
                   <Inventory />
-                </Suspense>
+                </RouteElement>
               }
             />
             <Route
               path="/account-service"
               element={
-                <Suspense fallback={<PageLoader />}>
+                <RouteElement name="account-service">
                   <AccountService />
-                </Suspense>
+                </RouteElement>
               }
             />
             <Route
               path="/deployment"
               element={
-                <Suspense fallback={<PageLoader />}>
+                <RouteElement name="deployment">
                   <Deployment />
-                </Suspense>
+                </RouteElement>
               }
             />
             <Route
               path="/compliance"
               element={
-                <Suspense fallback={<PageLoader />}>
+                <RouteElement name="compliance">
                   <CompliancePage />
-                </Suspense>
+                </RouteElement>
               }
             />
             <Route
               path="/sbom"
               element={
-                <Suspense fallback={<PageLoader />}>
+                <RouteElement name="sbom">
                   <SBOMPage />
-                </Suspense>
+                </RouteElement>
               }
             />
             <Route
               path="/analytics"
               element={
-                <Suspense fallback={<PageLoader />}>
+                <RouteElement name="analytics">
                   <Analytics />
-                </Suspense>
+                </RouteElement>
               }
             />
             <Route
               path="/telemetry"
               element={
-                <Suspense fallback={<PageLoader />}>
+                <RouteElement name="telemetry">
                   <TelemetryHeatmapPage />
-                </Suspense>
+                </RouteElement>
               }
             />
             <Route
               path="/incidents"
               element={
-                <Suspense fallback={<PageLoader />}>
+                <RouteElement name="incidents">
                   <IncidentResponsePage />
-                </Suspense>
+                </RouteElement>
               }
             />
             <Route
               path="/digital-twin"
               element={
-                <Suspense fallback={<PageLoader />}>
+                <RouteElement name="digital-twin">
                   <DigitalTwinPage />
-                </Suspense>
+                </RouteElement>
               }
             />
             <Route
               path="/executive-summary"
               element={
-                <Suspense fallback={<PageLoader />}>
+                <RouteElement name="executive-summary">
                   <ExecutiveSummaryPage />
-                </Suspense>
+                </RouteElement>
               }
             />
             <Route
               path="/user-management"
               element={
-                <Suspense fallback={<PageLoader />}>
+                <RouteElement name="user-management">
                   <UserManagement />
-                </Suspense>
+                </RouteElement>
               }
             />
             <Route
               path="/access-denied"
               element={
-                <Suspense fallback={<PageLoader />}>
+                <RouteElement name="access-denied">
                   <AccessDenied />
-                </Suspense>
+                </RouteElement>
               }
             />
           </Route>

--- a/src/app/components/deployment.tsx
+++ b/src/app/components/deployment.tsx
@@ -4,6 +4,7 @@ import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { useAuth } from "@/lib/use-auth";
 import { getPrimaryRole, canPerformAction } from "@/lib/rbac";
+import { ConfirmDialog } from "@/components/confirm-dialog";
 
 import type { Tab } from "./deployment/deployment-types";
 import { UploadFirmwareModal } from "./deployment/upload-firmware-modal";
@@ -45,6 +46,9 @@ export function Deployment() {
     advanceStage,
     deprecateFirmware,
     activateFirmware,
+    pendingConfirmation,
+    confirmAction,
+    cancelAction,
   } = useFirmwareDeployment(currentUser, auditLog.addAuditEntry);
 
   const vulnTracker = useVulnerabilityTracker(auditLog.addAuditEntry);
@@ -272,6 +276,17 @@ export function Deployment() {
           onSubmit={guardedCreateVulnerability}
         />
       )}
+
+      {/* Story 21.2: Firmware action confirmation dialog */}
+      <ConfirmDialog
+        open={!!pendingConfirmation}
+        title={pendingConfirmation?.title ?? ""}
+        message={pendingConfirmation?.message ?? ""}
+        confirmLabel={pendingConfirmation?.confirmLabel}
+        confirmVariant={pendingConfirmation?.variant}
+        onConfirm={confirmAction}
+        onCancel={cancelAction}
+      />
     </div>
   );
 }

--- a/src/app/components/geo-location-map.tsx
+++ b/src/app/components/geo-location-map.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback, useRef, useEffect } from "react";
+import { useMemo, useCallback, useRef, useEffect, useReducer } from "react";
 import { ComposableMap, Geographies, Geography, ZoomableGroup } from "react-simple-maps";
 import { MapPin } from "lucide-react";
 import { resolveDeviceCoordinates } from "../../lib/location-coords";
@@ -38,24 +38,103 @@ import {
 export type { GeoDevice } from "./geo-location/geo-location-types";
 
 // ---------------------------------------------------------------------------
+// Story 21.1: Consolidated map state via useReducer
+// ---------------------------------------------------------------------------
+interface MapState {
+  statusFilter: GeoStatusFilter;
+  selectedDevice: GeoDevice | null;
+  tooltipPosition: { x: number; y: number };
+  mapLoaded: boolean;
+  mapError: boolean;
+  zoom: number;
+  center: [number, number];
+  showGeofences: boolean;
+  trailDevice: ResolvedDevice | null;
+  trailPoints: TrailPoint[];
+}
+
+const INITIAL_MAP_STATE: MapState = {
+  statusFilter: "all",
+  selectedDevice: null,
+  tooltipPosition: { x: 0, y: 0 },
+  mapLoaded: false,
+  mapError: false,
+  zoom: 1,
+  center: [0, 20],
+  showGeofences: true,
+  trailDevice: null,
+  trailPoints: [],
+};
+
+type MapAction =
+  | { type: "SELECT_DEVICE"; device: GeoDevice; position: { x: number; y: number } }
+  | { type: "DESELECT_DEVICE" }
+  | { type: "SET_VIEW"; center: [number, number]; zoom: number }
+  | { type: "NAVIGATE"; center: [number, number]; zoom: number }
+  | { type: "ZOOM_IN" }
+  | { type: "ZOOM_OUT" }
+  | { type: "RESET_VIEW" }
+  | { type: "SET_FILTER"; filter: GeoStatusFilter }
+  | { type: "MAP_LOADED" }
+  | { type: "MAP_ERROR" }
+  | { type: "RETRY_MAP" }
+  | { type: "TOGGLE_GEOFENCES" }
+  | { type: "SHOW_TRAIL"; device: ResolvedDevice; points: TrailPoint[] }
+  | { type: "HIDE_TRAIL" };
+
+function mapReducer(state: MapState, action: MapAction): MapState {
+  switch (action.type) {
+    case "SELECT_DEVICE":
+      return { ...state, selectedDevice: action.device, tooltipPosition: action.position };
+    case "DESELECT_DEVICE":
+      return { ...state, selectedDevice: null };
+    case "SET_VIEW":
+      return { ...state, center: action.center, zoom: action.zoom };
+    case "NAVIGATE":
+      return { ...state, center: action.center, zoom: action.zoom, selectedDevice: null };
+    case "ZOOM_IN":
+      return { ...state, zoom: Math.min(state.zoom * 1.5, 8) };
+    case "ZOOM_OUT":
+      return { ...state, zoom: Math.max(state.zoom / 1.5, 1) };
+    case "RESET_VIEW":
+      return { ...state, center: [0, 20], zoom: 1 };
+    case "SET_FILTER":
+      return { ...state, statusFilter: action.filter, selectedDevice: null };
+    case "MAP_LOADED":
+      return { ...state, mapLoaded: true };
+    case "MAP_ERROR":
+      return { ...state, mapError: true };
+    case "RETRY_MAP":
+      return { ...state, mapError: false, mapLoaded: false };
+    case "TOGGLE_GEOFENCES":
+      return { ...state, showGeofences: !state.showGeofences };
+    case "SHOW_TRAIL":
+      return { ...state, trailDevice: action.device, trailPoints: action.points };
+    case "HIDE_TRAIL":
+      return { ...state, trailDevice: null, trailPoints: [] };
+    default:
+      return state;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Main Component — GeoLocationMap
 // ---------------------------------------------------------------------------
 export function GeoLocationMap({ devices }: { devices: GeoDevice[] }) {
-  const [statusFilter, setStatusFilter] = useState<GeoStatusFilter>("all");
-  const [selectedDevice, setSelectedDevice] = useState<GeoDevice | null>(null);
-  const [tooltipPosition, setTooltipPosition] = useState({ x: 0, y: 0 });
-  const [mapLoaded, setMapLoaded] = useState(false);
-  const [mapError, setMapError] = useState(false);
-  const [zoom, setZoom] = useState(1);
-  const [center, setCenter] = useState<[number, number]>([0, 20]);
+  const [state, dispatch] = useReducer(mapReducer, INITIAL_MAP_STATE);
+  const {
+    statusFilter,
+    selectedDevice,
+    tooltipPosition,
+    mapLoaded,
+    mapError,
+    zoom,
+    center,
+    showGeofences,
+    trailDevice,
+    trailPoints,
+  } = state;
   const containerRef = useRef<HTMLDivElement>(null);
-
-  // Story 10.4: Geofence state
-  const [showGeofences, setShowGeofences] = useState(true);
-
-  // Story 10.5: Trail state
-  const [trailDevice, setTrailDevice] = useState<ResolvedDevice | null>(null);
-  const [trailPoints, setTrailPoints] = useState<TrailPoint[]>([]);
 
   // Story 9.3: Status filter pills
   const filteredDevices = useMemo(() => {
@@ -104,107 +183,73 @@ export function GeoLocationMap({ devices }: { devices: GeoDevice[] }) {
   const handleMarkerClick = useCallback(
     (device: GeoDevice, event: React.MouseEvent) => {
       event.stopPropagation();
-
       const container = containerRef.current;
       if (!container) return;
-
       const rect = container.getBoundingClientRect();
-      const x = event.clientX - rect.left + 12;
-      const y = event.clientY - rect.top + 12;
-
       if (selectedDevice?.id === device.id) {
-        setSelectedDevice(null);
+        dispatch({ type: "DESELECT_DEVICE" });
         return;
       }
-
-      setSelectedDevice(device);
-      setTooltipPosition({ x, y });
+      dispatch({
+        type: "SELECT_DEVICE",
+        device,
+        position: { x: event.clientX - rect.left + 12, y: event.clientY - rect.top + 12 },
+      });
     },
     [selectedDevice],
   );
 
-  // Story 10.2: Cluster click — zoom in on cluster
-  const handleClusterClick = useCallback((cluster: DeviceCluster, event: React.MouseEvent) => {
-    event.stopPropagation();
-    setCenter([cluster.lng, cluster.lat]);
-    setZoom((z) => Math.min(z * 2, 8));
-    setSelectedDevice(null);
-  }, []);
+  const handleClusterClick = useCallback(
+    (cluster: DeviceCluster, event: React.MouseEvent) => {
+      event.stopPropagation();
+      dispatch({
+        type: "NAVIGATE",
+        center: [cluster.lng, cluster.lat],
+        zoom: Math.min(zoom * 2, 8),
+      });
+    },
+    [zoom],
+  );
 
-  const handleMapClick = useCallback(() => {
-    setSelectedDevice(null);
-  }, []);
-
-  const handleZoomIn = useCallback(() => {
-    setZoom((z) => Math.min(z * 1.5, 8));
-  }, []);
-
-  const handleZoomOut = useCallback(() => {
-    setZoom((z) => Math.max(z / 1.5, 1));
-  }, []);
+  const handleMapClick = useCallback(() => dispatch({ type: "DESELECT_DEVICE" }), []);
+  const handleZoomIn = useCallback(() => dispatch({ type: "ZOOM_IN" }), []);
+  const handleZoomOut = useCallback(() => dispatch({ type: "ZOOM_OUT" }), []);
 
   const handleMoveEnd = useCallback((position: { coordinates: [number, number]; zoom: number }) => {
-    setCenter(position.coordinates);
-    setZoom(position.zoom);
+    dispatch({ type: "SET_VIEW", center: position.coordinates, zoom: position.zoom });
   }, []);
 
-  const handleRetry = useCallback(() => {
-    setMapError(false);
-    setMapLoaded(false);
-  }, []);
+  const handleRetry = useCallback(() => dispatch({ type: "RETRY_MAP" }), []);
 
-  // Story 10.3: Location search handler
   const handleLocationSelect = useCallback((coords: CityCoordinates) => {
-    setCenter([coords.lng, coords.lat]);
-    setZoom(4);
-    setSelectedDevice(null);
+    dispatch({ type: "NAVIGATE", center: [coords.lng, coords.lat], zoom: 4 });
   }, []);
 
-  const handleLocationClear = useCallback(() => {
-    setCenter([0, 20]);
-    setZoom(1);
-  }, []);
+  const handleLocationClear = useCallback(() => dispatch({ type: "RESET_VIEW" }), []);
 
-  // Story 10.4: Geofence handlers
   const handleSelectGeofence = useCallback((gf: Geofence) => {
-    setCenter([gf.centerLng, gf.centerLat]);
-    setZoom(4);
-    setSelectedDevice(null);
+    dispatch({ type: "NAVIGATE", center: [gf.centerLng, gf.centerLat], zoom: 4 });
   }, []);
 
-  const handleResetView = useCallback(() => {
-    setCenter([0, 20]);
-    setZoom(1);
-  }, []);
+  const handleResetView = useCallback(() => dispatch({ type: "RESET_VIEW" }), []);
 
-  // Story 10.5: Trail handler
   const handleShowTrail = useCallback(
     (device: GeoDevice) => {
-      // If trail is active for this device, hide it
       if (trailDevice?.id === device.id) {
-        setTrailDevice(null);
-        setTrailPoints([]);
+        dispatch({ type: "HIDE_TRAIL" });
         return;
       }
-
       const resolved = mappableDevices.find((d) => d.id === device.id);
       if (!resolved) {
-        setTrailDevice(null);
-        setTrailPoints([]);
+        dispatch({ type: "HIDE_TRAIL" });
         return;
       }
-
-      const trail = generateMockTrail(resolved);
-      setTrailDevice(resolved);
-      setTrailPoints(trail);
+      dispatch({ type: "SHOW_TRAIL", device: resolved, points: generateMockTrail(resolved) });
     },
     [trailDevice, mappableDevices],
   );
 
-  const handleHideTrail = useCallback(() => {
-    setTrailDevice(null);
-    setTrailPoints([]);
-  }, []);
+  const handleHideTrail = useCallback(() => dispatch({ type: "HIDE_TRAIL" }), []);
 
   // Handle geography load error
   useEffect(() => {
@@ -214,7 +259,7 @@ export function GeoLocationMap({ devices }: { devices: GeoDevice[] }) {
     // Story 22.2: Route through resilient-fetch for timeout handling
     import("../../lib/resilient-fetch").then(({ checkGeoAvailability }) =>
       checkGeoAvailability(GEO_URL).then((ok) => {
-        if (!cancelled && !ok) setMapError(true);
+        if (!cancelled && !ok) dispatch({ type: "MAP_ERROR" });
       }),
     );
 
@@ -233,8 +278,7 @@ export function GeoLocationMap({ devices }: { devices: GeoDevice[] }) {
   );
 
   const handleFilterChange = useCallback((filter: GeoStatusFilter) => {
-    setStatusFilter(filter);
-    setSelectedDevice(null);
+    dispatch({ type: "SET_FILTER", filter });
   }, []);
 
   return (
@@ -308,7 +352,7 @@ export function GeoLocationMap({ devices }: { devices: GeoDevice[] }) {
                     <Geographies geography={GEO_URL}>
                       {({ geographies }) => {
                         if (!mapLoaded && geographies.length > 0) {
-                          queueMicrotask(() => setMapLoaded(true));
+                          queueMicrotask(() => dispatch({ type: "MAP_LOADED" }));
                         }
                         return geographies.map((geo) => (
                           <Geography
@@ -362,7 +406,7 @@ export function GeoLocationMap({ devices }: { devices: GeoDevice[] }) {
                 <DeviceTooltip
                   device={selectedDevice}
                   position={tooltipPosition}
-                  onClose={() => setSelectedDevice(null)}
+                  onClose={() => dispatch({ type: "DESELECT_DEVICE" })}
                   onShowTrail={handleShowTrail}
                   containerRef={containerRef}
                   trailActive={trailDevice?.id === selectedDevice.id}
@@ -397,7 +441,7 @@ export function GeoLocationMap({ devices }: { devices: GeoDevice[] }) {
             <GeofencePanel
               geofences={geofences}
               showGeofences={showGeofences}
-              onToggleGeofences={() => setShowGeofences(!showGeofences)}
+              onToggleGeofences={() => dispatch({ type: "TOGGLE_GEOFENCES" })}
               onSelectGeofence={handleSelectGeofence}
               onCreateGeofence={() => {
                 // In production: open create geofence modal

--- a/src/components/confirm-dialog.tsx
+++ b/src/components/confirm-dialog.tsx
@@ -1,0 +1,72 @@
+/**
+ * IMS Gen 2 — Shared Confirm Dialog (Story 21.2)
+ *
+ * Replaces window.confirm() with a styled, accessible dialog that
+ * follows the enterprise design language and doesn't block the main thread.
+ */
+
+import { cn } from "../lib/utils";
+
+interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  confirmVariant?: "danger" | "warning" | "primary";
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+const VARIANT_CLASSES: Record<string, string> = {
+  danger: "bg-red-600 hover:bg-red-700",
+  warning: "bg-amber-600 hover:bg-amber-700",
+  primary: "bg-accent hover:bg-accent/90",
+};
+
+export function ConfirmDialog({
+  open,
+  title,
+  message,
+  confirmLabel = "Confirm",
+  confirmVariant = "primary",
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="confirm-title"
+    >
+      <div className="absolute inset-0 bg-black/40" onClick={onCancel} />
+      <div className="relative z-10 mx-4 w-full max-w-sm rounded-lg bg-card shadow-xl border border-border">
+        <div className="p-5 space-y-3">
+          <h2 id="confirm-title" className="text-[15px] font-semibold text-foreground">
+            {title}
+          </h2>
+          <p className="text-sm text-muted-foreground">{message}</p>
+        </div>
+        <div className="flex items-center justify-end gap-2 border-t border-border px-5 py-3">
+          <button
+            onClick={onCancel}
+            className="rounded border border-border bg-card px-3 py-1.5 text-sm font-medium text-foreground/80 hover:bg-muted transition-colors cursor-pointer"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            className={cn(
+              "rounded px-3 py-1.5 text-sm font-semibold text-white transition-colors cursor-pointer",
+              VARIANT_CLASSES[confirmVariant],
+            )}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/route-error-boundary.tsx
+++ b/src/components/route-error-boundary.tsx
@@ -1,0 +1,98 @@
+/**
+ * IMS Gen 2 — Route-level Error Boundary (Story 21.3)
+ *
+ * Wraps individual page routes so a crash in one page doesn't
+ * take down the entire app (sidebar, nav, header stay intact).
+ * Users can retry or navigate away without losing context.
+ */
+
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import { logger } from "../lib/logger";
+
+interface Props {
+  children: ReactNode;
+  routeName?: string;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class RouteErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    logger.error(`Route crash [${this.props.routeName ?? "unknown"}]: ${error.message}`, {
+      action: "route_crash",
+      resourceType: "route",
+      resourceId: this.props.routeName,
+      error: {
+        code: "ROUTE_ERROR_BOUNDARY",
+        stack: error.stack,
+      },
+    });
+    logger.addBreadcrumb(
+      "route-error-boundary",
+      `componentStack: ${errorInfo.componentStack?.slice(0, 200) ?? "unknown"}`,
+      "error",
+    );
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex h-full items-center justify-center p-8">
+          <div className="text-center max-w-md">
+            <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-red-100">
+              <svg
+                className="h-6 w-6 text-red-600"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth="1.5"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"
+                />
+              </svg>
+            </div>
+            <h2 className="text-lg font-semibold text-foreground">
+              This page encountered an error
+            </h2>
+            <p className="mt-2 text-sm text-muted-foreground">
+              {this.state.error?.message ?? "An unexpected error occurred"}
+            </p>
+            <div className="mt-5 flex items-center justify-center gap-3">
+              <button
+                onClick={() => this.setState({ hasError: false, error: null })}
+                className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 cursor-pointer"
+              >
+                Try again
+              </button>
+              <button
+                onClick={() => {
+                  this.setState({ hasError: false, error: null });
+                  window.location.href = "/";
+                }}
+                className="rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground hover:bg-muted cursor-pointer"
+              >
+                Go to Dashboard
+              </button>
+            </div>
+          </div>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/src/lib/hooks/use-firmware-deployment.ts
+++ b/src/lib/hooks/use-firmware-deployment.ts
@@ -8,6 +8,15 @@ import type {
 } from "../types/deployment";
 import { INITIAL_FIRMWARE } from "../types/deployment-constants";
 
+/** Pending confirmation state exposed for ConfirmDialog rendering (Story 21.2) */
+export interface FirmwareConfirmation {
+  id: string;
+  title: string;
+  message: string;
+  variant: "danger" | "warning" | "primary";
+  confirmLabel: string;
+}
+
 export function useFirmwareDeployment(
   currentUser: string,
   addAuditEntry: (action: AuditAction, resourceType: string, resourceId: string) => void,
@@ -15,6 +24,10 @@ export function useFirmwareDeployment(
   const [firmware, setFirmware] = useState<FirmwareEntry[]>(INITIAL_FIRMWARE);
   const [fwStatusFilter, setFwStatusFilter] = useState<FirmwareStatus | "All">("All");
   const [fwModelFilter, setFwModelFilter] = useState<string>("All");
+
+  // Story 21.2: Replace window.confirm with async confirmation pattern
+  const [pendingConfirmation, setPendingConfirmation] = useState<FirmwareConfirmation | null>(null);
+  const pendingActionRef = { current: null as (() => void) | null };
 
   const filteredFirmware = useMemo(() => {
     let items = firmware;
@@ -86,50 +99,59 @@ export function useFirmwareDeployment(
           toast.error("Separation of Duties: The uploader cannot advance to Testing");
           return;
         }
-        const confirmed = window.confirm(
-          `Are you sure you want to advance ${fw.version} to Testing?`,
-        );
-        if (!confirmed) return;
-
-        setFirmware((prev) =>
-          prev.map((f) =>
-            f.id === id
-              ? {
-                  ...f,
-                  stage: "Testing" as FirmwareStage,
-                  testedBy: currentUser,
-                  testedDate: new Date().toISOString(),
-                }
-              : f,
-          ),
-        );
-        addAuditEntry("Modified", "Firmware", `FW#${fw.id}`);
-        toast.success(`${fw.version} advanced to Testing`);
+        // Story 21.2: Async confirmation via ConfirmDialog
+        setPendingConfirmation({
+          id,
+          title: "Advance to Testing",
+          message: `Are you sure you want to advance ${fw.version} to Testing?`,
+          variant: "primary",
+          confirmLabel: "Advance",
+        });
+        pendingActionRef.current = () => {
+          setFirmware((prev) =>
+            prev.map((f) =>
+              f.id === id
+                ? {
+                    ...f,
+                    stage: "Testing" as FirmwareStage,
+                    testedBy: currentUser,
+                    testedDate: new Date().toISOString(),
+                  }
+                : f,
+            ),
+          );
+          addAuditEntry("Modified", "Firmware", `FW#${fw.id}`);
+          toast.success(`${fw.version} advanced to Testing`);
+        };
       } else if (fw.stage === "Testing") {
         if (fw.testedBy === currentUser) {
           toast.error("Separation of Duties: The tester cannot approve");
           return;
         }
-        const confirmed = window.confirm(
-          `Are you sure you want to advance ${fw.version} to Approved?`,
-        );
-        if (!confirmed) return;
-
-        setFirmware((prev) =>
-          prev.map((f) =>
-            f.id === id
-              ? {
-                  ...f,
-                  stage: "Approved" as FirmwareStage,
-                  status: "Active" as FirmwareStatus,
-                  approvedBy: currentUser,
-                  approvedDate: new Date().toISOString(),
-                }
-              : f,
-          ),
-        );
-        addAuditEntry("Modified", "Firmware", `FW#${fw.id}`);
-        toast.success(`${fw.version} approved`);
+        setPendingConfirmation({
+          id,
+          title: "Approve Firmware",
+          message: `Are you sure you want to advance ${fw.version} to Approved?`,
+          variant: "primary",
+          confirmLabel: "Approve",
+        });
+        pendingActionRef.current = () => {
+          setFirmware((prev) =>
+            prev.map((f) =>
+              f.id === id
+                ? {
+                    ...f,
+                    stage: "Approved" as FirmwareStage,
+                    status: "Active" as FirmwareStatus,
+                    approvedBy: currentUser,
+                    approvedDate: new Date().toISOString(),
+                  }
+                : f,
+            ),
+          );
+          addAuditEntry("Modified", "Firmware", `FW#${fw.id}`);
+          toast.success(`${fw.version} approved`);
+        };
       }
     },
     [firmware, currentUser, addAuditEntry],
@@ -137,62 +159,83 @@ export function useFirmwareDeployment(
 
   const deprecateFirmware = useCallback(
     (id: string) => {
-      try {
-        const fw = firmware.find((f) => f.id === id);
-        if (!fw) return;
-        const confirmed = window.confirm(`Deprecate firmware ${fw.version}?`);
-        if (!confirmed) return;
-
-        setFirmware((prev) =>
-          prev.map((f) =>
-            f.id === id
-              ? {
-                  ...f,
-                  stage: "Deprecated" as FirmwareStage,
-                  status: "Deprecated" as FirmwareStatus,
-                  devices: 0,
-                }
-              : f,
-          ),
-        );
-        addAuditEntry("Modified", "Firmware", `FW#${fw.id}`);
-        toast.success(`${fw.version} deprecated`);
-      } catch (err) {
-        toast.error(
-          `Failed to deprecate firmware: ${err instanceof Error ? err.message : "Unknown error"}`,
-        );
-      }
+      const fw = firmware.find((f) => f.id === id);
+      if (!fw) return;
+      setPendingConfirmation({
+        id,
+        title: "Deprecate Firmware",
+        message: `Deprecate firmware ${fw.version}? This will remove it from active deployment.`,
+        variant: "danger",
+        confirmLabel: "Deprecate",
+      });
+      pendingActionRef.current = () => {
+        try {
+          setFirmware((prev) =>
+            prev.map((f) =>
+              f.id === id
+                ? {
+                    ...f,
+                    stage: "Deprecated" as FirmwareStage,
+                    status: "Deprecated" as FirmwareStatus,
+                    devices: 0,
+                  }
+                : f,
+            ),
+          );
+          addAuditEntry("Modified", "Firmware", `FW#${fw.id}`);
+          toast.success(`${fw.version} deprecated`);
+        } catch (err) {
+          toast.error(
+            `Failed to deprecate firmware: ${err instanceof Error ? err.message : "Unknown error"}`,
+          );
+        }
+      };
     },
     [firmware, addAuditEntry],
   );
 
   const activateFirmware = useCallback(
     (id: string) => {
-      try {
-        const fw = firmware.find((f) => f.id === id);
-        if (!fw) return;
-        const confirmed = window.confirm(
-          `Reactivate firmware ${fw.version}? It will return to Uploaded stage.`,
-        );
-        if (!confirmed) return;
-
-        setFirmware((prev) =>
-          prev.map((f) =>
-            f.id === id
-              ? { ...f, stage: "Uploaded" as FirmwareStage, status: "Pending" as FirmwareStatus }
-              : f,
-          ),
-        );
-        addAuditEntry("Modified", "Firmware", `FW#${fw.id}`);
-        toast.success(`${fw.version} reactivated`);
-      } catch (err) {
-        toast.error(
-          `Failed to reactivate firmware: ${err instanceof Error ? err.message : "Unknown error"}`,
-        );
-      }
+      const fw = firmware.find((f) => f.id === id);
+      if (!fw) return;
+      setPendingConfirmation({
+        id,
+        title: "Reactivate Firmware",
+        message: `Reactivate firmware ${fw.version}? It will return to Uploaded stage.`,
+        variant: "warning",
+        confirmLabel: "Reactivate",
+      });
+      pendingActionRef.current = () => {
+        try {
+          setFirmware((prev) =>
+            prev.map((f) =>
+              f.id === id
+                ? { ...f, stage: "Uploaded" as FirmwareStage, status: "Pending" as FirmwareStatus }
+                : f,
+            ),
+          );
+          addAuditEntry("Modified", "Firmware", `FW#${fw.id}`);
+          toast.success(`${fw.version} reactivated`);
+        } catch (err) {
+          toast.error(
+            `Failed to reactivate firmware: ${err instanceof Error ? err.message : "Unknown error"}`,
+          );
+        }
+      };
     },
     [firmware, addAuditEntry],
   );
+
+  const confirmAction = useCallback(() => {
+    pendingActionRef.current?.();
+    pendingActionRef.current = null;
+    setPendingConfirmation(null);
+  }, []);
+
+  const cancelAction = useCallback(() => {
+    pendingActionRef.current = null;
+    setPendingConfirmation(null);
+  }, []);
 
   return {
     firmware,
@@ -205,5 +248,9 @@ export function useFirmwareDeployment(
     advanceStage,
     deprecateFirmware,
     activateFirmware,
+    // Story 21.2: Async confirmation support
+    pendingConfirmation,
+    confirmAction,
+    cancelAction,
   };
 }


### PR DESCRIPTION
## Summary

Three critical Epic 21 stories — state management cleanup and resilience:

- **#281** — Consolidate 10 `useState` calls in `geo-location-map.tsx` into a single `useReducer` with typed `MapState`/`MapAction`. Eliminates multi-setState batching issues and state drift between related fields (tooltip + selectedDevice, center + zoom, trailDevice + trailPoints).
- **#282** — Extract shared `ConfirmDialog` component, replace all 4 `window.confirm()` calls in firmware deployment hook. Hook exposes `pendingConfirmation` state + `confirmAction`/`cancelAction` callbacks. Dialog supports `primary`/`warning`/`danger` variants with proper ARIA attributes.
- **#283** — Add `RouteErrorBoundary` wrapping every lazy-loaded route. Page crashes show contextual error UI ("Try again" + "Go to Dashboard") while sidebar/header stay intact. Structured logging via `logger.error` with route name context.

### New files
- `src/components/confirm-dialog.tsx` — Shared styled confirmation dialog
- `src/components/route-error-boundary.tsx` — Per-route error boundary with recovery UI

### Modified files
- `geo-location-map.tsx` — 10 useState → 1 useReducer + typed dispatch
- `use-firmware-deployment.ts` — window.confirm → async pendingConfirmation pattern
- `deployment.tsx` — Renders ConfirmDialog from hook state
- `App.tsx` — Every route wrapped with RouteErrorBoundary + RouteElement helper

Closes #281, closes #282, closes #283

## Test plan
- [x] `npm run build` passes
- [x] 503/503 unit tests pass
- [x] Lint: 0 new errors
- [ ] Manual: Map interactions (click, zoom, filter, geofence, trail) work identically
- [ ] Manual: Firmware advance/deprecate/reactivate show styled dialog instead of browser confirm
- [ ] Manual: Force a page error — verify sidebar stays, error UI shows with recovery options

🤖 Generated with [Claude Code](https://claude.com/claude-code)