### PR TITLE
Wire download-links tab into Deployment + kanban drag-and-drop

### DIFF
--- a/src/app/components/account-service.tsx
+++ b/src/app/components/account-service.tsx
@@ -2,6 +2,8 @@ import { useState } from "react";
 import { Plus, Calendar, LayoutGrid } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
+import { DndProvider } from "react-dnd";
+import { HTML5Backend } from "react-dnd-html5-backend";
 import { useAuth } from "@/lib/use-auth";
 import { getPrimaryRole, canPerformAction } from "@/lib/rbac";
 import { useServiceOrders } from "@/lib/hooks/use-service-orders";
@@ -126,16 +128,18 @@ export function AccountService() {
 
       {/* Content */}
       {view === "kanban" ? (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-          {COLUMN_ORDER.map((status) => (
-            <KanbanColumn
-              key={status}
-              status={status}
-              orders={ordersByStatus[status]}
-              onMove={handleMove}
-            />
-          ))}
-        </div>
+        <DndProvider backend={HTML5Backend}>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+            {COLUMN_ORDER.map((status) => (
+              <KanbanColumn
+                key={status}
+                status={status}
+                orders={ordersByStatus[status]}
+                onMove={handleMove}
+              />
+            ))}
+          </div>
+        </DndProvider>
       ) : (
         <CalendarView orders={filteredOrders} />
       )}

--- a/src/app/components/deployment.tsx
+++ b/src/app/components/deployment.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback } from "react";
-import { Upload, Package, Shield, Clock, Bug, FileText, Plus } from "lucide-react";
+import { Upload, Package, Shield, Clock, Bug, FileText, Plus, Link2 } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { useAuth } from "@/lib/use-auth";
@@ -15,6 +15,7 @@ import { FirmwareList } from "./deployment/firmware-list";
 import { VulnerabilityTab } from "./deployment/vulnerability-tab";
 import { ReportsTab } from "./deployment/reports-tab";
 import { AuditLogTab } from "./deployment/audit-log-tab";
+import { DownloadLinksTab } from "./firmware/download-links-tab";
 import { useAuditLog } from "@/lib/hooks/use-audit-log";
 import { useFirmwareDeployment } from "@/lib/hooks/use-firmware-deployment";
 import { useVulnerabilityTracker } from "@/lib/hooks/use-vulnerability-tracker";
@@ -140,6 +141,7 @@ export function Deployment() {
   const TABS: { id: Tab; label: string; icon: typeof Shield; visible: boolean }[] = [
     { id: "firmware", label: "Firmware", icon: Package, visible: true },
     { id: "vulnerabilities", label: "Vulnerabilities", icon: Bug, visible: true },
+    { id: "download-links", label: "Download Links", icon: Link2, visible: canManage },
     { id: "reports", label: "Regulatory Reports", icon: FileText, visible: true },
     { id: "audit", label: "Audit Log", icon: Clock, visible: canViewAudit },
   ];
@@ -228,6 +230,9 @@ export function Deployment() {
           handleRemediationChange={vulnTracker.handleRemediationChange}
         />
       )}
