### PR TITLE
[Epic 21+23] useDialogManager + FormField adoption in modals

### DIFF
--- a/src/app/components/compliance/compliance.tsx
+++ b/src/app/components/compliance/compliance.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/lib/utils";
 import { useAuth } from "@/lib/use-auth";
 import { getPrimaryRole, canPerformAction } from "@/lib/rbac";
 import { useComplianceManagement } from "@/lib/hooks/use-compliance-management";
+import { useDialogManager } from "@/lib/hooks/use-dialog-manager";
 import type {
   ComplianceItem,
   CertificationType,
@@ -53,33 +54,28 @@ export function CompliancePage() {
   // Expanded vulnerability panel
   const [expandedItemId, setExpandedItemId] = useState<string | null>(null);
 
-  // Modals
-  const [submitModalOpen, setSubmitModalOpen] = useState(false);
-  const [vulnModalOpen, setVulnModalOpen] = useState(false);
-  const [reportModalOpen, setReportModalOpen] = useState(false);
-  const [confirmAction, setConfirmAction] = useState<{
-    type: "approve" | "deprecate";
-    itemId: string;
-  } | null>(null);
+  // Story 21.5: Unified dialog manager — guarantees one dialog at a time
+  type ComplianceDialog = "submit" | "vuln" | "report" | "confirm-approve" | "confirm-deprecate";
+  const dialogs = useDialogManager<ComplianceDialog>();
 
   const handleApprove = (itemId: string) => {
     if (!canPerformAction(role, "approve")) {
       toast.error("Access denied — insufficient permissions");
-      setConfirmAction(null);
+      dialogs.close();
       return;
     }
     hookApprove(itemId);
-    setConfirmAction(null);
+    dialogs.close();
   };
 
   const handleDeprecate = (itemId: string) => {
     if (!canPerformAction(role, "edit")) {
       toast.error("Access denied — insufficient permissions");
-      setConfirmAction(null);
+      dialogs.close();
       return;
     }
     hookDeprecate(itemId);
-    setConfirmAction(null);
+    dialogs.close();
   };
 
   // ---------------------------------------------------------------------------
@@ -99,7 +95,7 @@ export function CompliancePage() {
         <div className="flex items-center gap-2">
           {canSubmitForReview(role) && (
             <button
-              onClick={() => setSubmitModalOpen(true)}
+              onClick={() => dialogs.open("submit")}
               className="flex items-center gap-1.5 rounded border border-border bg-card px-3 py-1.5 text-sm font-medium text-foreground/80 hover:border-accent-text/50 hover:text-foreground transition-colors duration-150"
             >
               <Send className="h-3.5 w-3.5" />
@@ -107,7 +103,7 @@ export function CompliancePage() {
             </button>
           )}
           <button
-            onClick={() => setReportModalOpen(true)}
+            onClick={() => dialogs.open("report")}
             className="flex items-center gap-1.5 rounded bg-accent px-3 py-1.5 text-sm font-semibold text-white hover:bg-accent-hover transition-colors duration-150"
           >
             <FileText className="h-3.5 w-3.5" />
@@ -150,8 +146,8 @@ export function CompliancePage() {
           setExpandedItemId={setExpandedItemId}
           role={role}
           onSubmitForReview={handleSubmitForReview}
-          onApprove={(id) => setConfirmAction({ type: "approve", itemId: id })}
-          onDeprecate={(id) => setConfirmAction({ type: "deprecate", itemId: id })}
+          onApprove={(id) => dialogs.open("confirm-approve", { itemId: id })}
+          onDeprecate={(id) => dialogs.open("confirm-deprecate", { itemId: id })}
           onRemediationChange={handleRemediationChange}
         />
       )}
@@ -161,17 +157,17 @@ export function CompliancePage() {
         <VulnerabilitiesTab
           vulnerabilities={sortedVulnerabilities}
           role={role}
-          onCreateVuln={() => setVulnModalOpen(true)}
+          onCreateVuln={() => dialogs.open("vuln")}
         />
       )}
 
       {/* === Reports Tab === */}
       {activeTab === "reports" && <ReportsTab items={filteredItems} allItems={complianceItems} />}
 
-      {/* Modals */}
-      {submitModalOpen && (
+      {/* Modals — Story 21.5: useDialogManager ensures one-at-a-time */}
+      {dialogs.isDialogOpen("submit") && (
         <SubmitForReviewModal
-          onClose={() => setSubmitModalOpen(false)}
+          onClose={dialogs.close}
           onSubmit={(data) => {
             if (!canPerformAction(role, "create")) {
               toast.error("Access denied — insufficient permissions");
@@ -194,7 +190,7 @@ export function CompliancePage() {
                 vulnerabilities: [],
               };
               addComplianceItem(newItem);
-              setSubmitModalOpen(false);
+              dialogs.close();
               toast.success("Compliance item submitted for review");
             } catch (error: unknown) {
               // Modal stays open — form input preserved for retry.
@@ -206,9 +202,9 @@ export function CompliancePage() {
         />
       )}
 
-      {vulnModalOpen && (
+      {dialogs.isDialogOpen("vuln") && (
         <CreateVulnerabilityModal
-          onClose={() => setVulnModalOpen(false)}
+          onClose={dialogs.close}
           onSubmit={(data) => {
             if (!canPerformAction(role, "create")) {
               toast.error("Access denied — insufficient permissions");
@@ -227,42 +223,44 @@ export function CompliancePage() {
               resolvedDate: null,
             };
             addVulnerability(newVuln);
-            setVulnModalOpen(false);
+            dialogs.close();
             toast.success("Vulnerability record created");
           }}
         />
       )}
 
-      {reportModalOpen && (
-        <ReportModal items={complianceItems} onClose={() => setReportModalOpen(false)} />
+      {dialogs.isDialogOpen("report") && (
+        <ReportModal items={complianceItems} onClose={dialogs.close} />
       )}
 
-      {confirmAction && (
+      {(dialogs.isDialogOpen("confirm-approve") || dialogs.isDialogOpen("confirm-deprecate")) && (
         <ConfirmDialog
           title={
-            confirmAction.type === "approve"
+            dialogs.isDialogOpen("confirm-approve")
               ? "Approve Compliance Item"
               : "Deprecate Compliance Item"
           }
           message={
-            confirmAction.type === "approve"
+            dialogs.isDialogOpen("confirm-approve")
               ? "Approve this compliance item? It will be marked as compliant."
               : "Deprecate this compliance item? It will no longer be considered current."
           }
-          confirmLabel={confirmAction.type === "approve" ? "Approve" : "Deprecate"}
+          confirmLabel={dialogs.isDialogOpen("confirm-approve") ? "Approve" : "Deprecate"}
           confirmClass={
-            confirmAction.type === "approve"
+            dialogs.isDialogOpen("confirm-approve")
               ? "bg-emerald-600 hover:bg-emerald-700"
               : "bg-amber-600 hover:bg-amber-700"
           }
           onConfirm={() => {
-            if (confirmAction.type === "approve") {
-              handleApprove(confirmAction.itemId);
+            const itemId = dialogs.getContext<string>("itemId");
+            if (!itemId) return;
+            if (dialogs.isDialogOpen("confirm-approve")) {
+              handleApprove(itemId);
             } else {
-              handleDeprecate(confirmAction.itemId);
+              handleDeprecate(itemId);
             }
           }}
-          onCancel={() => setConfirmAction(null)}
+          onCancel={dialogs.close}
         />
       )}
     </div>

--- a/src/app/components/deployment.tsx
+++ b/src/app/components/deployment.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/lib/utils";
 import { useAuth } from "@/lib/use-auth";
 import { getPrimaryRole, canPerformAction } from "@/lib/rbac";
 import { ConfirmDialog } from "@/components/confirm-dialog";
+import { useDialogManager } from "@/lib/hooks/use-dialog-manager";
 
 import type { Tab } from "./deployment/deployment-types";
 import { UploadFirmwareModal } from "./deployment/upload-firmware-modal";
@@ -54,8 +55,10 @@ export function Deployment() {
   const vulnTracker = useVulnerabilityTracker(auditLog.addAuditEntry);
 
   const [activeTab, setActiveTab] = useState<Tab>("firmware");
-  const [uploadModalOpen, setUploadModalOpen] = useState(false);
-  const [vulnModalOpen, setVulnModalOpen] = useState(false);
+
+  // Story 21.5: Unified dialog manager
+  type DeploymentDialog = "upload" | "vuln";
+  const dialogs = useDialogManager<DeploymentDialog>();
 
   // RBAC-guarded vulnerability creation
   const guardedCreateVulnerability = useCallback(
@@ -119,7 +122,7 @@ export function Deployment() {
         return;
       }
       try {
-        hookUpload(data, () => setUploadModalOpen(false));
+        hookUpload(data, () => dialogs.close());
       } catch (error: unknown) {
         // Modal stays open — form input preserved for retry.
         if (error instanceof Error && !error.message.includes("failed")) {
@@ -168,7 +171,7 @@ export function Deployment() {
         </div>
         {activeTab === "firmware" && canManage && (
           <button
-            onClick={() => setUploadModalOpen(true)}
+            onClick={() => dialogs.open("upload")}
             className="flex items-center gap-1 rounded-sm bg-accent px-2.5 py-1.5 text-sm font-medium text-white hover:bg-accent/90 transition-colors duration-150"
           >
             <Upload className="h-3 w-3" />
@@ -177,7 +180,7 @@ export function Deployment() {
         )}
         {activeTab === "vulnerabilities" && canManageVulns && (
           <button
-            onClick={() => setVulnModalOpen(true)}
+            onClick={() => dialogs.open("vuln")}
             className="flex items-center gap-1 rounded-sm bg-accent px-2.5 py-1.5 text-sm font-medium text-white hover:bg-accent/90 transition-colors duration-150"
           >
             <Plus className="h-3 w-3" />
@@ -202,7 +205,7 @@ export function Deployment() {
             currentUser={currentUser}
             canManage={canManage}
             isAdmin={isAdmin}
-            onUploadClick={() => setUploadModalOpen(true)}
+            onUploadClick={() => dialogs.open("upload")}
             advanceStage={guardedAdvanceStage}
             deprecateFirmware={guardedDeprecate}
             activateFirmware={guardedActivate}
@@ -263,16 +266,16 @@ export function Deployment() {
 
       {/* Upload Modal -- Story 11.1 */}
       <UploadFirmwareModal
-        open={uploadModalOpen}
-        onClose={() => setUploadModalOpen(false)}
+        open={dialogs.isDialogOpen("upload")}
+        onClose={() => dialogs.close()}
         onSubmit={handleUpload}
       />
 
       {/* Create Vulnerability Modal -- Story 11.5 */}
-      {vulnModalOpen && (
+      {dialogs.isDialogOpen("vuln") && (
         <CreateVulnerabilityModal
           firmwareList={firmware}
-          onClose={() => setVulnModalOpen(false)}
+          onClose={() => dialogs.close()}
           onSubmit={guardedCreateVulnerability}
         />
       )}

--- a/src/app/components/dialogs/create-device-modal.tsx
+++ b/src/app/components/dialogs/create-device-modal.tsx
@@ -4,6 +4,9 @@ import { X } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { DeviceStatus } from "@/lib/types";
+import { FormField } from "@/components/form/form-field";
+import { FormInput } from "@/components/form/form-input";
+import { FormSelect } from "@/components/form/form-select";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -141,25 +144,16 @@ export function CreateDeviceModal({ open, onClose, onCreateDevice }: CreateDevic
 
   if (!open) return null;
 
-  const inputClass =
-    "h-10 w-full border border-border bg-card px-3 text-[15px] text-foreground placeholder:text-muted-foreground rounded-lg focus:border-[#2563eb] focus:outline-none focus:ring-1 focus:ring-[#2563eb]";
-
-  const labelClass = "block text-[14px] font-medium text-foreground/80 mb-1";
-
   return (
     <FocusTrap>
       <div className="fixed inset-0 z-[60] flex items-center justify-center">
-        {/* Backdrop */}
         <div className="absolute inset-0 bg-black/30" onClick={handleClose} aria-hidden="true" />
-
-        {/* Modal */}
         <div
           className="relative z-10 w-full max-w-[520px] rounded-2xl bg-card shadow-xl"
           role="dialog"
           aria-modal="true"
           aria-label="Create device"
         >
-          {/* Header */}
           <div className="flex items-center justify-between border-b border-border/60 px-6 py-4">
             <h3 className="text-[16px] font-semibold text-foreground">Create Device</h3>
             <button
@@ -175,67 +169,40 @@ export function CreateDeviceModal({ open, onClose, onCreateDevice }: CreateDevic
             </button>
           </div>
 
-          {/* Body */}
+          {/* Story 23.4: Shared FormField/FormInput/FormSelect */}
           <form onSubmit={handleSubmit} className="px-6 py-5 space-y-4">
-            {/* Device Name */}
-            <div>
-              <label htmlFor="device-name" className={labelClass}>
-                Device Name <span className="text-red-500">*</span>
-              </label>
-              <input
+            <FormField label="Device Name" htmlFor="device-name" required error={errors.name}>
+              <FormInput
                 id="device-name"
-                type="text"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 placeholder="e.g. INV-3200A"
+                error={!!errors.name}
                 aria-describedby={errors.name ? "device-name-error" : undefined}
-                aria-invalid={!!errors.name || undefined}
-                className={cn(inputClass, errors.name && "border-red-400")}
               />
-              {errors.name && (
-                <p id="device-name-error" className="mt-1 text-[14px] text-red-500" role="alert">
-                  {errors.name}
-                </p>
-              )}
-            </div>
+            </FormField>
 
-            {/* Serial Number + Device Model row */}
             <div className="grid grid-cols-2 gap-3">
-              <div>
-                <label htmlFor="device-serial" className={labelClass}>
-                  Serial Number <span className="text-red-500">*</span>
-                </label>
-                <input
+              <FormField
+                label="Serial Number"
+                htmlFor="device-serial"
+                required
+                error={errors.serial}
+              >
+                <FormInput
                   id="device-serial"
-                  type="text"
                   value={serial}
                   onChange={(e) => setSerial(e.target.value)}
                   placeholder="e.g. SN-4821"
-                  aria-describedby={errors.serial ? "device-serial-error" : undefined}
-                  aria-invalid={!!errors.serial || undefined}
-                  className={cn(inputClass, errors.serial && "border-red-400")}
+                  error={!!errors.serial}
                 />
-                {errors.serial && (
-                  <p
-                    id="device-serial-error"
-                    className="mt-1 text-[14px] text-red-500"
-                    role="alert"
-                  >
-                    {errors.serial}
-                  </p>
-                )}
-              </div>
-              <div>
-                <label htmlFor="device-model" className={labelClass}>
-                  Device Model <span className="text-red-500">*</span>
-                </label>
-                <select
+              </FormField>
+              <FormField label="Device Model" htmlFor="device-model" required error={errors.model}>
+                <FormSelect
                   id="device-model"
                   value={model}
                   onChange={(e) => setModel(e.target.value)}
-                  aria-describedby={errors.model ? "device-model-error" : undefined}
-                  aria-invalid={!!errors.model || undefined}
-                  className={cn(inputClass, errors.model && "border-red-400")}
+                  error={!!errors.model}
                 >
                   <option value="">Select model</option>
                   {DEVICE_MODELS.map((m) => (
@@ -243,144 +210,74 @@ export function CreateDeviceModal({ open, onClose, onCreateDevice }: CreateDevic
                       {m}
                     </option>
                   ))}
-                </select>
-                {errors.model && (
-                  <p id="device-model-error" className="mt-1 text-[14px] text-red-500" role="alert">
-                    {errors.model}
-                  </p>
-                )}
-              </div>
+                </FormSelect>
+              </FormField>
             </div>
 
-            {/* Firmware Version + Status row */}
             <div className="grid grid-cols-2 gap-3">
-              <div>
-                <label htmlFor="device-firmware" className={labelClass}>
-                  Firmware Version <span className="text-red-500">*</span>
-                </label>
-                <input
+              <FormField
+                label="Firmware Version"
+                htmlFor="device-firmware"
+                required
+                error={errors.firmware}
+              >
+                <FormInput
                   id="device-firmware"
-                  type="text"
                   value={firmware}
                   onChange={(e) => setFirmware(e.target.value)}
                   placeholder="e.g. v4.0.0"
-                  aria-describedby={errors.firmware ? "device-firmware-error" : undefined}
-                  aria-invalid={!!errors.firmware || undefined}
-                  className={cn(inputClass, errors.firmware && "border-red-400")}
+                  error={!!errors.firmware}
                 />
-                {errors.firmware && (
-                  <p
-                    id="device-firmware-error"
-                    className="mt-1 text-[14px] text-red-500"
-                    role="alert"
-                  >
-                    {errors.firmware}
-                  </p>
-                )}
-              </div>
-              <div>
-                <label htmlFor="device-status" className={labelClass}>
-                  Status <span className="text-red-500">*</span>
-                </label>
-                <select
+              </FormField>
+              <FormField label="Status" htmlFor="device-status" required error={errors.status}>
+                <FormSelect
                   id="device-status"
                   value={status}
                   onChange={(e) => setStatus(e.target.value as DeviceStatus)}
-                  aria-describedby={errors.status ? "device-status-error" : undefined}
-                  aria-invalid={!!errors.status || undefined}
-                  className={cn(inputClass, errors.status && "border-red-400")}
+                  error={!!errors.status}
                 >
                   {DEVICE_STATUSES.map((s) => (
                     <option key={s.value} value={s.value}>
                       {s.label}
                     </option>
                   ))}
-                </select>
-                {errors.status && (
-                  <p
-                    id="device-status-error"
-                    className="mt-1 text-[14px] text-red-500"
-                    role="alert"
-                  >
-                    {errors.status}
-                  </p>
-                )}
-              </div>
+                </FormSelect>
+              </FormField>
             </div>
 
-            {/* Location */}
-            <div>
-              <label htmlFor="device-location" className={labelClass}>
-                Location <span className="text-red-500">*</span>
-              </label>
-              <input
+            <FormField label="Location" htmlFor="device-location" required error={errors.location}>
+              <FormInput
                 id="device-location"
-                type="text"
                 value={location}
                 onChange={(e) => setLocation(e.target.value)}
                 placeholder="e.g. Denver, CO"
-                aria-describedby={errors.location ? "device-location-error" : undefined}
-                aria-invalid={!!errors.location || undefined}
-                className={cn(inputClass, errors.location && "border-red-400")}
+                error={!!errors.location}
               />
-              {errors.location && (
-                <p
-                  id="device-location-error"
-                  className="mt-1 text-[14px] text-red-500"
-                  role="alert"
-                >
-                  {errors.location}
-                </p>
-              )}
-            </div>
+            </FormField>
 
-            {/* Latitude + Longitude row */}
             <div className="grid grid-cols-2 gap-3">
-              <div>
-                <label htmlFor="device-lat" className={labelClass}>
-                  Latitude
-                </label>
-                <input
+              <FormField label="Latitude" htmlFor="device-lat" error={errors.lat}>
+                <FormInput
                   id="device-lat"
-                  type="text"
                   inputMode="decimal"
                   value={lat}
                   onChange={(e) => setLat(e.target.value)}
                   placeholder="e.g. 39.74"
-                  aria-describedby={errors.lat ? "device-lat-error" : undefined}
-                  aria-invalid={!!errors.lat || undefined}
-                  className={cn(inputClass, errors.lat && "border-red-400")}
+                  error={!!errors.lat}
                 />
-                {errors.lat && (
-                  <p id="device-lat-error" className="mt-1 text-[14px] text-red-500" role="alert">
-                    {errors.lat}
-                  </p>
-                )}
-              </div>
-              <div>
-                <label htmlFor="device-lng" className={labelClass}>
-                  Longitude
-                </label>
-                <input
+              </FormField>
+              <FormField label="Longitude" htmlFor="device-lng" error={errors.lng}>
+                <FormInput
                   id="device-lng"
-                  type="text"
                   inputMode="decimal"
                   value={lng}
                   onChange={(e) => setLng(e.target.value)}
                   placeholder="e.g. -104.99"
-                  aria-describedby={errors.lng ? "device-lng-error" : undefined}
-                  aria-invalid={!!errors.lng || undefined}
-                  className={cn(inputClass, errors.lng && "border-red-400")}
+                  error={!!errors.lng}
                 />
-                {errors.lng && (
-                  <p id="device-lng-error" className="mt-1 text-[14px] text-red-500" role="alert">
-                    {errors.lng}
-                  </p>
-                )}
-              </div>
+              </FormField>
             </div>
 
-            {/* Actions */}
             <div className="flex items-center justify-end gap-3 pt-2">
               <button
                 type="button"

--- a/src/app/components/dialogs/invite-user-modal.tsx
+++ b/src/app/components/dialogs/invite-user-modal.tsx
@@ -4,6 +4,9 @@ import { X } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import type { Role } from "@/lib/rbac";
+import { FormField } from "@/components/form/form-field";
+import { FormInput } from "@/components/form/form-input";
+import { FormSelect } from "@/components/form/form-select";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -134,25 +137,16 @@ export function InviteUserModal({ open, onClose, onInvite }: InviteUserModalProp
 
   if (!open) return null;
 
-  const inputClass =
-    "h-10 w-full border border-border bg-card px-3 text-[15px] text-foreground placeholder:text-muted-foreground rounded-lg focus:border-[#2563eb] focus:outline-none focus:ring-1 focus:ring-[#2563eb]";
-
-  const labelClass = "block text-[14px] font-medium text-foreground/80 mb-1";
-
   return (
     <FocusTrap>
       <div className="fixed inset-0 z-[60] flex items-center justify-center">
-        {/* Backdrop */}
         <div className="absolute inset-0 bg-black/30" onClick={handleClose} aria-hidden="true" />
-
-        {/* Modal */}
         <div
           className="relative z-10 w-full max-w-[480px] rounded-2xl bg-card shadow-xl"
           role="dialog"
           aria-modal="true"
           aria-label="Invite user"
         >
-          {/* Header */}
           <div className="flex items-center justify-between border-b border-border/60 px-6 py-4">
             <h3 className="text-[16px] font-semibold text-foreground">Invite User</h3>
             <button
@@ -168,113 +162,75 @@ export function InviteUserModal({ open, onClose, onInvite }: InviteUserModalProp
             </button>
           </div>
 
-          {/* Body */}
+          {/* Story 23.4: Shared FormField/FormInput/FormSelect */}
           <form onSubmit={handleSubmit} className="px-6 py-5 space-y-4">
-            {/* Email */}
-            <div>
-              <label htmlFor="invite-email" className={labelClass}>
-                Email <span className="text-red-500">*</span>
-              </label>
-              <input
+            <FormField label="Email" htmlFor="invite-email" required error={errors.email}>
+              <FormInput
                 id="invite-email"
                 type="email"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 placeholder="user@company.com"
-                aria-describedby={errors.email ? "invite-email-error" : undefined}
-                aria-invalid={!!errors.email || undefined}
-                className={cn(inputClass, errors.email && "border-red-400")}
+                error={!!errors.email}
               />
-              {errors.email && (
-                <p id="invite-email-error" className="mt-1 text-[14px] text-red-500" role="alert">
-                  {errors.email}
-                </p>
-              )}
-            </div>
+            </FormField>
 
-            {/* Name row */}
             <div className="grid grid-cols-2 gap-3">
-              <div>
-                <label htmlFor="invite-first-name" className={labelClass}>
-                  First Name <span className="text-red-500">*</span>
-                </label>
-                <input
+              <FormField
+                label="First Name"
+                htmlFor="invite-first-name"
+                required
+                error={errors.firstName}
+              >
+                <FormInput
                   id="invite-first-name"
-                  type="text"
                   value={firstName}
                   onChange={(e) => setFirstName(e.target.value)}
                   placeholder="Jane"
-                  aria-describedby={errors.firstName ? "invite-first-name-error" : undefined}
-                  aria-invalid={!!errors.firstName || undefined}
-                  className={cn(inputClass, errors.firstName && "border-red-400")}
+                  error={!!errors.firstName}
                 />
-                {errors.firstName && (
-                  <p
-                    id="invite-first-name-error"
-                    className="mt-1 text-[14px] text-red-500"
-                    role="alert"
-                  >
-                    {errors.firstName}
-                  </p>
-                )}
-              </div>
-              <div>
-                <label htmlFor="invite-last-name" className={labelClass}>
-                  Last Name <span className="text-red-500">*</span>
-                </label>
-                <input
+              </FormField>
+              <FormField
+                label="Last Name"
+                htmlFor="invite-last-name"
+                required
+                error={errors.lastName}
+              >
+                <FormInput
                   id="invite-last-name"
-                  type="text"
                   value={lastName}
                   onChange={(e) => setLastName(e.target.value)}
                   placeholder="Martinez"
-                  aria-describedby={errors.lastName ? "invite-last-name-error" : undefined}
-                  aria-invalid={!!errors.lastName || undefined}
-                  className={cn(inputClass, errors.lastName && "border-red-400")}
+                  error={!!errors.lastName}
                 />
-                {errors.lastName && (
-                  <p
-                    id="invite-last-name-error"
-                    className="mt-1 text-[14px] text-red-500"
-                    role="alert"
-                  >
-                    {errors.lastName}
-                  </p>
-                )}
-              </div>
+              </FormField>
             </div>
 
-            {/* Role */}
-            <div>
-              <label htmlFor="invite-role" className={labelClass}>
-                Role <span className="text-red-500">*</span>
-              </label>
-              <select
+            <FormField label="Role" htmlFor="invite-role" required>
+              <FormSelect
                 id="invite-role"
                 value={role}
                 onChange={(e) => setRole(e.target.value as Role)}
-                className={inputClass}
               >
                 {ROLES.map((r) => (
                   <option key={r} value={r}>
                     {r}
                   </option>
                 ))}
-              </select>
-            </div>
+              </FormSelect>
+            </FormField>
 
-            {/* Department */}
-            <div>
-              <label htmlFor="invite-department" className={labelClass}>
-                Department <span className="text-red-500">*</span>
-              </label>
-              <select
+            <FormField
+              label="Department"
+              htmlFor="invite-department"
+              required
+              error={errors.department}
+            >
+              <FormSelect
                 id="invite-department"
                 value={department}
                 onChange={(e) => setDepartment(e.target.value)}
-                aria-describedby={errors.department ? "invite-department-error" : undefined}
-                aria-invalid={!!errors.department || undefined}
-                className={cn(inputClass, errors.department && "border-red-400")}
+                error={!!errors.department}
               >
                 <option value="">Select department</option>
                 {DEPARTMENTS.map((d) => (
@@ -282,47 +238,26 @@ export function InviteUserModal({ open, onClose, onInvite }: InviteUserModalProp
                     {d}
                   </option>
                 ))}
-              </select>
-              {errors.department && (
-                <p
-                  id="invite-department-error"
-                  className="mt-1 text-[14px] text-red-500"
-                  role="alert"
-                >
-                  {errors.department}
-                </p>
-              )}
-            </div>
+              </FormSelect>
+            </FormField>
 
-            {/* Customer — visible only for CustomerAdmin */}
             {role === "CustomerAdmin" && (
-              <div>
-                <label htmlFor="invite-customer" className={labelClass}>
-                  Customer <span className="text-red-500">*</span>
-                </label>
-                <input
+              <FormField
+                label="Customer"
+                htmlFor="invite-customer"
+                required
+                error={errors.customer}
+              >
+                <FormInput
                   id="invite-customer"
-                  type="text"
                   value={customer}
                   onChange={(e) => setCustomer(e.target.value)}
                   placeholder="e.g. Sungrow Power"
-                  aria-describedby={errors.customer ? "invite-customer-error" : undefined}
-                  aria-invalid={!!errors.customer || undefined}
-                  className={cn(inputClass, errors.customer && "border-red-400")}
+                  error={!!errors.customer}
                 />
-                {errors.customer && (
-                  <p
-                    id="invite-customer-error"
-                    className="mt-1 text-[14px] text-red-500"
-                    role="alert"
-                  >
-                    {errors.customer}
-                  </p>
-                )}
-              </div>
+              </FormField>
             )}
 
-            {/* Actions */}
             <div className="flex items-center justify-end gap-3 pt-2">
               <button
                 type="button"

--- a/src/app/components/incidents/incident-response-page.tsx
+++ b/src/app/components/incidents/incident-response-page.tsx
@@ -7,6 +7,7 @@ import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { useAuth } from "@/lib/use-auth";
 import { getPrimaryRole, canPerformAction } from "@/lib/rbac";
+import { useDialogManager } from "@/lib/hooks/use-dialog-manager";
 import type {
   Incident,
   IncidentStatus,
@@ -46,9 +47,10 @@ export function IncidentResponsePage() {
 
   const [activeTab, setActiveTab] = useState<TabId>("incidents");
   const [selectedIncident, setSelectedIncident] = useState<Incident | null>(null);
-  const [showCreateDialog, setShowCreateDialog] = useState(false);
-  const [isolateDevice, setIsolateDevice] = useState<AffectedDevice | null>(null);
-  const [releaseDevice, setReleaseDevice] = useState<AffectedDevice | null>(null);
+
+  // Story 21.5: Unified dialog manager — guarantees one dialog at a time
+  type IncidentDialog = "create" | "isolate" | "release";
+  const dialogs = useDialogManager<IncidentDialog>();
 
   // Sync selectedIncident with incidents array after mutations
   useEffect(() => {
@@ -89,7 +91,7 @@ export function IncidentResponsePage() {
         return;
       }
       hookIsolateConfirm(deviceId, policy);
-      setIsolateDevice(null);
+      dialogs.close();
     },
     [role, hookIsolateConfirm],
   );
@@ -101,7 +103,7 @@ export function IncidentResponsePage() {
         return;
       }
       hookReleaseConfirm(deviceId, reason);
-      setReleaseDevice(null);
+      dialogs.close();
     },
     [role, hookReleaseConfirm],
   );
@@ -163,11 +165,14 @@ export function IncidentResponsePage() {
         <IncidentListTab
           incidents={incidents}
           onSelectIncident={(inc) => setSelectedIncident(inc)}
-          onCreateIncident={() => setShowCreateDialog(true)}
+          onCreateIncident={() => dialogs.open("create")}
         />
       )}
       {activeTab === "isolated" && (
-        <IsolatedDevicesTab incidents={incidents} onRelease={(dev) => setReleaseDevice(dev)} />
+        <IsolatedDevicesTab
+          incidents={incidents}
+          onRelease={(dev) => dialogs.open("release", { device: dev })}
+        />
       )}
       {activeTab === "quarantine" && (
         <QuarantineZonesTab
@@ -186,28 +191,28 @@ export function IncidentResponsePage() {
           incident={selectedIncident}
           onClose={() => setSelectedIncident(null)}
           onStatusChange={handleStatusChange}
-          onIsolate={(dev) => setIsolateDevice(dev)}
-          onRelease={(dev) => setReleaseDevice(dev)}
+          onIsolate={(dev) => dialogs.open("isolate", { device: dev })}
+          onRelease={(dev) => dialogs.open("release", { device: dev })}
           onStepComplete={handleStepComplete}
         />
       )}
 
       {/* Dialogs */}
       <CreateIncidentDialog
-        open={showCreateDialog}
-        onClose={() => setShowCreateDialog(false)}
+        open={dialogs.isDialogOpen("create")}
+        onClose={dialogs.close}
         onCreate={handleCreateIncidentGuarded}
       />
       <IsolationDialog
-        device={isolateDevice}
-        open={!!isolateDevice}
-        onClose={() => setIsolateDevice(null)}
+        device={dialogs.getContext<AffectedDevice>("device") ?? null}
+        open={dialogs.isDialogOpen("isolate")}
+        onClose={dialogs.close}
         onConfirm={handleIsolateConfirm}
       />
       <ReleaseDialog
-        device={releaseDevice}
-        open={!!releaseDevice}
-        onClose={() => setReleaseDevice(null)}
+        device={dialogs.getContext<AffectedDevice>("device") ?? null}
+        open={dialogs.isDialogOpen("release")}
+        onClose={dialogs.close}
         onConfirm={handleReleaseConfirm}
       />
     </div>

--- a/src/lib/hooks/use-dialog-manager.ts
+++ b/src/lib/hooks/use-dialog-manager.ts
@@ -1,0 +1,54 @@
+/**
+ * IMS Gen 2 — useDialogManager (Story 21.5)
+ *
+ * Centralizes modal/dialog state for page components.
+ * Guarantees only one dialog is open at a time — prevents z-index
+ * conflicts, focus trap collisions, and overlapping modals.
+ */
+
+import { useState, useCallback } from "react";
+
+export interface DialogState<T extends string = string> {
+  type: T | "closed";
+  context?: Record<string, unknown>;
+}
+
+export interface DialogManager<T extends string = string> {
+  /** Current dialog state */
+  dialog: DialogState<T>;
+  /** Whether any dialog is open */
+  isOpen: boolean;
+  /** Whether a specific dialog is open */
+  isDialogOpen: (type: T) => boolean;
+  /** Open a dialog (closes any currently open dialog) */
+  open: (type: T, context?: Record<string, unknown>) => void;
+  /** Close the current dialog */
+  close: () => void;
+  /** Get context value for current dialog */
+  getContext: <V = unknown>(key: string) => V | undefined;
+}
+
+export function useDialogManager<T extends string = string>(): DialogManager<T> {
+  const [dialog, setDialog] = useState<DialogState<T>>({ type: "closed" });
+
+  const open = useCallback((type: T, context?: Record<string, unknown>) => {
+    setDialog({ type, context });
+  }, []);
+
+  const close = useCallback(() => {
+    setDialog({ type: "closed" });
+  }, []);
+
+  const isOpen = dialog.type !== "closed";
+
+  const isDialogOpen = useCallback((type: T) => dialog.type === type, [dialog.type]);
+
+  const getContext = useCallback(
+    <V = unknown>(key: string): V | undefined => {
+      return dialog.context?.[key] as V | undefined;
+    },
+    [dialog.context],
+  );
+
+  return { dialog, isOpen, isDialogOpen, open, close, getContext };
+}


### PR DESCRIPTION
## Summary

- **#285** — `useDialogManager<T>` hook: typed dialog state machine guaranteeing one dialog open at a time. Migrated 3 pages (compliance 4→1, incidents 3→1, deployment 2→1 dialog state). Eliminates overlapping modal risk.
- **#302** — Migrate create-device-modal (8 fields) and invite-user-modal (6 fields) to shared `FormField`/`FormInput`/`FormSelect`. Removes ~300 lines of inline boilerplate. Eliminates hardcoded `#2563eb` hex focus colors — now uses design token focus ring.

### New files
- `src/lib/hooks/use-dialog-manager.ts` — Generic typed dialog state hook

### Modified files
- `compliance.tsx` — 4 useState → useDialogManager
- `incident-response-page.tsx` — 3 useState → useDialogManager  
- `deployment.tsx` — 2 useState → useDialogManager
- `create-device-modal.tsx` — Inline fields → FormField/FormInput/FormSelect
- `invite-user-modal.tsx` — Inline fields → FormField/FormInput/FormSelect

**Net: +219 / -327 lines** (108 lines removed)

Closes #285, closes #302

## Test plan
- [x] `npm run build` passes
- [x] 503/503 unit tests pass
- [ ] Manual: Compliance modals open one at a time (no overlap)
- [ ] Manual: Incident create/isolate/release dialogs mutually exclusive
- [ ] Manual: Device create + user invite forms render, validate, and submit correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)