### PR TITLE
Fix: remove language dropdown, fix health + risk distribution charts

### DIFF
--- a/src/app/components/digital-twin/fleet-health-summary.tsx
+++ b/src/app/components/digital-twin/fleet-health-summary.tsx
@@ -66,45 +66,37 @@ export function FleetHealthSummary({ twins }: { twins: DigitalTwin[] }) {
         <p className="text-[12px] font-semibold uppercase text-muted-foreground mb-2">
           Health Distribution
         </p>
-        <div className="flex items-end gap-3 h-[48px]">
-          <div className="flex flex-col items-center gap-1 flex-1">
-            <div
-              className="w-full rounded-t"
-              style={{
-                height: `${(critical / maxBucket) * 40}px`,
-                backgroundColor: "#ef4444",
-                minHeight: critical > 0 ? 4 : 0,
-              }}
-            />
-            <span className="text-[12px] text-muted-foreground">Crit</span>
-            <span className="text-[14px] font-bold tabular-nums text-foreground/80">
-              {critical}
-            </span>
-          </div>
-          <div className="flex flex-col items-center gap-1 flex-1">
-            <div
-              className="w-full rounded-t"
-              style={{
-                height: `${(warning / maxBucket) * 40}px`,
-                backgroundColor: "#f59e0b",
-                minHeight: warning > 0 ? 4 : 0,
-              }}
-            />
-            <span className="text-[12px] text-muted-foreground">Warn</span>
-            <span className="text-[14px] font-bold tabular-nums text-foreground/80">{warning}</span>
-          </div>
-          <div className="flex flex-col items-center gap-1 flex-1">
-            <div
-              className="w-full rounded-t"
-              style={{
-                height: `${(healthy / maxBucket) * 40}px`,
-                backgroundColor: "#10b981",
-                minHeight: healthy > 0 ? 4 : 0,
-              }}
-            />
-            <span className="text-[12px] text-muted-foreground">OK</span>
-            <span className="text-[14px] font-bold tabular-nums text-foreground/80">{healthy}</span>
-          </div>
+        {/* Bar area — fixed height with bottom-aligned bars */}
+        <div className="flex items-end gap-3 h-[44px] mb-1.5">
+          {[
+            { value: critical, color: "#ef4444" },
+            { value: warning, color: "#f59e0b" },
+            { value: healthy, color: "#10b981" },
+          ].map(({ value, color }) => (
+            <div key={color} className="flex-1">
+              <div
+                className="w-full rounded-t"
+                style={{
+                  height: `${maxBucket > 0 ? (value / maxBucket) * 40 : 0}px`,
+                  backgroundColor: color,
+                  minHeight: value > 0 ? 4 : 0,
+                }}
+              />
+            </div>
+          ))}
+        </div>
+        {/* Labels — separate row for consistent alignment */}
+        <div className="flex gap-3">
+          {[
+            { label: "Crit", value: critical },
+            { label: "Warn", value: warning },
+            { label: "OK", value: healthy },
+          ].map(({ label, value }) => (
+            <div key={label} className="flex-1 text-center">
+              <span className="text-[12px] text-muted-foreground block">{label}</span>
+              <span className="text-[14px] font-bold tabular-nums text-foreground/80">{value}</span>
+            </div>
+          ))}
         </div>
       </div>
 

--- a/src/app/components/layouts/sidebar.tsx
+++ b/src/app/components/layouts/sidebar.tsx
@@ -22,7 +22,6 @@ import { cn } from "@/lib/utils";
 import { useAuth } from "@/lib/use-auth";
 import { getPrimaryRole, canAccessPage } from "@/lib/rbac";
 import { AppVersionBadge } from "../app-version-badge";
-import { LocaleSwitcher } from "../locale-switcher";
 
 interface NavItem {
   labelKey: string;
@@ -303,11 +302,6 @@ export function Sidebar({ collapsed, onToggle }: SidebarProps) {
             </button>
           </>
         )}
-      </div>
-
-      {/* Locale switcher */}
-      <div className={cn("border-t border-border/40 px-3 py-2", collapsed ? "px-2" : "")}>
-        <LocaleSwitcher compact={collapsed} />
       </div>
 
       {/* App version */}

--- a/src/app/components/telemetry/telemetry-heatmap-page.tsx
+++ b/src/app/components/telemetry/telemetry-heatmap-page.tsx
@@ -328,39 +328,37 @@ function RiskDistributionChart() {
     { label: "Critical (0-30)", count: 63, pct: 5, color: "#ef4444" },
   ];
 
-  const barWidth = 680;
-  const barHeight = 28;
-
-  let offsetX = 0;
+  // Pre-compute offsets (no mutable variable in render)
+  const barWidth = 100; // percentage-based for responsiveness
+  const offsets = segments.reduce<number[]>((acc, _seg, i) => {
+    acc.push(i === 0 ? 0 : acc[i - 1]! + segments[i - 1]!.pct);
+    return acc;
+  }, []);
 
   return (
     <div>
-      {/* Stacked bar */}
+      {/* Stacked bar — percentage-based viewBox for consistent sizing */}
       <svg
-        viewBox={`0 0 ${barWidth} ${barHeight}`}
-        className="w-full h-auto rounded-lg overflow-hidden"
+        viewBox="0 0 100 6"
+        preserveAspectRatio="none"
+        className="w-full h-7 rounded-lg overflow-hidden"
+        role="img"
+        aria-label="Fleet risk distribution bar chart"
       >
-        {segments.map((seg) => {
-          const w = (seg.pct / 100) * barWidth;
-          const x = offsetX;
-          offsetX += w;
-          return (
-            <rect
-              key={seg.label}
-              x={x}
-              y={0}
-              width={w}
-              height={barHeight}
-              fill={seg.color}
-              rx={x === 0 ? 6 : 0}
-              ry={x === 0 ? 6 : 0}
-            />
-          );
-        })}
+        {segments.map((seg, i) => (
+          <rect
+            key={seg.label}
+            x={offsets[i]}
+            y={0}
+            width={(seg.pct / 100) * barWidth}
+            height={6}
+            fill={seg.color}
+          />
+        ))}
       </svg>
 
-      {/* Legend */}
-      <div className="mt-3 grid grid-cols-5 gap-3">
+      {/* Legend — responsive grid */}
+      <div className="mt-3 grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
         {segments.map((seg) => (
           <div key={seg.label} className="flex items-center gap-2">
             <span


### PR DESCRIPTION
## Summary

Three UI fixes:

1. **Remove language dropdown from sidebar** — LocaleSwitcher removed from sidebar. Not needed for single-locale enterprise deployment.
2. **Fix digital twin health distribution chart** — Separated bar area from labels into distinct rows. Bars now bottom-align cleanly regardless of value.
3. **Fix telemetry fleet risk distribution chart** — Replaced mutable offsetX with pre-computed offsets, percentage-based viewBox for consistent sizing, responsive legend grid (2→3→5 cols), symmetric rounded corners.

### Modified files
- `sidebar.tsx` — Remove LocaleSwitcher import + render
- `fleet-health-summary.tsx` — Restructure bar chart layout
- `telemetry-heatmap-page.tsx` — Rewrite RiskDistributionChart

## Test plan
- [x] Build passes
- [x] All tests pass
- [ ] Manual: Sidebar — no language dropdown visible
- [ ] Manual: Digital Twin → health distribution bars aligned at bottom
- [ ] Manual: Telemetry → fleet risk bar fills full width, legend wraps on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)