+
+      {/* ===== Download Links Tab -- Epic 26 (Story 26.7) ===== */}
+      {activeTab === "download-links" && canManage && <DownloadLinksTab />}
 
       {/* ===== Regulatory Reports Tab -- Story 11.6 ===== */}
       {activeTab === "reports" && (

--- a/src/app/components/deployment/deployment-types.ts
+++ b/src/app/components/deployment/deployment-types.ts
@@ -2,7 +2,7 @@
 // Types
 // =============================================================================
 
-export type Tab = "firmware" | "vulnerabilities" | "reports" | "audit";
+export type Tab = "firmware" | "vulnerabilities" | "download-links" | "reports" | "audit";
 export type FirmwareStage = "Uploaded" | "Testing" | "Approved" | "Deprecated";
 export type FirmwareStatus = "Active" | "Deprecated" | "Pending";
 export type VulnSeverity = "Critical" | "High" | "Medium" | "Low";

--- a/src/app/components/service-orders/service-order-kanban.tsx
+++ b/src/app/components/service-orders/service-order-kanban.tsx
@@ -1,5 +1,6 @@
-import { memo } from "react";
-import { Clock, MapPin, ArrowRight, CheckCircle } from "lucide-react";
+import { memo, useRef } from "react";
+import { Clock, MapPin, ArrowRight, CheckCircle, GripVertical } from "lucide-react";
+import { useDrag, useDrop } from "react-dnd";
 import { cn } from "@/lib/utils";
 import type {
   ServiceOrder,
@@ -8,6 +9,8 @@ import type {
   ServiceType,
 } from "@/lib/mock-data/service-order-data";
 import { STATUS_LABELS } from "@/lib/mock-data/service-order-data";
+
+const DRAG_TYPE = "SERVICE_ORDER";
 
 /* ─── Constants ───────────────────────────────────────────────────── */
 
@@ -81,11 +84,28 @@ const KanbanCard = memo(function KanbanCard({
   order: ServiceOrder;
   onMove: (id: string, newStatus: Status) => void;
 }) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [{ isDragging }, drag] = useDrag({
+    type: DRAG_TYPE,
+    item: { id: order.id, status: order.status },
+    collect: (monitor) => ({ isDragging: monitor.isDragging() }),
+  });
+  drag(ref);
+
   return (
-    <div className="rounded border border-border bg-card p-3 space-y-2 hover:border-accent-text/40 transition-colors duration-150">
-      {/* Top row: ID + Priority */}
+    <div
+      ref={ref}
+      className={cn(
+        "rounded border border-border bg-card p-3 space-y-2 hover:border-accent-text/40 transition-colors duration-150 cursor-grab active:cursor-grabbing",
+        isDragging && "opacity-40 ring-2 ring-accent-text/30",
+      )}
+    >
+      {/* Top row: drag handle + ID + Priority */}
       <div className="flex items-center justify-between">
-        <span className="text-[12px] font-mono text-muted-foreground">{order.id}</span>
+        <div className="flex items-center gap-1">
+          <GripVertical className="h-3 w-3 text-muted-foreground/50" aria-hidden="true" />
+          <span className="text-[12px] font-mono text-muted-foreground">{order.id}</span>
+        </div>
         <PriorityBadge priority={order.priority} />
       </div>
 
@@ -151,12 +171,35 @@ export function KanbanColumn({
   orders: ServiceOrder[];
   onMove: (id: string, newStatus: Status) => void;
 }) {
+  const dropRef = useRef<HTMLDivElement>(null);
+  const [{ isOver, canDrop }, drop] = useDrop({
+    accept: DRAG_TYPE,
+    drop: (item: { id: string; status: Status }) => {
+      if (item.status !== status) {
+        onMove(item.id, status);
+      }
+    },
+    canDrop: (item: { id: string; status: Status }) => item.status !== status,
+    collect: (monitor) => ({
+      isOver: monitor.isOver(),
+      canDrop: monitor.canDrop(),
+    }),
+  });
+  drop(dropRef);
+
   const sorted = [...orders].sort(
     (a, b) => new Date(a.scheduledDate).getTime() - new Date(b.scheduledDate).getTime(),
   );
 
   return (
-    <div className="flex flex-col rounded border border-border bg-muted min-h-[300px]">
+    <div
+      ref={dropRef}
+      className={cn(
+        "flex flex-col rounded border border-border bg-muted min-h-[300px] transition-colors duration-150",
+        isOver && canDrop && "border-accent-text bg-accent/5",
+        isOver && !canDrop && "border-muted-foreground/30",
+      )}
+    >
       {/* Column header */}
       <div className="flex items-center justify-between border-b border-border px-3 py-2.5">
         <h3 className="text-sm font-bold text-foreground">{STATUS_LABELS[status]}</h3>


### PR DESCRIPTION
## Summary

Two user-facing gaps fixed — no new complexity, just wiring existing code:

- **Download Links tab** — The entire Epic 26 secure firmware distribution UI (download-links-tab, generate-link modal, bulk-generate modal, download-history panel) was built but never mounted in any page. Now accessible as a "Download Links" tab in the Deployment page, visible to Admin/Manager roles.
- **Kanban drag-and-drop** — `react-dnd` was installed but never imported. Service order kanban cards are now draggable between Scheduled/InProgress/Completed columns using HTML5 backend. Visual feedback: grip handle, drag opacity, column highlight on hover. Button transitions still work alongside drag.

### Modified files
- `deployment.tsx` — Import + render DownloadLinksTab, add tab definition
- `deployment-types.ts` — Add `"download-links"` to Tab union
- `service-order-kanban.tsx` — Add useDrag to KanbanCard, useDrop to KanbanColumn, drag handle icon
- `account-service.tsx` — Wrap kanban grid with DndProvider

## Test plan
- [x] `npm run build` passes
- [x] 503/503 unit tests pass
- [ ] Manual: Navigate to Deployment → "Download Links" tab visible for Admin/Manager
- [ ] Manual: Generate single link, bulk generate links, copy URL
- [ ] Manual: Drag a service order card from Scheduled → InProgress, verify toast + state change
- [ ] Manual: Drag to same column — no action (canDrop prevents it)
- [ ] Manual: Button transitions (Start/Complete) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)