### PR TITLE
[Story 23.10] Extract named Props interfaces for 20+ components

### DIFF
--- a/src/app/components/analytics/ring-chart.tsx
+++ b/src/app/components/analytics/ring-chart.tsx
@@ -1,14 +1,12 @@
 import type { RingSegment } from "@/lib/mock-data/analytics-data";
 
-export function RingChart({
-  segments,
-  size = 160,
-  strokeWidth = 20,
-}: {
+interface RingChartProps {
   segments: RingSegment[];
   size?: number;
   strokeWidth?: number;
-}) {
+}
+
+export function RingChart({ segments, size = 160, strokeWidth = 20 }: RingChartProps) {
   const radius = (size - strokeWidth) / 2;
   const circumference = 2 * Math.PI * radius;
   const total = segments.reduce((sum, seg) => sum + seg.value, 0);

--- a/src/app/components/blast-radius/blast-radius-panel.tsx
+++ b/src/app/components/blast-radius/blast-radius-panel.tsx
@@ -116,17 +116,19 @@ function getStatusColor(status: DeviceStatus): string {
 // ---------------------------------------------------------------------------
 // BlastRadiusSummary
 // ---------------------------------------------------------------------------
+interface BlastRadiusSummaryProps {
+  affectedCount: number;
+  estimatedDowntime: number;
+  riskLevel: RiskLevel;
+  radiusKm: number;
+}
+
 function BlastRadiusSummary({
   affectedCount,
   estimatedDowntime,
   riskLevel,
   radiusKm,
-}: {
-  affectedCount: number;
-  estimatedDowntime: number;
-  riskLevel: RiskLevel;
-  radiusKm: number;
-}) {
+}: BlastRadiusSummaryProps) {
   return (
     <div className="rounded-xl border border-border/60 bg-muted p-4">
       <div className="flex items-center justify-between mb-3">
@@ -218,15 +220,13 @@ function BlastRadiusDeviceList({ devices }: { devices: BlastRadiusDevice[] }) {
 // ---------------------------------------------------------------------------
 // BlastRadiusOverlay (SVG circle for map integration)
 // ---------------------------------------------------------------------------
-export function BlastRadiusOverlay({
-  centerX,
-  centerY,
-  radius,
-}: {
+interface BlastRadiusOverlayProps {
   centerX: number;
   centerY: number;
   radius: number;
-}) {
+}
+
+export function BlastRadiusOverlay({ centerX, centerY, radius }: BlastRadiusOverlayProps) {
   return (
     <g>
       {/* Outer fill */}

--- a/src/app/components/compliance/compliance-modals.tsx
+++ b/src/app/components/compliance/compliance-modals.tsx
@@ -33,6 +33,15 @@ export function ModalOverlay({
 // Confirm Dialog
 // =============================================================================
 
+interface ConfirmDialogProps {
+  title: string;
+  message: string;
+  confirmLabel: string;
+  confirmClass: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
 export function ConfirmDialog({
   title,
   message,
@@ -40,14 +49,7 @@ export function ConfirmDialog({
   confirmClass,
   onConfirm,
   onCancel,
-}: {
-  title: string;
-  message: string;
-  confirmLabel: string;
-  confirmClass: string;
-  onConfirm: () => void;
-  onCancel: () => void;
-}) {
+}: ConfirmDialogProps) {
   return (
     <ModalOverlay onClose={onCancel}>
       <div className="w-full max-w-sm rounded-lg bg-card shadow-xl border border-border">

--- a/src/app/components/deployment/create-vulnerability-modal.tsx
+++ b/src/app/components/deployment/create-vulnerability-modal.tsx
@@ -7,15 +7,17 @@ import type { FirmwareEntry, VulnerabilityEntry, VulnSeverity } from "./deployme
 // Create Vulnerability Modal — Story 11.5
 // =============================================================================
 
+interface CreateVulnerabilityModalProps {
+  firmwareList: FirmwareEntry[];
+  onClose: () => void;
+  onSubmit: (data: Omit<VulnerabilityEntry, "id" | "resolvedDate">) => void;
+}
+
 export function CreateVulnerabilityModal({
   firmwareList,
   onClose,
   onSubmit,
-}: {
-  firmwareList: FirmwareEntry[];
-  onClose: () => void;
-  onSubmit: (data: Omit<VulnerabilityEntry, "id" | "resolvedDate">) => void;
-}) {
+}: CreateVulnerabilityModalProps) {
   const [cveId, setCveId] = useState("");
   const [severity, setSeverity] = useState<VulnSeverity | "">("");
   const [affectedComponent, setAffectedComponent] = useState("");

--- a/src/app/components/digital-twin/state-comparison-view.tsx
+++ b/src/app/components/digital-twin/state-comparison-view.tsx
@@ -3,15 +3,13 @@ import { cn } from "../../../lib/utils";
 import type { TwinStateSnapshot } from "./digital-twin-types";
 
 // Story 15.2 — State Comparison View
-export function StateComparisonView({
-  left,
-  right,
-  onClose,
-}: {
+interface StateComparisonViewProps {
   left: TwinStateSnapshot;
   right: TwinStateSnapshot;
   onClose: () => void;
-}) {
+}
+
+export function StateComparisonView({ left, right, onClose }: StateComparisonViewProps) {
   const fields: { label: string; getLeft: () => string; getRight: () => string }[] = [
     {
       label: "Firmware",

--- a/src/app/components/digital-twin/state-replay-timeline.tsx
+++ b/src/app/components/digital-twin/state-replay-timeline.tsx
@@ -2,17 +2,19 @@ import { cn } from "../../../lib/utils";
 import type { TwinStateSnapshot } from "./digital-twin-types";
 
 // Story 15.2 — State Replay Timeline
+interface StateReplayTimelineProps {
+  snapshots: TwinStateSnapshot[];
+  selectedIds: string[];
+  activeId: string | null;
+  onSelect: (id: string) => void;
+}
+
 export function StateReplayTimeline({
   snapshots,
   selectedIds,
   activeId,
   onSelect,
-}: {
-  snapshots: TwinStateSnapshot[];
-  selectedIds: string[];
-  activeId: string | null;
-  onSelect: (id: string) => void;
-}) {
+}: StateReplayTimelineProps) {
   return (
     <div className="relative px-4 py-3">
       {/* Timeline bar */}

--- a/src/app/components/geo-location/device-map-tooltip.tsx
+++ b/src/app/components/geo-location/device-map-tooltip.tsx
@@ -54,6 +54,15 @@ export function StatusBadge({ status }: { status: string }) {
 // DeviceTooltip
 // ---------------------------------------------------------------------------
 
+interface DeviceTooltipProps {
+  device: GeoDevice;
+  position: { x: number; y: number };
+  onClose: () => void;
+  onShowTrail: (device: GeoDevice) => void;
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  trailActive: boolean;
+}
+
 /** Tooltip card shown when a marker is clicked */
 export function DeviceTooltip({
   device,
@@ -62,14 +71,7 @@ export function DeviceTooltip({
   onShowTrail,
   containerRef,
   trailActive,
-}: {
-  device: GeoDevice;
-  position: { x: number; y: number };
-  onClose: () => void;
-  onShowTrail: (device: GeoDevice) => void;
-  containerRef: React.RefObject<HTMLDivElement | null>;
-  trailActive: boolean;
-}) {
+}: DeviceTooltipProps) {
   const tooltipRef = useRef<HTMLDivElement>(null);
   const [adjustedPos, setAdjustedPos] = useState(position);
 

--- a/src/app/components/geo-location/device-markers.tsx
+++ b/src/app/components/geo-location/device-markers.tsx
@@ -7,16 +7,14 @@ import type { GeoDevice } from "./geo-location-types";
 // ClusterMarker (Story 10.2)
 // ---------------------------------------------------------------------------
 
-/** Story 10.2: Cluster marker showing grouped device count */
-export function ClusterMarker({
-  cluster,
-  zoom,
-  onClick,
-}: {
+interface ClusterMarkerProps {
   cluster: DeviceCluster;
   zoom: number;
   onClick: (cluster: DeviceCluster, event: React.MouseEvent) => void;
-}) {
+}
+
+/** Story 10.2: Cluster marker showing grouped device count */
+export function ClusterMarker({ cluster, zoom, onClick }: ClusterMarkerProps) {
   const size = Math.min(16 + cluster.count * 2, 36) / Math.sqrt(zoom);
   const fontSize = Math.max(8, 11 / Math.sqrt(zoom));
 
@@ -59,15 +57,13 @@ export function ClusterMarker({
 // GeofenceOverlays (Story 10.4)
 // ---------------------------------------------------------------------------
 
-export function GeofenceOverlays({
-  geofences,
-  zoom,
-  geofenceCircleRadius,
-}: {
+interface GeofenceOverlaysProps {
   geofences: Geofence[];
   zoom: number;
   geofenceCircleRadius: (radiusKm: number) => number;
-}) {
+}
+
+export function GeofenceOverlays({ geofences, zoom, geofenceCircleRadius }: GeofenceOverlaysProps) {
   return (
     <>
       {geofences.map((gf) => (
@@ -127,15 +123,13 @@ export function TrailDots({ trailPoints, zoom }: { trailPoints: TrailPoint[]; zo
 // SingleDeviceMarker (Story 10.2)
 // ---------------------------------------------------------------------------
 
-export function SingleDeviceMarkers({
-  devices,
-  zoom,
-  onMarkerClick,
-}: {
+interface SingleDeviceMarkersProps {
   devices: ResolvedDevice[];
   zoom: number;
   onMarkerClick: (device: GeoDevice, event: React.MouseEvent) => void;
-}) {
+}
+
+export function SingleDeviceMarkers({ devices, zoom, onMarkerClick }: SingleDeviceMarkersProps) {
   return (
     <>
       {devices.map((device) => (

--- a/src/app/components/geo-location/geofence-panel.tsx
+++ b/src/app/components/geo-location/geofence-panel.tsx
@@ -7,6 +7,14 @@ import type { Geofence } from "./geo-location-types";
 // GeofencePanel (Story 10.4)
 // ---------------------------------------------------------------------------
 
+interface GeofencePanelProps {
+  geofences: Geofence[];
+  showGeofences: boolean;
+  onToggleGeofences: () => void;
+  onSelectGeofence: (geofence: Geofence) => void;
+  onCreateGeofence: () => void;
+}
+
 /** Story 10.4: Geofence panel — collapsible sidebar listing all geofences */
 export function GeofencePanel({
   geofences,
@@ -14,13 +22,7 @@ export function GeofencePanel({
   onToggleGeofences,
   onSelectGeofence,
   onCreateGeofence,
-}: {
-  geofences: Geofence[];
-  showGeofences: boolean;
-  onToggleGeofences: () => void;
-  onSelectGeofence: (geofence: Geofence) => void;
-  onCreateGeofence: () => void;
-}) {
+}: GeofencePanelProps) {
   const [expanded, setExpanded] = useState(true);
 
   return (

--- a/src/app/components/geo-location/status-filter-pills.tsx
+++ b/src/app/components/geo-location/status-filter-pills.tsx
@@ -6,6 +6,15 @@ import { FILTER_OPTIONS } from "./geo-location-types";
 // StatusFilterPills (Story 9.3)
 // ---------------------------------------------------------------------------
 
+interface StatusFilterPillsProps {
+  statusFilter: GeoStatusFilter;
+  statusCounts: Record<string, number>;
+  mappableCount: number;
+  totalCount: number;
+  clusterCount: number;
+  onFilterChange: (filter: GeoStatusFilter) => void;
+}
+
 export function StatusFilterPills({
   statusFilter,
   statusCounts,
@@ -13,14 +22,7 @@ export function StatusFilterPills({
   totalCount,
   clusterCount,
   onFilterChange,
-}: {
-  statusFilter: GeoStatusFilter;
-  statusCounts: Record<string, number>;
-  mappableCount: number;
-  totalCount: number;
-  clusterCount: number;
-  onFilterChange: (filter: GeoStatusFilter) => void;
-}) {
+}: StatusFilterPillsProps) {
   return (
     <div className="flex flex-wrap items-center gap-2">
       {FILTER_OPTIONS.map((opt) => {

--- a/src/app/components/geo-location/trail-timeline.tsx
+++ b/src/app/components/geo-location/trail-timeline.tsx
@@ -6,16 +6,14 @@ import type { GeoDevice, TrailPoint } from "./geo-location-types";
 // TrailTimeline (Story 10.5)
 // ---------------------------------------------------------------------------
 
-/** Story 10.5: Device position history trail timeline */
-export function TrailTimeline({
-  device,
-  trail,
-  onHideTrail,
-}: {
+interface TrailTimelineProps {
   device: GeoDevice;
   trail: TrailPoint[];
   onHideTrail: () => void;
-}) {
+}
+
+/** Story 10.5: Device position history trail timeline */
+export function TrailTimeline({ device, trail, onHideTrail }: TrailTimelineProps) {
   return (
     <div className="card-elevated overflow-hidden">
       <div className="flex items-center justify-between px-4 py-3 border-b border-border/60">

--- a/src/app/components/geo-location/zoom-controls.tsx
+++ b/src/app/components/geo-location/zoom-controls.tsx
@@ -4,15 +4,13 @@ import { ZoomIn, ZoomOut, Navigation } from "lucide-react";
 // ZoomControls
 // ---------------------------------------------------------------------------
 
-export function ZoomControls({
-  onZoomIn,
-  onZoomOut,
-  onResetView,
-}: {
+interface ZoomControlsProps {
   onZoomIn: () => void;
   onZoomOut: () => void;
   onResetView: () => void;
-}) {
+}
+
+export function ZoomControls({ onZoomIn, onZoomOut, onResetView }: ZoomControlsProps) {
   return (
     <div className="absolute top-3 right-3 z-20 flex flex-col gap-1">
       <button

--- a/src/app/components/incidents/create-incident-dialog.tsx
+++ b/src/app/components/incidents/create-incident-dialog.tsx
@@ -8,15 +8,14 @@ import type { Incident, IncidentSeverity, IncidentCategory } from "@/lib/inciden
 // ---------------------------------------------------------------------------
 // Create Incident Dialog (Story 14.1 AC1-AC2)
 // ---------------------------------------------------------------------------
-export function CreateIncidentDialog({
-  open,
-  onClose,
-  onCreate,
-}: {
+
+interface CreateIncidentDialogProps {
   open: boolean;
   onClose: () => void;
   onCreate: (incident: Incident) => void;
-}) {
+}
+
+export function CreateIncidentDialog({ open, onClose, onCreate }: CreateIncidentDialogProps) {
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [severity, setSeverity] = useState<IncidentSeverity>("Medium");

--- a/src/app/components/incidents/incident-detail-panel.tsx
+++ b/src/app/components/incidents/incident-detail-panel.tsx
@@ -13,6 +13,15 @@ import { IncidentTimeline } from "./incident-timeline";
 import { PlaybookExecutor } from "./playbook-executor";
 import { NetworkTopologyGraph, LateralMovementPanel } from "./network-topology-graph";
 
+interface IncidentDetailPanelProps {
+  incident: Incident;
+  onClose: () => void;
+  onStatusChange: (incidentId: string, newStatus: IncidentStatus, note: string) => void;
+  onIsolate: (device: AffectedDevice) => void;
+  onRelease: (device: AffectedDevice) => void;
+  onStepComplete: (incidentId: string, stepNumber: number) => void;
+}
+
 export function IncidentDetailPanel({
   incident,
   onClose,
@@ -20,14 +29,7 @@ export function IncidentDetailPanel({
   onIsolate,
   onRelease,
   onStepComplete,
-}: {
-  incident: Incident;
-  onClose: () => void;
-  onStatusChange: (incidentId: string, newStatus: IncidentStatus, note: string) => void;
-  onIsolate: (device: AffectedDevice) => void;
-  onRelease: (device: AffectedDevice) => void;
-  onStepComplete: (incidentId: string, stepNumber: number) => void;
-}) {
+}: IncidentDetailPanelProps) {
   const [activeSection, setActiveSection] = useState<
     "details" | "devices" | "topology" | "playbook" | "timeline"
   >("details");

--- a/src/app/components/incidents/incident-list-tab.tsx
+++ b/src/app/components/incidents/incident-list-tab.tsx
@@ -13,15 +13,17 @@ import type {
 } from "@/lib/incident-types";
 import { SeverityBadge, StatusBadge, CategoryBadge } from "./incident-badges";
 
+interface IncidentListTabProps {
+  incidents: Incident[];
+  onSelectIncident: (incident: Incident) => void;
+  onCreateIncident: () => void;
+}
+
 export function IncidentListTab({
   incidents,
   onSelectIncident,
   onCreateIncident,
-}: {
-  incidents: Incident[];
-  onSelectIncident: (incident: Incident) => void;
-  onCreateIncident: () => void;
-}) {
+}: IncidentListTabProps) {
   const [statusFilter, setStatusFilter] = useState<IncidentStatus | "All">("All");
   const [severityFilter, setSeverityFilter] = useState<IncidentSeverity | "All">("All");
   const [categoryFilter, setCategoryFilter] = useState<IncidentCategory | "All">("All");

--- a/src/app/components/service-orders/service-order-filter-bar.tsx
+++ b/src/app/components/service-orders/service-order-filter-bar.tsx
@@ -20,6 +20,19 @@ const SERVICE_ORDER_EXPORT_COLUMNS: ExportColumn<ServiceOrder>[] = [
 
 /* ─── Filter Bar ──────────────────────────────────────────────────── */
 
+interface FilterBarProps {
+  statusFilter: string;
+  priorityFilter: string;
+  searchQuery: string;
+  onStatusChange: (v: string) => void;
+  onPriorityChange: (v: string) => void;
+  onSearchChange: (v: string) => void;
+  onClearAll: () => void;
+  filteredOrders: ServiceOrder[];
+  filteredCount: number;
+  totalCount: number;
+}
+
 export function FilterBar({
   statusFilter,
   priorityFilter,
@@ -31,18 +44,7 @@ export function FilterBar({
   filteredOrders,
   filteredCount,
   totalCount,
-}: {
-  statusFilter: string;
-  priorityFilter: string;
-  searchQuery: string;
-  onStatusChange: (v: string) => void;
-  onPriorityChange: (v: string) => void;
-  onSearchChange: (v: string) => void;
-  onClearAll: () => void;
-  filteredOrders: ServiceOrder[];
-  filteredCount: number;
-  totalCount: number;
-}) {
+}: FilterBarProps) {
   const hasActiveFilters = statusFilter !== "all" || priorityFilter !== "all" || searchQuery !== "";
 
   const selectClasses =


### PR DESCRIPTION
## Summary
- Extract anonymous inline prop types to named `*Props` interfaces for all components with 3+ props
- 20+ components refactored across 16 files (analytics, blast-radius, compliance, deployment, digital-twin, geo-location, incidents, service-orders)
- Improves IDE hover docs, enables props type reuse, unblocks Storybook auto-docs
- Components with 1-2 props left unchanged per AC3
- Pure type-only refactor — zero behavioral changes

## Test plan
- [ ] `npm run build` — no type errors
- [ ] `npm test` — all existing tests pass unchanged
- [ ] Verify IDE hover shows named interface (e.g., `IncidentDetailPanelProps`) instead of inline `{ ... }`

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)