### PR TITLE
[Story 22.6] Connect hlm-api.ts → api-client.ts → provider pipeline

### DIFF
--- a/src/__tests__/lib/hlm-api.test.ts
+++ b/src/__tests__/lib/hlm-api.test.ts
@@ -1,4 +1,6 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
+import { setApiProvider } from "@/lib/providers/registry";
+import { createMockApiProvider } from "@/lib/providers/mock/mock-api-provider";
 import {
   getDefaultHeaders,
   listDevices,
@@ -40,6 +42,11 @@ import {
 } from "@/lib/hlm-api";
 import { APP_BUILD_INFO } from "@/lib/app-version";
 import { FailureType } from "@/lib/types";
+
+// Wire mock provider so hlm-api facade functions can delegate
+beforeAll(() => {
+  setApiProvider(createMockApiProvider());
+});
 
 // =============================================================================
 // getDefaultHeaders

--- a/src/lib/hlm-api.ts
+++ b/src/lib/hlm-api.ts
@@ -1,8 +1,12 @@
 /**
- * IMS Gen 2 — HLM API Client (Stub)
+ * IMS Gen 2 — HLM API Client (Facade)
  *
- * All methods return empty/mock data and log a warning.
- * Replace with real AppSync/GraphQL calls in production.
+ * Thin delegation layer: every function forwards to the active IApiProvider
+ * registered by ProviderRegistry. The provider is resolved at call time via
+ * the module-level singleton in registry.tsx.
+ *
+ * Components import from this file — the underlying provider (mock, Amplify,
+ * Terraform, CDK) is transparent to callers.
  */
 
 import type {
@@ -39,11 +43,7 @@ import type {
 } from "./opensearch-types";
 
 import { APP_BUILD_INFO } from "./app-version";
-import {
-  handleMutationResult,
-  handleBooleanMutationResult,
-  type MutationResult,
-} from "./api-error-handler";
+import { getApiProvider } from "./providers/registry";
 
 // Re-export for consumers that need to catch specific errors
 export { ApiMutationError } from "./api-error-handler";
@@ -60,109 +60,81 @@ export function getDefaultHeaders(): Record<string, string> {
   };
 }
 
-function stub<T>(name: string, fallback: T): T {
-  // Structured log context includes app version for traceability
-  const ctx = { source: "hlm-api", method: name, version: APP_BUILD_INFO.full };
-  const logger = (globalThis as Record<string, unknown>)["structuredLog"];
-  if (typeof logger === "function") {
-    (logger as (level: string, meta: Record<string, string>) => void)("warn", {
-      ...ctx,
-      message: `${name}() — returning mock data`,
-    });
-  }
-  return fallback;
-}
-
-const emptyPage = <T>(): PaginatedResponse<T> => ({
-  items: [],
-  total: 0,
-  page: 1,
-  pageSize: 25,
-  hasMore: false,
-});
-
-const emptySearch = <T>(): SearchResult<T> => ({
-  hits: [],
-  total: 0,
-  took: 0,
-  maxScore: 0,
-});
-
 // =============================================================================
-// Queries (13)
+// Queries
 // =============================================================================
 
 export async function listDevices(
-  _page?: number,
-  _pageSize?: number,
-  _filters?: Record<string, string>,
+  page?: number,
+  pageSize?: number,
+  filters?: Record<string, string>,
 ): Promise<PaginatedResponse<Device>> {
-  return stub("listDevices", emptyPage<Device>());
+  return getApiProvider().listDevices(page, pageSize, filters);
 }
 
-export async function getDevice(_id: string): Promise<Device | null> {
-  return stub("getDevice", null);
+export async function getDevice(id: string): Promise<Device | null> {
+  return getApiProvider().getDevice(id);
 }
 
-export async function searchDevices(_query: string): Promise<SearchResult<Device>> {
-  return stub("searchDevices", emptySearch<Device>());
+export async function searchDevices(query: string): Promise<SearchResult<Device>> {
+  return getApiProvider().searchDevices(query);
 }
 
 export async function listFirmware(
-  _page?: number,
-  _pageSize?: number,
+  page?: number,
+  pageSize?: number,
 ): Promise<PaginatedResponse<Firmware>> {
-  return stub("listFirmware", emptyPage<Firmware>());
+  return getApiProvider().listFirmware(page, pageSize);
 }
 
-export async function getFirmware(_id: string): Promise<Firmware | null> {
-  return stub("getFirmware", null);
+export async function getFirmware(id: string): Promise<Firmware | null> {
+  return getApiProvider().getFirmware(id);
 }
 
 export async function listServiceOrders(
-  _page?: number,
-  _pageSize?: number,
-  _status?: string,
+  page?: number,
+  pageSize?: number,
+  status?: string,
 ): Promise<PaginatedResponse<ServiceOrder>> {
-  return stub("listServiceOrders", emptyPage<ServiceOrder>());
+  return getApiProvider().listServiceOrders(page, pageSize, status);
 }
 
 export async function listCompliance(
-  _status?: string,
-  _certType?: string,
+  status?: string,
+  certType?: string,
 ): Promise<PaginatedResponse<Compliance>> {
-  return stub("listCompliance", emptyPage<Compliance>());
+  return getApiProvider().listCompliance(status, certType);
 }
 
 export async function listVulnerabilities(
-  _severity?: string,
+  severity?: string,
 ): Promise<PaginatedResponse<Vulnerability>> {
-  return stub("listVulnerabilities", emptyPage<Vulnerability>());
+  return getApiProvider().listVulnerabilities(severity);
 }
 
 export async function listAuditLogs(
-  _startDate: string,
-  _endDate: string,
-  _limit?: number,
-  _nextToken?: string,
+  startDate: string,
+  endDate: string,
+  limit?: number,
+  nextToken?: string,
 ): Promise<PaginatedResponse<AuditLog>> {
-  return stub("listAuditLogs", emptyPage<AuditLog>());
+  return getApiProvider().listAuditLogs(startDate, endDate, limit, nextToken);
 }
 
-export async function getAuditLogsByUser(_userId: string): Promise<AuditLog[]> {
-  return stub("getAuditLogsByUser", []);
+export async function getAuditLogsByUser(userId: string): Promise<AuditLog[]> {
+  return getApiProvider().getAuditLogsByUser(userId);
 }
 
-export async function getCustomer(_id: string): Promise<Customer | null> {
-  return stub("getCustomer", null);
+export async function getCustomer(id: string): Promise<Customer | null> {
+  return getApiProvider().getCustomer(id);
 }
 
 export async function listNotifications(): Promise<Notification[]> {
-  return stub("listNotifications", []);
+  return getApiProvider().listNotifications();
 }
 
 export async function getDeviceAggregations(): Promise<AggregationResult[]> {
-  return stub("getDeviceAggregations", []);
+  return getApiProvider().getDeviceAggregations();
 }
 
 export async function getDashboardMetrics(): Promise<{
@@ -172,57 +144,38 @@ export async function getDashboardMetrics(): Promise<{
   pendingApprovals: number;
   healthScore: number;
 }> {
-  return stub("getDashboardMetrics", {
-    totalDevices: 0,
-    onlineDevices: 0,
-    activeDeployments: 0,
-    pendingApprovals: 0,
-    healthScore: 0,
-  });
+  return getApiProvider().getDashboardMetrics();
 }
 
 // =============================================================================
-// Mutations (6)
-//
-// Each mutation processes its result through handleMutationResult /
-// handleBooleanMutationResult so that GraphQL errors, authorization
-// failures, and unexpected null responses surface as toast notifications
-// and thrown ApiMutationError instances. Callers MUST wrap calls in
-// try/catch to keep modals open on failure.
+// Mutations
 // =============================================================================
 
-export async function createServiceOrder(_input: Partial<ServiceOrder>): Promise<ServiceOrder> {
-  // TODO: replace stub with real GraphQL call that returns MutationResult<ServiceOrder>
-  const raw: MutationResult<ServiceOrder> = { data: stub("createServiceOrder", null) };
-  return handleMutationResult(raw, "createServiceOrder");
+export async function createServiceOrder(input: Partial<ServiceOrder>): Promise<ServiceOrder> {
+  return getApiProvider().createServiceOrder(input);
 }
 
 export async function updateServiceOrder(
-  _id: string,
-  _input: Partial<ServiceOrder>,
+  id: string,
+  input: Partial<ServiceOrder>,
 ): Promise<ServiceOrder> {
-  const raw: MutationResult<ServiceOrder> = { data: stub("updateServiceOrder", null) };
-  return handleMutationResult(raw, "updateServiceOrder");
+  return getApiProvider().updateServiceOrder(id, input);
 }
 
-export async function uploadFirmware(_input: Partial<Firmware>): Promise<Firmware> {
-  const raw: MutationResult<Firmware> = { data: stub("uploadFirmware", null) };
-  return handleMutationResult(raw, "uploadFirmware");
+export async function uploadFirmware(input: Partial<Firmware>): Promise<Firmware> {
+  return getApiProvider().uploadFirmware(input);
 }
 
-export async function approveFirmware(_id: string, _stage: string): Promise<Firmware> {
-  const raw: MutationResult<Firmware> = { data: stub("approveFirmware", null) };
-  return handleMutationResult(raw, "approveFirmware");
+export async function approveFirmware(id: string, stage: string): Promise<Firmware> {
+  return getApiProvider().approveFirmware(id, stage);
 }
 
-export async function submitComplianceReview(_id: string): Promise<Compliance> {
-  const raw: MutationResult<Compliance> = { data: stub("submitComplianceReview", null) };
-  return handleMutationResult(raw, "submitComplianceReview");
+export async function submitComplianceReview(id: string): Promise<Compliance> {
+  return getApiProvider().submitComplianceReview(id);
 }
 
-export async function acknowledgeNotification(_id: string): Promise<boolean> {
-  const raw: MutationResult<boolean> = { data: stub("acknowledgeNotification", true) };
-  return handleBooleanMutationResult(raw, "acknowledgeNotification");
+export async function acknowledgeNotification(id: string): Promise<boolean> {
+  return getApiProvider().acknowledgeNotification(id);
 }
 
 // =============================================================================
@@ -230,56 +183,52 @@ export async function acknowledgeNotification(_id: string): Promise<boolean> {
 // =============================================================================
 
 export async function getDeviceTelemetry(
-  _deviceId: string,
-  _startDate: string,
-  _endDate: string,
+  deviceId: string,
+  startDate: string,
+  endDate: string,
 ): Promise<TelemetryReading[]> {
-  return stub("getDeviceTelemetry", []);
+  return getApiProvider().getDeviceTelemetry(deviceId, startDate, endDate);
 }
 
 export async function getHeatmapAggregation(
-  _bounds?: { northLat: number; southLat: number; eastLng: number; westLng: number },
-  _precision?: number,
-  _riskThreshold?: number,
+  bounds?: { northLat: number; southLat: number; eastLng: number; westLng: number },
+  precision?: number,
+  riskThreshold?: number,
 ): Promise<HeatmapAggregation> {
-  return stub("getHeatmapAggregation", { cells: [], totalDevices: 0 });
+  return getApiProvider().getHeatmapAggregation(bounds, precision, riskThreshold);
 }
 
 export async function getBlastRadius(
-  _lat: number,
-  _lng: number,
-  _radiusKm: number,
-  _includeOffline?: boolean,
+  lat: number,
+  lng: number,
+  radiusKm: number,
+  includeOffline?: boolean,
 ): Promise<BlastRadiusResult | null> {
-  return stub("getBlastRadius", null);
+  return getApiProvider().getBlastRadius(lat, lng, radiusKm, includeOffline);
 }
 
-export async function getBlastRadiusHistory(_deviceId?: string): Promise<BlastRadiusResult[]> {
-  return stub("getBlastRadiusHistory", []);
+export async function getBlastRadiusHistory(deviceId?: string): Promise<BlastRadiusResult[]> {
+  return getApiProvider().getBlastRadiusHistory(deviceId);
 }
 
 export async function ingestTelemetry(
-  _deviceId: string,
-  _metrics: Partial<TelemetryReading>,
+  deviceId: string,
+  metrics: Partial<TelemetryReading>,
 ): Promise<TelemetryReading | null> {
-  return stub("ingestTelemetry", null);
+  return getApiProvider().ingestTelemetry(deviceId, metrics);
 }
 
 export async function runBlastRadiusSimulation(
-  _deviceId: string,
-  _radiusKm: number,
-  _failureType: FailureType,
-  _severity?: number,
+  deviceId: string,
+  radiusKm: number,
+  failureType: FailureType,
+  severity?: number,
 ): Promise<BlastRadiusResult | null> {
-  return stub("runBlastRadiusSimulation", null);
+  return getApiProvider().runBlastRadiusSimulation(deviceId, radiusKm, failureType, severity);
 }
 
 export async function getTelemetryPipelineStatus(): Promise<TelemetryPipelineStatus> {
-  return stub("getTelemetryPipelineStatus", {
-    recordsIngestedLastHour: 0,
-    health: "healthy" as const,
-    lastSuccessfulIngestion: new Date().toISOString(),
-  });
+  return getApiProvider().getTelemetryPipelineStatus();
 }
 
 // =============================================================================
@@ -288,73 +237,68 @@ export async function getTelemetryPipelineStatus(): Promise<TelemetryPipelineSta
 
 /** Story 18.2: Global search across all entity types with fuzzy matching */
 export async function searchGlobal(
-  _query: string,
-  _entityTypes?: string[],
-  _limit?: number,
+  query: string,
+  entityTypes?: string[],
+  limit?: number,
 ): Promise<GlobalSearchResponse> {
-  return stub("searchGlobal", { total: 0, results: [] });
+  return getApiProvider().searchGlobal(query, entityTypes, limit);
 }
 
 /** Story 18.3: Advanced device search with combined text + filter criteria */
 export async function searchDevicesAdvanced(
-  _query: string,
-  _filters?: DeviceSearchFilters,
+  query: string,
+  filters?: DeviceSearchFilters,
 ): Promise<SearchResult<Device>> {
-  return stub("searchDevicesAdvanced", emptySearch<Device>());
+  return getApiProvider().searchDevicesAdvanced(query, filters);
 }
 
 /** Story 18.4: Vulnerability search by CVE ID, component, or description */
 export async function searchVulnerabilities(
-  _query: string,
-  _severity?: string,
+  query: string,
+  severity?: string,
 ): Promise<SearchResult<Vulnerability>> {
-  return stub("searchVulnerabilities", emptySearch<Vulnerability>());
+  return getApiProvider().searchVulnerabilities(query, severity);
 }
 
 /** Story 18.5: Server-side aggregations for analytics charts */
 export async function getAggregation(
-  _metric: AggregationMetric,
-  _timeRange?: TimeRange,
+  metric: AggregationMetric,
+  timeRange?: TimeRange,
 ): Promise<AggregationResponse> {
-  return stub("getAggregation", { metric: _metric, data: {} });
+  return getApiProvider().getAggregation(metric, timeRange);
 }
 
 /** Story 18.6: Geo bounding box query — devices in map viewport */
 export async function searchDevicesByBounds(
-  _bounds: GeoBoundingBox,
-  _status?: string,
+  bounds: GeoBoundingBox,
+  status?: string,
 ): Promise<GeoDeviceResult[]> {
-  return stub("searchDevicesByBounds", []);
+  return getApiProvider().searchDevicesByBounds(bounds, status);
 }
 
 /** Story 18.6: Geo distance query — devices within radius of a point */
 export async function searchDevicesByDistance(
-  _params: GeoDistanceQuery,
+  params: GeoDistanceQuery,
 ): Promise<GeoDeviceResult[]> {
-  return stub("searchDevicesByDistance", []);
+  return getApiProvider().searchDevicesByDistance(params);
 }
 
 /** Story 18.6: Geo clustering — geohash_grid aggregation for map clusters */
 export async function getDeviceGeoClusters(
-  _bounds?: GeoBoundingBox,
-  _precision?: number,
+  bounds?: GeoBoundingBox,
+  precision?: number,
 ): Promise<GeoCluster[]> {
-  return stub("getDeviceGeoClusters", []);
+  return getApiProvider().getDeviceGeoClusters(bounds, precision);
 }
 
 /** Story 18.1: OSIS pipeline health status */
 export async function getOsisPipelineHealth(): Promise<PipelineHealthStatus> {
-  return stub("getOsisPipelineHealth", {
-    state: "Running" as const,
-    recordsSyncedLastHour: 0,
-    currentLagSeconds: 0,
-    lastUpdated: new Date().toISOString(),
-  });
+  return getApiProvider().getOsisPipelineHealth();
 }
 
 /** Story 18.1: Trigger full re-index from DynamoDB (Admin only) */
 export async function triggerReindex(): Promise<boolean> {
-  return stub("triggerReindex", true);
+  return getApiProvider().triggerReindex();
 }
 
 // Re-export OpenSearch types for convenience

--- a/src/lib/providers/mock/mock-api-provider.ts
+++ b/src/lib/providers/mock/mock-api-provider.ts
@@ -1,54 +1,301 @@
-import type { IApiProvider } from "../types";
-import * as hlmApi from "@/lib/hlm-api";
+import type { IApiProvider, DashboardMetrics, HeatmapBounds } from "../types";
+import type {
+  PaginatedResponse,
+  SearchResult,
+  Device,
+  Firmware,
+  ServiceOrder,
+  Compliance,
+  Vulnerability,
+  AuditLog,
+  Customer,
+  Notification,
+  AggregationResult,
+  TelemetryReading,
+  HeatmapAggregation,
+  BlastRadiusResult,
+  TelemetryPipelineStatus,
+  FailureType,
+} from "@/lib/types";
+import type {
+  GlobalSearchResponse,
+  DeviceSearchFilters,
+  AggregationMetric,
+  AggregationResponse,
+  TimeRange,
+  GeoBoundingBox,
+  GeoDistanceQuery,
+  GeoDeviceResult,
+  GeoCluster,
+  PipelineHealthStatus,
+} from "@/lib/opensearch-types";
+import {
+  handleMutationResult,
+  handleBooleanMutationResult,
+  type MutationResult,
+} from "@/lib/api-error-handler";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const emptyPage = <T>(): PaginatedResponse<T> => ({
+  items: [],
+  total: 0,
+  page: 1,
+  pageSize: 25,
+  hasMore: false,
+});
+
+const emptySearch = <T>(): SearchResult<T> => ({
+  hits: [],
+  total: 0,
+  took: 0,
+  maxScore: 0,
+});
 
 /**
- * Mock API Provider — wraps the existing hlm-api.ts stub functions
- * behind the IApiProvider interface. Pure delegation, no logic copied.
+ * Mock API Provider — self-contained mock implementations for all 35
+ * IApiProvider methods. Returns empty/zero-value data for queries and
+ * processes mutations through the standard error handler pipeline.
  */
 export function createMockApiProvider(): IApiProvider {
   return {
+    // =========================================================================
     // Queries
-    listDevices: hlmApi.listDevices,
-    getDevice: hlmApi.getDevice,
-    searchDevices: hlmApi.searchDevices,
-    listFirmware: hlmApi.listFirmware,
-    getFirmware: hlmApi.getFirmware,
-    listServiceOrders: hlmApi.listServiceOrders,
-    listCompliance: hlmApi.listCompliance,
-    listVulnerabilities: hlmApi.listVulnerabilities,
-    listAuditLogs: hlmApi.listAuditLogs,
-    getAuditLogsByUser: hlmApi.getAuditLogsByUser,
-    getCustomer: hlmApi.getCustomer,
-    listNotifications: hlmApi.listNotifications,
-    getDeviceAggregations: hlmApi.getDeviceAggregations,
-    getDashboardMetrics: hlmApi.getDashboardMetrics,
+    // =========================================================================
 
+    async listDevices(
+      _page?: number,
+      _pageSize?: number,
+      _filters?: Record<string, string>,
+    ): Promise<PaginatedResponse<Device>> {
+      return emptyPage<Device>();
+    },
+
+    async getDevice(_id: string): Promise<Device | null> {
+      return null;
+    },
+
+    async searchDevices(_query: string): Promise<SearchResult<Device>> {
+      return emptySearch<Device>();
+    },
+
+    async listFirmware(_page?: number, _pageSize?: number): Promise<PaginatedResponse<Firmware>> {
+      return emptyPage<Firmware>();
+    },
+
+    async getFirmware(_id: string): Promise<Firmware | null> {
+      return null;
+    },
+
+    async listServiceOrders(
+      _page?: number,
+      _pageSize?: number,
+      _status?: string,
+    ): Promise<PaginatedResponse<ServiceOrder>> {
+      return emptyPage<ServiceOrder>();
+    },
+
+    async listCompliance(
+      _status?: string,
+      _certType?: string,
+    ): Promise<PaginatedResponse<Compliance>> {
+      return emptyPage<Compliance>();
+    },
+
+    async listVulnerabilities(_severity?: string): Promise<PaginatedResponse<Vulnerability>> {
+      return emptyPage<Vulnerability>();
+    },
+
+    async listAuditLogs(
+      _startDate: string,
+      _endDate: string,
+      _limit?: number,
+      _nextToken?: string,
+    ): Promise<PaginatedResponse<AuditLog>> {
+      return emptyPage<AuditLog>();
+    },
+
+    async getAuditLogsByUser(_userId: string): Promise<AuditLog[]> {
+      return [];
+    },
+
+    async getCustomer(_id: string): Promise<Customer | null> {
+      return null;
+    },
+
+    async listNotifications(): Promise<Notification[]> {
+      return [];
+    },
+
+    async getDeviceAggregations(): Promise<AggregationResult[]> {
+      return [];
+    },
+
+    async getDashboardMetrics(): Promise<DashboardMetrics> {
+      return {
+        totalDevices: 0,
+        onlineDevices: 0,
+        activeDeployments: 0,
+        pendingApprovals: 0,
+        healthScore: 0,
+      };
+    },
+
+    // =========================================================================
     // Mutations
-    createServiceOrder: hlmApi.createServiceOrder,
-    updateServiceOrder: hlmApi.updateServiceOrder,
-    uploadFirmware: hlmApi.uploadFirmware,
-    approveFirmware: hlmApi.approveFirmware,
-    submitComplianceReview: hlmApi.submitComplianceReview,
-    acknowledgeNotification: hlmApi.acknowledgeNotification,
+    // =========================================================================
 
-    // Telemetry
-    getDeviceTelemetry: hlmApi.getDeviceTelemetry,
-    getHeatmapAggregation: hlmApi.getHeatmapAggregation,
-    getBlastRadius: hlmApi.getBlastRadius,
-    getBlastRadiusHistory: hlmApi.getBlastRadiusHistory,
-    ingestTelemetry: hlmApi.ingestTelemetry,
-    runBlastRadiusSimulation: hlmApi.runBlastRadiusSimulation,
-    getTelemetryPipelineStatus: hlmApi.getTelemetryPipelineStatus,
+    async createServiceOrder(_input: Partial<ServiceOrder>): Promise<ServiceOrder> {
+      const raw: MutationResult<ServiceOrder> = { data: null };
+      return handleMutationResult(raw, "createServiceOrder");
+    },
 
-    // OpenSearch
-    searchGlobal: hlmApi.searchGlobal,
-    searchDevicesAdvanced: hlmApi.searchDevicesAdvanced,
-    searchVulnerabilities: hlmApi.searchVulnerabilities,
-    getAggregation: hlmApi.getAggregation,
-    searchDevicesByBounds: hlmApi.searchDevicesByBounds,
-    searchDevicesByDistance: hlmApi.searchDevicesByDistance,
-    getDeviceGeoClusters: hlmApi.getDeviceGeoClusters,
-    getOsisPipelineHealth: hlmApi.getOsisPipelineHealth,
-    triggerReindex: hlmApi.triggerReindex,
+    async updateServiceOrder(_id: string, _input: Partial<ServiceOrder>): Promise<ServiceOrder> {
+      const raw: MutationResult<ServiceOrder> = { data: null };
+      return handleMutationResult(raw, "updateServiceOrder");
+    },
+
+    async uploadFirmware(_input: Partial<Firmware>): Promise<Firmware> {
+      const raw: MutationResult<Firmware> = { data: null };
+      return handleMutationResult(raw, "uploadFirmware");
+    },
+
+    async approveFirmware(_id: string, _stage: string): Promise<Firmware> {
+      const raw: MutationResult<Firmware> = { data: null };
+      return handleMutationResult(raw, "approveFirmware");
+    },
+
+    async submitComplianceReview(_id: string): Promise<Compliance> {
+      const raw: MutationResult<Compliance> = { data: null };
+      return handleMutationResult(raw, "submitComplianceReview");
+    },
+
+    async acknowledgeNotification(_id: string): Promise<boolean> {
+      const raw: MutationResult<boolean> = { data: true };
+      return handleBooleanMutationResult(raw, "acknowledgeNotification");
+    },
+
+    // =========================================================================
+    // Telemetry & Environmental Monitoring
+    // =========================================================================
+
+    async getDeviceTelemetry(
+      _deviceId: string,
+      _startDate: string,
+      _endDate: string,
+    ): Promise<TelemetryReading[]> {
+      return [];
+    },
+
+    async getHeatmapAggregation(
+      _bounds?: HeatmapBounds,
+      _precision?: number,
+      _riskThreshold?: number,
+    ): Promise<HeatmapAggregation> {
+      return { cells: [], totalDevices: 0 };
+    },
+
+    async getBlastRadius(
+      _lat: number,
+      _lng: number,
+      _radiusKm: number,
+      _includeOffline?: boolean,
+    ): Promise<BlastRadiusResult | null> {
+      return null;
+    },
+
+    async getBlastRadiusHistory(_deviceId?: string): Promise<BlastRadiusResult[]> {
+      return [];
+    },
+
+    async ingestTelemetry(
+      _deviceId: string,
+      _metrics: Partial<TelemetryReading>,
+    ): Promise<TelemetryReading | null> {
+      return null;
+    },
+
+    async runBlastRadiusSimulation(
+      _deviceId: string,
+      _radiusKm: number,
+      _failureType: FailureType,
+      _severity?: number,
+    ): Promise<BlastRadiusResult | null> {
+      return null;
+    },
+
+    async getTelemetryPipelineStatus(): Promise<TelemetryPipelineStatus> {
+      return {
+        recordsIngestedLastHour: 0,
+        health: "healthy" as const,
+        lastSuccessfulIngestion: new Date().toISOString(),
+      };
+    },
+
+    // =========================================================================
+    // OpenSearch — Global Search, Advanced Search, Aggregations, Geo
+    // =========================================================================
+
+    async searchGlobal(
+      _query: string,
+      _entityTypes?: string[],
+      _limit?: number,
+    ): Promise<GlobalSearchResponse> {
+      return { total: 0, results: [] };
+    },
+
+    async searchDevicesAdvanced(
+      _query: string,
+      _filters?: DeviceSearchFilters,
+    ): Promise<SearchResult<Device>> {
+      return emptySearch<Device>();
+    },
+
+    async searchVulnerabilities(
+      _query: string,
+      _severity?: string,
+    ): Promise<SearchResult<Vulnerability>> {
+      return emptySearch<Vulnerability>();
+    },
+
+    async getAggregation(
+      _metric: AggregationMetric,
+      _timeRange?: TimeRange,
+    ): Promise<AggregationResponse> {
+      return { metric: _metric, data: {} };
+    },
+
+    async searchDevicesByBounds(
+      _bounds: GeoBoundingBox,
+      _status?: string,
+    ): Promise<GeoDeviceResult[]> {
+      return [];
+    },
+
+    async searchDevicesByDistance(_params: GeoDistanceQuery): Promise<GeoDeviceResult[]> {
+      return [];
+    },
+
+    async getDeviceGeoClusters(
+      _bounds?: GeoBoundingBox,
+      _precision?: number,
+    ): Promise<GeoCluster[]> {
+      return [];
+    },
+
+    async getOsisPipelineHealth(): Promise<PipelineHealthStatus> {
+      return {
+        state: "Running" as const,
+        recordsSyncedLastHour: 0,
+        currentLagSeconds: 0,
+        lastUpdated: new Date().toISOString(),
+      };
+    },
+
+    async triggerReindex(): Promise<boolean> {
+      return true;
+    },
   };
 }

--- a/src/lib/providers/registry.tsx
+++ b/src/lib/providers/registry.tsx
@@ -16,6 +16,33 @@ const ReactQueryDevtools = lazy(() =>
 import type { IApiProvider, IStorageProvider } from "./types";
 
 // =============================================================================
+// Module-level singleton — non-React access to the API provider
+// =============================================================================
+
+let _apiProvider: IApiProvider | null = null;
+
+/**
+ * Set the active API provider instance. Called by ProviderRegistry during
+ * render so the singleton is available before any queryFn fires.
+ */
+export function setApiProvider(provider: IApiProvider): void {
+  _apiProvider = provider;
+}
+
+/**
+ * Get the active API provider for non-hook contexts (e.g. hlm-api.ts facade).
+ * Throws if called before ProviderRegistry has mounted.
+ */
+export function getApiProvider(): IApiProvider {
+  if (!_apiProvider) {
+    throw new Error(
+      "API provider not initialized. Ensure ProviderRegistry has mounted before calling API functions.",
+    );
+  }
+  return _apiProvider;
+}
+
+// =============================================================================
 // Context
 // =============================================================================
 
@@ -43,6 +70,10 @@ interface ProviderRegistryProps {
  * API and Storage are plain object instances provided via context.
  */
 export function ProviderRegistry({ api, storage, AuthProvider, children }: ProviderRegistryProps) {
+  // Sync the module-level singleton so hlm-api.ts facade can delegate
+  // to the active provider without needing React context.
+  setApiProvider(api);
+
   const registryValue = useMemo(() => ({ api, storage }), [api, storage]);
 
   return (


### PR DESCRIPTION
## Summary
- **hlm-api.ts** now delegates all 35 functions to the active `IApiProvider` via `getApiProvider()` singleton — `stub()` removed
- **mock-api-provider.ts** is self-contained with inline mock implementations — no circular dependency with hlm-api
- **registry.tsx** exports `setApiProvider()`/`getApiProvider()` module-level singleton, set during `ProviderRegistry` render

Closes #294

## Test plan
- [x] `npm run build` — TypeScript compiles, no errors
- [x] `npm test` — 503/503 tests pass, all 33 test files green
- [ ] `npm run dev` — app loads, mock data flows through provider pipeline
- [ ] Verify no circular dependency (mock-api-provider no longer imports hlm-api)

🤖 Generated with [Claude Code](https://claude.com/claude-code)