### PR TITLE
[Epic 27] Device Lifecycle 360 — planning docs

### DIFF
--- a/Docs/epics/epic-27/epic-27-overview.md
+++ b/Docs/epics/epic-27/epic-27-overview.md
@@ -1,0 +1,76 @@
+# Epic 27 — Device Lifecycle 360 & Cross-Domain Timeline
+
+## Vision
+
+Surface the complete lifecycle of every device as a **single, persona-aware story** — from registration through firmware deployments, service orders, ownership changes, status transitions, and decommission. This epic adds **no new systems of record**. Instead, it composes existing telemetry (audit log, CDC events, firmware assignments, digital twin snapshots, service orders) into a unified timeline that Technicians, Admins, Sales, and Customers can each consume through their own lens.
+
+## Business Context
+
+The IMS Gen2 core already captures the data — every entity change writes an AUDIT# record (Epic 8), firmware history is first-class (Epic 4 + Story 20.6), and Digital Twin state snapshots are retained for 180 days (Epic 15). What's missing is the **presentation layer** that turns this raw data into a story a user can trust, export, and act on.
+
+For a template that aspires to be enterprise-grade, a unified "device passport" is table stakes for:
+
+- **Compliance** — chain-of-custody for NIST SR-11 (supply-chain integrity) and CM-8 (asset inventory)
+- **Warranty & Insurance** — provable ownership and operational history
+- **Support & Field Service** — technicians need one screen, not five tabs
+- **Sales** — demo-able narrative ("bought → deployed → updated N times → zero incidents → $X saved")
+- **Forensics** — reconstruct device state at a past timestamp for incident response
+
+## Architecture Principles
+
+1. **Compose, don't rebuild** — Every story reuses existing data sources (CDCEvent from 20.8, AuditLog from Epic 8, FirmwareAssignment from Story 26.9, Digital Twin snapshots from Epic 15). No new event bus, no new audit table.
+2. **Presentation over capture** — This epic adds UI, view-models, and small field additions. It does NOT introduce new write paths for existing entity changes.
+3. **Persona-aware by default** — The same underlying event stream is filtered by `rbac.ts` roles, not duplicated per persona.
+4. **Read-only read-models** — Any derived view (ownership chain, status history) is a projection over existing audit logs, not a new source of truth.
+5. **Exportable** — Every timeline surface supports CSV export (reusing the pattern from `audit-log-tab.tsx`).
+
+## Enterprise Standards (MUST match existing codebase quality)
+
+| Standard                                      | Reference Implementation                                | Applies To                                                                    |
+| --------------------------------------------- | ------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| **Factory functions** (`createXxxProvider()`) | `createMockApiProvider()`, `createAmplifyAuthAdapter()` | Any new provider or view-model factory                                        |
+| **JSDoc with @example**                       | `IAuthAdapter` in `auth-adapter.ts`                     | Every new public type and hook                                                |
+| **TanStack Query integration**                | Existing query patterns                                 | All timeline/ownership hooks use `useQuery` with proper cache keys            |
+| **RBAC enforcement**                          | `canAccess()`, `canPerform()` in `src/lib/rbac.ts`      | Timeline filtering MUST route through existing RBAC, not duplicate role logic |
+| **NIST compliance**                           | AU-2/AU-3 audit logging, AC-3 access enforcement        | Export and view actions are audit-logged                                      |
+| **Readonly config properties**                | `refreshIntervalMs` in `IAuthAdapter`                   | Any new config constants are `readonly`                                       |
+| **Accessibility**                             | Existing story a11y + Storybook addon                   | Timeline is keyboard-navigable, WCAG 2.1 AA                                   |
+
+## Stories
+
+| Story | Title                                         | Phase               | Points | Priority |
+| ----- | --------------------------------------------- | ------------------- | ------ | -------- |
+| 27.1  | Per-Device Unified Lifecycle Timeline         | 1 — Composition     | 8      | P0       |
+| 27.2  | Persona-Aware Timeline Filtering              | 1 — Composition     | 5      | P0       |
+| 27.3  | Device Ownership / Custody Chain View         | 2 — Derived Views   | 5      | P1       |
+| 27.4  | Firmware Approval Comments & Rollback Reasons | 2 — Field Additions | 3      | P1       |
+| 27.5  | Device Status Transition History              | 2 — Derived Views   | 3      | P1       |
+
+## Dependencies
+
+- **Epic 8** — Audit Trail infrastructure (AUDIT# records, Lambda processor) — MUST be live
+- **Epic 20 Story 20.6** — Firmware Version History (timeline pattern, detail page convention) — reference implementation
+- **Epic 20 Story 20.8** — CDC Event Provider (`ICDCProvider`, `CDCEvent`, `getChangeHistory`) — data source for 21.1
+- **Story 26.9** — `FirmwareAssignment` entity — extended in 21.4
+- **Epic 15** — Digital Twin state snapshots — referenced (not modified) by 21.1
+
+## Out of Scope (Explicitly Deferred)
+
+- **Device location history** — YAGNI until a customer asks; current lat/lng is sufficient for Epic 9/10 use cases
+- **Config snapshots / diff viewer** — Digital Twin already captures state; building a diff UI is polish, not enterprise-critical
+- **Event-sourced temporal "state at T"** — audit log + Digital Twin snapshots already answer this; building a dedicated read-model is over-engineering
+- **Lifecycle PDF export** — CSV export (reused from audit-log-tab) is sufficient; PDF generation is deferred as marketing polish
+- **Record-level revision counters / optimistic locking** — no write-contention problem exists; `_schemaVersion` is sufficient
+- **Custom fields on timeline events** — BAs can filter existing fields; custom-field infrastructure is a separate concern
+
+## Delivery Sequence
+
+1. **Sprint 1:** Stories 21.1 + 21.2 — the visible demo win (unified timeline + persona filter)
+2. **Sprint 2:** Stories 21.3 + 21.4 + 21.5 — ownership chain, approval/rollback reasons, status transition history
+
+## Success Metrics
+
+- Technician "time to context" on a dispatched device drops from ~5 clicks (across tabs) to 1 click
+- Sales demo reconstructs a device's full story without switching screens
+- Compliance exports for a single device can be generated in under 30 seconds
+- Zero new database tables introduced (composition-only verification)

--- a/Docs/epics/epic-27/epic-27-overview.md
+++ b/Docs/epics/epic-27/epic-27-overview.md
@@ -50,9 +50,9 @@ For a template that aspires to be enterprise-grade, a unified "device passport" 
 
 - **Epic 8** — Audit Trail infrastructure (AUDIT# records, Lambda processor) — MUST be live
 - **Epic 20 Story 20.6** — Firmware Version History (timeline pattern, detail page convention) — reference implementation
-- **Epic 20 Story 20.8** — CDC Event Provider (`ICDCProvider`, `CDCEvent`, `getChangeHistory`) — data source for 21.1
-- **Story 26.9** — `FirmwareAssignment` entity — extended in 21.4
-- **Epic 15** — Digital Twin state snapshots — referenced (not modified) by 21.1
+- **Epic 20 Story 20.8** — CDC Event Provider (`ICDCProvider`, `CDCEvent`, `getChangeHistory`) — data source for 27.1
+- **Story 26.9** — `FirmwareAssignment` entity — extended in 27.4
+- **Epic 15** — Digital Twin state snapshots — referenced (not modified) by 27.1
 
 ## Out of Scope (Explicitly Deferred)
 

--- a/Docs/epics/epic-27/story-27.1.md
+++ b/Docs/epics/epic-27/story-27.1.md
@@ -1,0 +1,115 @@
+# Story 27.1: Per-Device Unified Lifecycle Timeline
+
+**Epic:** Epic 27 — Device Lifecycle 360 & Cross-Domain Timeline
+**Phase:** PHASE 1: COMPOSITION
+**Persona:** Raj (Operations Manager) / Field Technician
+**Priority:** P0
+**Story Points:** 8
+**Status:** New
+**GitHub Issue:** #417
+**Target URL:** `/inventory/:deviceId` (Lifecycle tab)
+
+## User Story
+
+As an operations manager or field technician, I want to see the complete lifecycle of a device on one screen — including firmware deployments, service orders, ownership changes, status transitions, and audit events — so that I can understand the device's full story without navigating between multiple tabs or screens.
+
+## Preconditions
+
+- Device detail page exists at `/inventory/:deviceId` (Epic 3)
+- Audit trail infrastructure is live (Epic 8 — `AuditLog` entity, Lambda processor writing AUDIT# records)
+- CDC provider interface exists (Story 20.8 — `ICDCProvider.getChangeHistory(entityId, timeRange)`)
+- Firmware assignment history is queryable per device (Story 26.9 — `FirmwareAssignment` with `previousFirmwareVersion`)
+- Service order history is queryable per device (Epic 5)
+- RBAC roles and page access are defined in `src/lib/rbac.ts`
+
+## Context / Business Rules
+
+- **Composition, not capture:** This story MUST NOT introduce a new write path for device events. All events displayed in the timeline are read from existing systems of record (AuditLog, CDCEvent, FirmwareAssignment, ServiceOrder, DigitalTwinSnapshot).
+- **Event taxonomy:** Timeline events are classified into five categories — `Firmware` (uploaded/approved/deployed/rolled-back), `Service` (order created/assigned/resolved/closed), `Ownership` (customer reassigned), `Status` (online/offline/maintenance/decommissioned), `Audit` (other entity-level changes not covered above).
+- **Newest-first ordering:** Timeline is sorted by event timestamp descending. Ties resolved by event type priority (Firmware > Service > Ownership > Status > Audit).
+- **Clickable provenance:** Each event node links to its source entity — firmware version detail, service order detail, audit log entry, etc.
+- **Retention alignment:** Timeline honors existing retention policies — 30-day default window for audit events, 180-day for Digital Twin snapshots, unbounded for FirmwareAssignment and ServiceOrder. User can extend window via date-range selector.
+- **No new data entity:** The unified view uses a **view-model** (`DeviceLifecycleEvent`) that is projected in the UI layer from the existing sources; it is not persisted.
+
+## Acceptance Criteria
+
+- [ ] AC1: Device detail page (`/inventory/:deviceId`) exposes a new **Lifecycle** tab alongside existing tabs (Overview, Firmware, Service Orders, etc.)
+- [ ] AC2: `DeviceLifecycleEvent` view-model type is defined in `src/lib/types.ts` with fields: `id`, `deviceId`, `category` (enum: Firmware/Service/Ownership/Status/Audit), `action`, `actor` (userId + displayName), `timestamp`, `summary`, `sourceEntityType`, `sourceEntityId`, `metadata` (record)
+- [ ] AC3: A `useDeviceLifecycle(deviceId, timeRange)` hook is created in `src/lib/hooks/use-device-lifecycle.ts` that aggregates events from: `getChangeHistory()` (CDC/audit), `listFirmwareAssignments(deviceId)`, `listServiceOrdersByDevice(deviceId)`, and returns a merged, sorted `DeviceLifecycleEvent[]`
+- [ ] AC4: The Lifecycle tab renders a **vertical timeline** (reuses the pattern from Story 20.6's firmware timeline component) with newest events at top
+- [ ] AC5: Each timeline node displays: category icon, color-coded indicator (Firmware = blue, Service = amber, Ownership = purple, Status = teal, Audit = gray), event summary, actor name, relative timestamp (e.g., "3 days ago"), and an expandable detail section
+- [ ] AC6: Clicking a timeline node navigates to the source entity (firmware version page, service order detail, audit log entry, etc.)
+- [ ] AC7: A date-range selector (default: last 30 days; options: 7d / 30d / 90d / 180d / all) reloads the timeline with the selected window
+- [ ] AC8: A category filter (multi-select: Firmware, Service, Ownership, Status, Audit) filters visible events without refetching
+- [ ] AC9: Page shows skeleton loading states while the aggregate query resolves
+- [ ] AC10: If any source query fails, a partial result is shown with a warning banner indicating which sources were unavailable (resilience — no single failure blanks the timeline)
+- [ ] AC11: Unit tests cover the aggregation logic in `useDeviceLifecycle` with ≥ 85% coverage including merge ordering, partial-failure handling, and empty-state
+- [ ] AC12: CSV export button exports the currently-filtered timeline events (columns: timestamp, category, action, actor, summary, sourceEntityType, sourceEntityId) — reuses the export pattern from `audit-log-tab.tsx`
+
+## UI Behavior
+
+- Tab is labeled "Lifecycle" and uses a clock-with-arrow icon (lucide `History`)
+- Timeline is a vertical stepper anchored to the left of the content area; event details expand inline to the right
+- Each timeline node is compact: 48px high when collapsed, expands on click
+- Category icons use existing lucide icons: `Cpu` (Firmware), `Wrench` (Service), `Users` (Ownership), `Activity` (Status), `FileText` (Audit)
+- Color indicators are 4px-wide vertical bars next to each node — not full-background colors, to preserve enterprise density
+- Date-range selector and category filter are in a sticky toolbar above the timeline
+- Mobile (< 768px): timeline collapses to an accordion; date-range becomes a sheet selector
+- Empty state: "No lifecycle events in this window" with a suggestion to widen the date range
+- Loading state: 6 skeleton nodes of varying height
+- Error state: inline warning banner above the timeline, does NOT replace it
+
+## Out of Scope
+
+- Persona-based filtering of the timeline (Story 27.2)
+- Ownership-change dedicated view with chain-of-custody export (Story 27.3)
+- Status-transition dedicated analytics view (Story 27.5)
+- PDF export of the lifecycle (deferred — CSV is sufficient for this story)
+- Real-time WebSocket updates of the timeline (CDC subscription is Story 20.8; this story uses `getChangeHistory` for point-in-time reads)
+- Lifecycle events for entities OTHER than devices (firmware lifecycle is Story 20.6; service order history is Epic 5)
+- Editing or deleting lifecycle events (events are immutable by design)
+
+## Tech Spec Reference
+
+See [tech-spec.md](./tech-spec.md) for aggregation algorithm, view-model mapping, and error-boundary strategy (to be authored alongside this story).
+
+## Dev Checklist (NOT for QA)
+
+1. Add `DeviceLifecycleEvent` type and `DeviceLifecycleCategory` enum to `src/lib/types.ts`
+2. Create `src/lib/hooks/use-device-lifecycle.ts` with TanStack Query `useQueries` aggregating the 3+ source queries
+3. Create `src/app/components/devices/device-lifecycle-tab.tsx` containing the timeline, filters, and export button
+4. Create `src/app/components/devices/device-lifecycle-timeline.tsx` (reusable timeline component; consider whether to extract a shared `TimelineRail` component if patterns align with Story 20.6 firmware timeline)
+5. Create `src/app/components/devices/device-lifecycle-filters.tsx` (date-range + category filter toolbar)
+6. Wire the Lifecycle tab into the device detail page tab list
+7. Add CSV export helper — reuse `exportAuditLogsToCsv` pattern from Story 8.4
+8. Write unit tests in `src/__tests__/hooks/use-device-lifecycle.test.ts` covering: merge ordering, partial failure (one source 500s), empty state, large result pagination
+9. Write component tests for timeline rendering, filtering, empty state
+10. Add Storybook stories for `DeviceLifecycleTimeline` (empty, loading, mixed events, partial-failure states)
+
+## AutoGent Test Prompts
+
+1. **AC1 — Tab presence:** "Navigate to `/inventory/device-001`. Verify a 'Lifecycle' tab is visible. Click it. Verify URL hash or query reflects the active tab."
+
+2. **AC2-AC3 — Aggregation:** "Call `useDeviceLifecycle('device-001', { range: '30d' })` from a test harness. Verify the returned array contains events from at least 3 distinct `sourceEntityType` values (firmware assignments, service orders, audit entries). Verify events are sorted by `timestamp` descending."
+
+3. **AC4-AC5 — Timeline rendering:** "On the Lifecycle tab for device-001, verify a vertical timeline is rendered. Verify at least 5 event nodes are visible. Verify each node shows a category icon, color indicator, summary, actor name, and relative timestamp. Click a node. Verify it expands to show additional detail fields."
+
+4. **AC6 — Deep link:** "On the Lifecycle tab, locate a Firmware-category event. Click its 'View firmware version' link. Verify navigation to `/deployment/firmware/:familyId` with the correct version pre-selected."
+
+5. **AC7-AC8 — Filtering:** "On the Lifecycle tab, set date range to '7d'. Verify only events from the last 7 days are visible. Deselect the 'Audit' category. Verify Audit-category events disappear without a network refetch."
+
+6. **AC9-AC10 — Resilience:** "Simulate a 500 error from `listServiceOrdersByDevice`. Navigate to the Lifecycle tab. Verify a warning banner shows 'Service order history unavailable'. Verify Firmware and Audit events still render."
+
+7. **AC12 — Export:** "On the Lifecycle tab with a 30d filter, click 'Export CSV'. Verify a CSV file downloads. Verify column headers match AC12. Verify row count equals the number of currently-filtered events."
+
+## Definition of Done
+
+- [ ] Code reviewed and approved
+- [ ] Unit tests passing (≥ 85% coverage on new code)
+- [ ] E2E test for Lifecycle tab navigation, filtering, and CSV export
+- [ ] Storybook stories published for `DeviceLifecycleTimeline`
+- [ ] Responsive layout verified (desktop, tablet, mobile)
+- [ ] WCAG 2.1 AA — timeline is keyboard-navigable; date-range selector is screen-reader accessible
+- [ ] No new database tables introduced (composition-only verified)
+- [ ] TypeScript strict — no `any` types
+- [ ] Compliance check green

--- a/Docs/epics/epic-27/story-27.2.md
+++ b/Docs/epics/epic-27/story-27.2.md
@@ -1,0 +1,101 @@
+# Story 27.2: Persona-Aware Timeline Filtering
+
+**Epic:** Epic 27 — Device Lifecycle 360 & Cross-Domain Timeline
+**Phase:** PHASE 1: COMPOSITION
+**Persona:** All personas (Admin, Manager, Technician, Viewer, CustomerAdmin)
+**Priority:** P0
+**Story Points:** 5
+**Status:** New
+**GitHub Issue:** #418
+**Target URL:** `/inventory/:deviceId` (Lifecycle tab)
+
+## User Story
+
+As a user of any role, I want the device lifecycle timeline to pre-filter to the events most relevant to my job, so that I see only what I need to act on without manually dismissing noise I don't care about — and so that sensitive events are hidden from roles that shouldn't see them.
+
+## Preconditions
+
+- Story 27.1 is complete (`DeviceLifecycleEvent` view-model + `useDeviceLifecycle` hook)
+- RBAC roles are defined in `src/lib/rbac.ts` — Admin, Manager, Technician, Viewer, CustomerAdmin
+- `useCurrentUser()` or equivalent hook exposes the current user's role
+
+## Context / Business Rules
+
+- **One event stream, many lenses:** Persona filtering is a VIEW concern, not a data concern. The same `useDeviceLifecycle` query feeds every persona; the filter runs in the UI layer.
+- **Persona → default category map:**
+  - **Technician** → Firmware + Service + Status (operational events; no ownership visibility, minimal audit)
+  - **Manager** → Firmware + Service + Status + Ownership (operational + business)
+  - **Admin** → all five categories (full visibility)
+  - **Viewer** → Firmware + Service + Status (read-only operational snapshot)
+  - **CustomerAdmin** → Firmware + Service + Ownership (scoped to their customer; no cross-tenant audit leakage)
+- **Hard RBAC enforcement:** Filters that hide events are NOT a substitute for authorization. The API provider for `getChangeHistory` MUST already respect RBAC (Story 20.8 + Epic 8). Persona filtering here only hides events the user IS allowed to see but probably doesn't want.
+- **Override allowed:** User can re-enable any category they are permitted to see. The persona default is a starting preset, not a lock.
+- **Persistence:** User's last category filter selection per device page is persisted in localStorage under key `lifecycle.filter.<role>` so returning users get their last view.
+- **No new permissions:** This story does NOT introduce new RBAC actions. It reuses existing role enums.
+
+## Acceptance Criteria
+
+- [ ] AC1: On initial render of the Lifecycle tab, category filter is pre-set according to the current user's role per the persona → default category map
+- [ ] AC2: A `getDefaultLifecycleCategories(role: UserRole): DeviceLifecycleCategory[]` helper is defined in `src/lib/rbac.ts` (or colocated `rbac-lifecycle.ts`) and unit-tested for all 5 roles
+- [ ] AC3: User can toggle any category on/off within the set of categories their role is permitted to see
+- [ ] AC4: If a user's role is NOT permitted to see a category (e.g., CustomerAdmin + Audit), that category checkbox is rendered **disabled** with a tooltip "Not available for your role", not hidden (transparency > magic)
+- [ ] AC5: The user's filter selection per device is persisted to localStorage (key: `lifecycle.filter.${role}.${deviceId}`) and restored on re-visit
+- [ ] AC6: A "Reset to default" button restores the persona-default selection and clears localStorage entry for that device
+- [ ] AC7: Filter changes do NOT refetch data — filtering happens client-side over the already-fetched `DeviceLifecycleEvent[]`
+- [ ] AC8: Unit tests cover: default category selection for each role, toggle behavior, permission-gated disabling, localStorage persistence, reset action — with ≥ 85% coverage
+- [ ] AC9: E2E test verifies that logging in as a Technician vs Admin on the same device yields different default timeline views
+
+## UI Behavior
+
+- Category filter remains the same component from Story 27.1, enhanced with:
+  - Persona-default selection applied on first render
+  - Disabled state for non-permitted categories, with hover tooltip
+  - Small "Reset to default" text button next to the filter
+  - Subtle "Showing default view for [Role]" helper text below the filter on first load (fades after 5s)
+- No change to the timeline rendering itself — still a simple client-side filter
+- Accessibility: disabled categories are keyboard-focusable with `aria-disabled="true"` and the tooltip is announced by screen readers
+
+## Out of Scope
+
+- Introducing new RBAC actions or modifying permission matrices (out of scope — reuse existing `src/lib/rbac.ts`)
+- Server-side filtering of `getChangeHistory` results by role (that's the responsibility of the API provider, already covered by Story 20.8 + Epic 8)
+- Per-user custom persona overrides (admin users cannot customize what a Technician sees by default — that's a future configurability story)
+- Cross-device filter presets (filter is per-device; no "apply to all devices" flag)
+
+## Tech Spec Reference
+
+See [tech-spec.md](./tech-spec.md) for the persona → category mapping rationale and localStorage key convention.
+
+## Dev Checklist (NOT for QA)
+
+1. Add `getDefaultLifecycleCategories(role)` and `getPermittedLifecycleCategories(role)` helpers to `src/lib/rbac.ts` (or `src/lib/rbac-lifecycle.ts`)
+2. Extend `device-lifecycle-filters.tsx` to consume the helpers and apply defaults
+3. Add localStorage read/write with debounce (150 ms) to avoid excessive writes during rapid toggling
+4. Add "Reset to default" button and wire it to clear localStorage + reapply default
+5. Add disabled-category visual + `aria-disabled` treatment and tooltip
+6. Write unit tests in `src/__tests__/lib/rbac-lifecycle.test.ts`
+7. Write component tests for filter default application, persist/restore, disabled behavior
+8. Update Storybook: add stories "as Technician", "as Admin", "as CustomerAdmin" variants
+
+## AutoGent Test Prompts
+
+1. **AC1-AC2 — Persona defaults:** "Mock current user role as 'Technician'. Render the Lifecycle tab. Verify the category filter has Firmware, Service, and Status checked by default; Ownership and Audit unchecked."
+
+2. **AC3-AC4 — Toggle + permission gate:** "As a CustomerAdmin, verify the Audit category checkbox is rendered but disabled with tooltip 'Not available for your role'. Attempt to click it. Verify state does not change."
+
+3. **AC5-AC6 — Persistence + reset:** "As a Manager, toggle off the Ownership category. Refresh the page. Verify Ownership remains unchecked. Click 'Reset to default'. Verify Ownership returns to checked and localStorage entry is cleared."
+
+4. **AC7 — Client-side filtering:** "With the Lifecycle tab loaded, open browser network tab and clear its log. Toggle the Service category off. Verify no new network request is sent. Verify Service events disappear from the timeline."
+
+5. **AC9 — Role differentiation E2E:** "Log in as Technician. Open device-001 Lifecycle. Count visible events. Log out. Log in as Admin. Open device-001 Lifecycle. Count visible events. Verify Admin count ≥ Technician count and includes Audit-category events."
+
+## Definition of Done
+
+- [ ] Code reviewed and approved
+- [ ] Unit tests passing (≥ 85% coverage on new code)
+- [ ] E2E test covering role-based default filtering
+- [ ] Storybook role variants published
+- [ ] WCAG 2.1 AA — disabled checkboxes are keyboard-focusable and screen-reader-accessible
+- [ ] No changes to RBAC permission matrix
+- [ ] TypeScript strict — no `any` types
+- [ ] Compliance check green

--- a/Docs/epics/epic-27/story-27.3.md
+++ b/Docs/epics/epic-27/story-27.3.md
@@ -1,0 +1,107 @@
+# Story 27.3: Device Ownership / Custody Chain View
+
+**Epic:** Epic 27 — Device Lifecycle 360 & Cross-Domain Timeline
+**Phase:** PHASE 2: DERIVED VIEWS
+**Persona:** Raj (Operations Manager) / Admin / Compliance Officer
+**Priority:** P1
+**Story Points:** 5
+**Status:** New
+**GitHub Issue:** #419
+**Target URL:** `/inventory/:deviceId` (Ownership tab)
+
+## User Story
+
+As an operations manager or compliance officer, I want to see the complete chain of custody for a device — every customer, site, and responsible party it has been associated with, with effective dates and the user who made each transfer — so that I can produce warranty, insurance, and NIST SR-11 / CM-8 compliance evidence on demand.
+
+## Preconditions
+
+- Device entity has a `customerId` field (Epic 3)
+- Optional `siteId` field may exist if Story 20.7 (Customer & Site Entity Model) has landed
+- Audit trail captures all `Device` updates including `customerId` changes (Epic 8 — Lambda processor writes AUDIT# records for every update)
+- `getChangeHistory(entityId, { fields: ['customerId', 'siteId'] })` is queryable via the CDC provider (Story 20.8)
+
+## Context / Business Rules
+
+- **No new table:** The ownership chain is a **projection** over the existing audit log. We are NOT creating a separate `DeviceOwnership` table. Every ownership change was already captured when `customerId` was updated.
+- **Derived record shape:** Each ownership record in the chain represents a **half-open interval** `[startAt, endAt)` during which the device was assigned to a specific customer (and optionally site). `endAt` is null for the current (active) assignment.
+- **Transfer reason — optional enhancement:** When a user changes `customerId` via the UI, the app SHOULD prompt for an optional transfer reason (free text, max 500 chars). If captured, it is stored on the audit log entry's `metadata.transferReason`. This is additive and non-blocking — existing transfers without a reason render as "Reason not recorded".
+- **Compliance-relevant fields:** The chain view surfaces: `customer`, `site` (if available), `startAt`, `endAt`, `durationDays`, `transferredBy` (user who made the change), `transferReason`.
+- **Export artifact:** The chain is exportable as CSV (reused pattern from Story 8.4) AND as a signed PDF "Chain of Custody Report" is **out of scope for this story** (deferred — CSV is sufficient; PDF can be a follow-up).
+- **Current device must always appear:** If the device has never changed ownership, the chain shows a single open-ended record from the device's `createdAt` to "present".
+
+## Acceptance Criteria
+
+- [ ] AC1: Device detail page exposes a new **Ownership** tab (next to the Lifecycle tab from Story 27.1)
+- [ ] AC2: A `DeviceOwnershipRecord` view-model type is added to `src/lib/types.ts` with fields: `customerId`, `customerName`, `siteId?`, `siteName?`, `startAt`, `endAt?`, `durationDays`, `transferredBy` (userId + displayName), `transferReason?`
+- [ ] AC3: A `useDeviceOwnershipChain(deviceId)` hook in `src/lib/hooks/use-device-ownership-chain.ts` derives the chain by: (a) calling `getChangeHistory(deviceId, { fields: ['customerId', 'siteId'] })`, (b) grouping consecutive identical assignments, (c) computing half-open intervals, (d) enriching with customer/site display names
+- [ ] AC4: The Ownership tab renders a **horizontal flow** (left-to-right) OR a vertical list showing the full chain. Default is vertical list on mobile, horizontal on desktop.
+- [ ] AC5: Each ownership record displays: customer badge, site (if any), start date, end date (or "Current"), duration (e.g., "2 years, 3 months"), transferred-by user, and expandable transfer reason
+- [ ] AC6: If the device has never changed ownership, the view renders a single record with a neutral indicator "No ownership changes recorded"
+- [ ] AC7: When the user initiates a customer reassignment from the device detail page (existing edit flow), a **Transfer Reason** textarea is added to the form. Submitting captures the reason in the audit log metadata.
+- [ ] AC8: CSV export exports the full chain with all fields from AC2
+- [ ] AC9: The view respects RBAC — Technicians and Viewers do NOT see the Ownership tab (ownership is Manager/Admin/CustomerAdmin scope). CustomerAdmin sees only records where their customer was the assignee.
+- [ ] AC10: Unit tests cover: empty chain, single-assignment chain, multi-transfer chain, missing transfer reason handling, CustomerAdmin scoping — with ≥ 85% coverage
+
+## UI Behavior
+
+- Tab is labeled "Ownership" with a `Users` lucide icon
+- Each record is a card with a colored left border (blue for active, gray for historical)
+- Timeline layout on desktop: cards stack horizontally with arrow connectors between them, newest on the right
+- Mobile layout: cards stack vertically, newest at top
+- Transfer reason is collapsed by default; expands on click with fade-in
+- "Transferred by" includes the user's avatar (if available) and display name, linking to the user profile page if RBAC permits
+- Transfer Reason textarea (AC7): placeholder "Reason for transfer (optional, e.g., 'warranty replacement', 'customer migration')"
+- CSV export button is placed in the top-right of the tab, consistent with Lifecycle tab
+
+## Out of Scope
+
+- Signed PDF chain-of-custody report (deferred — CSV is the first deliverable)
+- Bulk ownership transfer across multiple devices (enterprise feature, future story)
+- Ownership transfer approval workflow (future story — current behavior is immediate change with audit)
+- Tracking device CUSTODY at the individual-technician level (only customer + site in this story)
+- Historical customer display names that have since been renamed (we display current customer name; historical name can be inferred from audit log raw data for compliance)
+
+## Tech Spec Reference
+
+See [tech-spec.md](./tech-spec.md) for the chain-derivation algorithm and CustomerAdmin scoping strategy.
+
+## Dev Checklist (NOT for QA)
+
+1. Add `DeviceOwnershipRecord` type to `src/lib/types.ts`
+2. Create `src/lib/hooks/use-device-ownership-chain.ts` — query + derivation + enrichment
+3. Add a unit-testable pure function `deriveOwnershipChainFromAuditLog(events, deviceCreatedAt)` in `src/lib/mappers/device-ownership.mapper.ts`
+4. Create `src/app/components/devices/device-ownership-tab.tsx`
+5. Create `src/app/components/devices/device-ownership-card.tsx` (single record renderer)
+6. Extend existing device-reassignment form to include "Transfer Reason" textarea
+7. Wire audit-log write path to include `metadata.transferReason` when provided (coordinate with Epic 8 audit processor — verify it passes through `metadata`)
+8. Add RBAC gate for Ownership tab visibility using `canAccess('device.ownership', role)` — may require adding this action to `rbac.ts`
+9. Add CustomerAdmin filtering to `useDeviceOwnershipChain`
+10. CSV export helper
+11. Unit tests in `src/__tests__/mappers/device-ownership.mapper.test.ts` and `src/__tests__/hooks/use-device-ownership-chain.test.ts`
+12. Storybook stories for empty chain, single, multi-transfer, with/without reasons
+
+## AutoGent Test Prompts
+
+1. **AC1 — Tab visibility:** "As an Admin, navigate to `/inventory/device-001`. Verify the 'Ownership' tab is visible. Log out. Log in as a Technician. Navigate to the same device. Verify the Ownership tab is NOT visible."
+
+2. **AC3-AC5 — Chain derivation:** "Seed device-005 with audit history: created for customer-A on 2024-01-01, transferred to customer-B on 2024-06-15, transferred to customer-A again on 2025-02-01. Open its Ownership tab. Verify 3 records appear, in correct chronological order, with durations: ~5.5 months, ~7.5 months, and 'Current'."
+
+3. **AC6 — Single record:** "For a device with no ownership changes, open the Ownership tab. Verify a single record is shown with start date = device `createdAt`, end date = 'Current', and the 'No ownership changes recorded' indicator."
+
+4. **AC7 — Transfer reason capture:** "As an Admin, open the customer reassignment form for device-010. Verify a 'Transfer Reason' textarea is present. Enter 'warranty replacement'. Submit. Navigate to the Ownership tab. Verify the new record displays 'warranty replacement' in the expandable reason section."
+
+5. **AC8 — CSV export:** "Open device-005 Ownership tab. Click Export CSV. Verify download occurs. Open the CSV. Verify columns: customerId, customerName, siteId, siteName, startAt, endAt, durationDays, transferredBy, transferReason. Verify row count = chain length."
+
+6. **AC9 — CustomerAdmin scoping:** "Seed device-020 with transfers across customer-A → customer-B → customer-C. Log in as a CustomerAdmin of customer-B. Open device-020. Verify only the customer-B assignment record is visible."
+
+## Definition of Done
+
+- [ ] Code reviewed and approved
+- [ ] Unit tests passing (≥ 85% coverage on new code)
+- [ ] E2E test for chain display, transfer with reason, CSV export, RBAC scoping
+- [ ] Storybook stories published for all chain shapes
+- [ ] Responsive layout verified (desktop horizontal, mobile vertical)
+- [ ] WCAG 2.1 AA — cards keyboard-focusable, reason-expand has proper aria
+- [ ] No new database tables introduced (derivation-only verified)
+- [ ] TypeScript strict — no `any` types
+- [ ] Compliance check green

--- a/Docs/epics/epic-27/story-27.4.md
+++ b/Docs/epics/epic-27/story-27.4.md
@@ -1,0 +1,107 @@
+# Story 27.4: Firmware Approval Comments & Rollback Reasons
+
+**Epic:** Epic 27 — Device Lifecycle 360 & Cross-Domain Timeline
+**Phase:** PHASE 2: FIELD ADDITIONS
+**Persona:** Raj (Operations Manager) / Compliance Officer
+**Priority:** P1
+**Story Points:** 3
+**Status:** New
+**GitHub Issue:** #420
+**Target URL:** `/deployment/firmware/:firmwareId` (existing firmware detail page) + firmware approval flow
+
+## User Story
+
+As an operations manager or compliance officer, I want every firmware approval, rejection, and rollback action to capture a written reason or comment, so that the audit trail shows not just who acted and when, but why — providing the context needed for SoD compliance (NIST AC-5) and post-incident forensics.
+
+## Preconditions
+
+- Firmware multi-stage approval is implemented (Epic 4 — Stories 4.1–4.5, `approvalStage` enum with Uploaded / Testing / Approved)
+- `FirmwareAssignment` entity exists with `previousFirmwareVersion` field (Story 26.9)
+- Audit trail infrastructure writes AUDIT# records for every firmware state change (Epic 8)
+
+## Context / Business Rules
+
+- **Three new optional string fields — nothing else:** This story is deliberately small. No new workflow, no new state machine, no new permissions. Just three text fields on existing flows.
+- **Approval comment (optional):** When a user promotes a firmware through a stage (Uploaded → Testing → Approved), they MAY enter a free-text comment (max 1000 chars). Stored on the existing firmware version record as `approvalComment` (last write wins per stage — we keep the comment on the most recent approval action).
+- **Rejection reason (required when rejecting):** When a user rejects a firmware at any stage, they MUST enter a rejection reason (free text, max 1000 chars, minimum 10 chars). Stored on the firmware version record as `rejectionReason`.
+- **Rollback reason (required when rolling back):** When a `FirmwareAssignment` is created that moves a device BACK to a previous firmware version (rollback — detected by the new assignment's `version` being older than `previousFirmwareVersion`), the user MUST enter a rollback reason. Stored on `FirmwareAssignment.rollbackReason`.
+- **Existing assignments without reasons:** For FirmwareAssignment records created before this story, the `rollbackReason` field is null and displays as "Reason not recorded (historical)" in UI. No backfill.
+- **Comments are visible everywhere the action is:** Approval comments appear in the firmware version timeline (Story 20.6) and in the device lifecycle timeline (Story 27.1). Rollback reasons appear alongside the firmware event on the device lifecycle timeline.
+- **NIST SoD (AC-5):** The person adding the comment MUST be the person executing the action. System-generated approvals (automated CI gates) enter their reasons programmatically with `system` as the actor.
+
+## Acceptance Criteria
+
+- [ ] AC1: `Firmware` / `FirmwareVersion` type in `src/lib/types.ts` is extended with optional `approvalComment?: string` and `rejectionReason?: string` fields (max 1000 chars each)
+- [ ] AC2: `FirmwareAssignment` type is extended with optional `rollbackReason?: string` field
+- [ ] AC3: The firmware approval action UI (existing promote-to-next-stage button) is extended with an optional comment textarea; submission includes `approvalComment` in the mutation
+- [ ] AC4: The firmware rejection action UI is extended with a **required** rejection reason textarea (min 10 chars, max 1000); the submit button is disabled until reason is ≥ 10 chars
+- [ ] AC5: The firmware rollback UI (when the user assigns an older version to a device) is extended with a **required** rollback reason textarea (min 10 chars, max 1000); submit disabled until valid
+- [ ] AC6: A pure helper function `isRollback(newVersion: string, previousVersion: string | null): boolean` using semver comparison is added to `src/lib/firmware/firmware-version-utils.ts` and unit-tested for edge cases (null previous, equal versions, prerelease tags)
+- [ ] AC7: Mock API provider is updated so that mock firmware and assignment records include realistic example reasons (at least 3 firmware versions with approval comments, 2 rejections, 1 rollback)
+- [ ] AC8: The firmware version timeline (Story 20.6) renders approval comments and rejection reasons inline with their corresponding state-transition nodes
+- [ ] AC9: The device lifecycle timeline (Story 27.1) renders rollback reasons inline on Firmware-category events where `rollbackReason` is present
+- [ ] AC10: Unit tests cover: reason validation (min/max length), required-vs-optional distinction, rollback detection helper, historical records rendering (null reason) — with ≥ 85% coverage
+- [ ] AC11: E2E test covers: approve with comment, reject with required reason, rollback with required reason, then verifies reasons surface in both firmware timeline (20.6) and device lifecycle timeline (27.1)
+
+## UI Behavior
+
+- Approval comment textarea: placeholder "Optional: note for the audit trail (e.g., 'tested against customer sandbox, all green')"
+- Rejection reason textarea: placeholder "Required: why is this firmware rejected? (min 10 chars)"
+- Rollback reason textarea: placeholder "Required: why rollback to this older version? (min 10 chars, e.g., 'v1.1 destabilized customer X's fleet')"
+- Character counter (e.g., "42 / 1000") appears below each textarea and turns amber at > 900 chars
+- Display of existing comments/reasons uses a subtle quote-block style with a speech-bubble icon
+- Historical assignments without a rollback reason show muted text "Reason not recorded (historical)" — no alarming red/warning
+- Any comment or reason longer than 120 chars truncates in the timeline node view with a "show more" expand
+
+## Out of Scope
+
+- Structured reason taxonomies (dropdown of "CVE fix", "performance regression", etc.) — free text only for this story
+- Approval delegation trail (A approved via delegation from B) — future story
+- Editing or deleting existing comments (all comments are immutable like the audit log)
+- Backfilling historical assignment records with inferred rollback reasons
+- Multi-language reason input (English only)
+
+## Tech Spec Reference
+
+See [tech-spec.md](./tech-spec.md) for rollback detection semver rules and comment storage/retrieval strategy.
+
+## Dev Checklist (NOT for QA)
+
+1. Add `approvalComment` / `rejectionReason` fields to `Firmware` / `FirmwareVersion` type in `src/lib/types.ts`
+2. Add `rollbackReason` field to `FirmwareAssignment` type
+3. Extend mock API provider with realistic reason samples
+4. Extend `IApiProvider` mutations (`approveFirmware`, `rejectFirmware`, `assignFirmware`) to accept optional / required reasons per story rules
+5. Create `src/lib/firmware/firmware-version-utils.ts` with `isRollback()` pure helper
+6. Update approval/reject modal UI in `src/app/components/firmware/firmware-approval-actions.tsx` (or equivalent existing component)
+7. Update firmware assignment UI to detect rollback and require reason
+8. Update the firmware version timeline renderer (Story 20.6) to display comments
+9. Update the device lifecycle timeline renderer (Story 27.1) to display rollback reasons
+10. Unit tests: `firmware-version-utils.test.ts`, mutation validation tests, component tests for textarea behavior
+11. E2E test covering the full approve/reject/rollback + display flow
+
+## AutoGent Test Prompts
+
+1. **AC1-AC2 — Type additions:** "Import Firmware from types.ts. Verify it has optional properties approvalComment and rejectionReason, each typed as string | undefined. Import FirmwareAssignment. Verify it has optional property rollbackReason."
+
+2. **AC3 — Approve with optional comment:** "Navigate to a firmware in Testing stage. Click 'Approve'. Verify a comment textarea is visible with 'Optional' placeholder. Submit WITHOUT entering text. Verify submission succeeds and firmware advances to Approved."
+
+3. **AC4 — Reject requires reason:** "Navigate to a firmware in Testing. Click 'Reject'. Verify textarea is visible with 'Required' placeholder. Verify submit button is disabled. Enter 5 chars. Verify submit still disabled. Enter 15 chars. Verify submit enables. Submit. Verify rejection is recorded with the reason."
+
+4. **AC5-AC6 — Rollback detection:** "Assign v1.2 to device-001. Then initiate another assignment of v1.0 (older). Verify rollback reason textarea appears and submit is gated on ≥ 10 chars. Submit with reason 'customer regression'. Verify FirmwareAssignment record includes rollbackReason = 'customer regression'."
+
+5. **AC8 — Timeline display:** "On firmware detail page for a family with an approved version that has an approval comment, verify the comment is rendered inline in the timeline with the approval node."
+
+6. **AC9 — Lifecycle timeline rollback display:** "On the device-001 Lifecycle tab, locate the rollback Firmware event. Verify the rollback reason text is visible (or expandable if > 120 chars)."
+
+7. **AC11 — Full E2E:** "Execute approve → reject → assign rollback → display in both timelines flow, verifying all reasons surface correctly."
+
+## Definition of Done
+
+- [ ] Code reviewed and approved
+- [ ] Unit tests passing (≥ 85% coverage on new code)
+- [ ] E2E test covers approve/reject/rollback reason capture + display
+- [ ] Mock data updated with realistic samples
+- [ ] WCAG 2.1 AA — textareas have proper labels, character counters announced to screen readers
+- [ ] No changes to existing firmware state machine
+- [ ] TypeScript strict — no `any` types
+- [ ] Compliance check green

--- a/Docs/epics/epic-27/story-27.5.md
+++ b/Docs/epics/epic-27/story-27.5.md
@@ -1,0 +1,109 @@
+# Story 27.5: Device Status Transition History
+
+**Epic:** Epic 27 — Device Lifecycle 360 & Cross-Domain Timeline
+**Phase:** PHASE 2: DERIVED VIEWS
+**Persona:** Raj (Operations Manager) / Field Technician
+**Priority:** P1
+**Story Points:** 3
+**Status:** New
+**GitHub Issue:** #421
+**Target URL:** `/inventory/:deviceId` (Status tab, OR Lifecycle tab enrichment)
+
+## User Story
+
+As an operations manager, I want to see the full history of a device's status transitions (online, offline, maintenance, decommissioned) with duration in each state and the actor/source that triggered each change, so that I can diagnose stability patterns, detect flapping, and prove operational availability for SLAs.
+
+## Preconditions
+
+- Device entity has a `status` field using the `DeviceStatus` enum (online / offline / maintenance / decommissioned) in `src/lib/types.ts`
+- Audit trail captures every `Device.status` change (Epic 8)
+- `getChangeHistory(deviceId, { fields: ['status'] })` is queryable via CDC provider (Story 20.8)
+- Story 27.1 (device lifecycle timeline) is complete — this story may render either as a dedicated Status tab OR as an enriched Status-category view within the existing Lifecycle tab (see AC1)
+
+## Context / Business Rules
+
+- **No new field capture:** Status transitions are already recorded by the audit log whenever `Device.status` is updated. This story derives a **projection** and does not add new writes.
+- **Half-open intervals:** Each transition produces a record `[startAt, endAt)` where the device was in one status. `endAt` is null for the current status.
+- **Actor + source taxonomy:** Each transition is tagged with its `source`:
+  - `user` — a human changed the status via UI (actor = userId)
+  - `system` — automated heuristic (e.g., heartbeat-timeout detector changed status from online → offline; actor = "system")
+  - `device` — the device itself reported a status change (e.g., maintenance mode entered from device-side)
+  - `unknown` — source can't be determined (legacy records)
+- **Flapping detection:** A helper computes the count of transitions in the last 24 hours. If > 5, the record is flagged with a "flapping" indicator — useful for ops dashboards.
+- **Availability metric:** For any selected time window, show the percentage of time the device was in `online` status. Formula: `sum(online durations) / total window duration × 100`.
+- **Decommissioned is terminal:** Once a device transitions to `decommissioned`, subsequent changes are unusual and should be flagged (visual warning in the view). No enforcement — just visibility.
+- **Small display surface:** Prefer enriching the existing Lifecycle tab with a "Status Summary" panel rather than creating a new top-level tab — UX clarity.
+
+## Acceptance Criteria
+
+- [ ] AC1: A **Status Summary panel** is added to the top of the device Lifecycle tab (Story 27.1), above the timeline. The panel displays: current status (badge), time-in-current-status, availability % for the selected window, and a flapping indicator if applicable.
+- [ ] AC2: A `DeviceStatusTransition` view-model type is added to `src/lib/types.ts` with fields: `status` (DeviceStatus enum), `startAt`, `endAt?`, `durationMs`, `actor` (userId or 'system' or 'device' or 'unknown'), `source` (enum: user/system/device/unknown), `reason?` (if stored in metadata)
+- [ ] AC3: A `useDeviceStatusHistory(deviceId, timeRange)` hook in `src/lib/hooks/use-device-status-history.ts` derives transitions by: (a) calling `getChangeHistory(deviceId, { fields: ['status'] }, timeRange)`, (b) grouping consecutive same-status records, (c) computing half-open intervals and durations
+- [ ] AC4: A pure helper `computeAvailability(transitions, window): number` returns the online-percentage for the window, unit-tested for edge cases (empty, always-online, always-offline, window-spanning-transitions)
+- [ ] AC5: A pure helper `detectFlapping(transitions, windowMs): { count: number; isFlapping: boolean }` returns transition count in the last N ms and whether it exceeds the flapping threshold (default 5)
+- [ ] AC6: Within the Lifecycle timeline, Status-category events are enriched with duration (e.g., "online → offline (was online for 4 days 3 hours)") — the duration is computed in the view-model
+- [ ] AC7: When the device's current status is `decommissioned`, the Status Summary panel shows a muted "Decommissioned" indicator and the availability % is not calculated (N/A displayed)
+- [ ] AC8: CSV export of status transitions is available (columns: status, startAt, endAt, durationMs, actor, source, reason)
+- [ ] AC9: Unit tests cover: empty history, single-status history, multi-transition history, availability math, flapping detection, decommissioned state handling — with ≥ 85% coverage
+
+## UI Behavior
+
+- Status Summary panel is a compact row at the top of the Lifecycle tab — no vertical sprawl
+- Current status badge uses existing status color tokens (green / gray / amber / slate)
+- Time-in-current-status displays as relative string ("for 4 days 3 hours")
+- Availability % is rendered with a sparkline-thin bar showing online vs non-online proportion for the window
+- Flapping indicator: small amber chip "⚡ Flapping (6 changes in 24h)" — uses existing alert-style chip component
+- Decommissioned indicator: muted gray chip "Decommissioned" with the date
+- Status transitions in the timeline (from Story 27.1) gain a duration suffix and an actor-source icon (user silhouette, gear for system, chip icon for device)
+- CSV export button: reuse toolbar pattern from Lifecycle tab (not a separate button bar)
+
+## Out of Scope
+
+- Configurable flapping threshold per device (hardcoded to 5/24h in this story)
+- Alerting on flapping (notifications / email / pager) — future story
+- Status transition approval workflow
+- Historical actor display names that have since been renamed (use current user record)
+- Separate Status tab (we're enriching Lifecycle tab, not creating a new tab)
+
+## Tech Spec Reference
+
+See [tech-spec.md](./tech-spec.md) for availability calculation edge cases and flapping threshold rationale.
+
+## Dev Checklist (NOT for QA)
+
+1. Add `DeviceStatusTransition` type to `src/lib/types.ts`
+2. Create `src/lib/hooks/use-device-status-history.ts`
+3. Create `src/lib/mappers/device-status.mapper.ts` with pure derivation + `computeAvailability` + `detectFlapping` helpers
+4. Create `src/app/components/devices/device-status-summary.tsx` (Status Summary panel)
+5. Wire the Status Summary panel into `device-lifecycle-tab.tsx` (from Story 27.1)
+6. Enrich the timeline node renderer to show status transition duration and actor-source icon
+7. Extend mock API provider and audit data so at least one device has a realistic status history including a flapping scenario
+8. CSV export helper extending the Lifecycle CSV export
+9. Unit tests in `device-status.mapper.test.ts` and `use-device-status-history.test.ts`
+10. Storybook: "Stable device", "Flapping device", "Decommissioned device" variants of the summary panel
+
+## AutoGent Test Prompts
+
+1. **AC1 — Summary panel presence:** "Navigate to `/inventory/device-001` Lifecycle tab. Verify a Status Summary panel is visible above the timeline. Verify it shows current status badge, time-in-current-status, and availability percentage."
+
+2. **AC3-AC4 — Availability calculation:** "Seed device-030 with history: online from Jan 1 to Jan 10, offline Jan 10 to Jan 12, online Jan 12 to Jan 20. Set window to Jan 1–Jan 20 (20 days). Verify availability % = ((9 + 8) / 20) × 100 = 85%. Allow ±0.5% floating-point tolerance."
+
+3. **AC5 — Flapping detection:** "Seed device-031 with 6 status changes within the last 23 hours. Open its Lifecycle tab. Verify flapping indicator appears with count '6 changes in 24h'. Seed device-032 with 4 changes in the same window. Verify no flapping indicator."
+
+4. **AC6 — Duration in timeline:** "Open device-001 Lifecycle timeline. Locate a status transition event (e.g., online → offline). Verify the event summary includes duration text (e.g., 'was online for 4 days 3 hours')."
+
+5. **AC7 — Decommissioned handling:** "Mark device-099 as decommissioned. Open Lifecycle tab. Verify Status Summary shows 'Decommissioned' chip and availability = 'N/A'."
+
+6. **AC8 — CSV export:** "Click CSV export. Open the file. Verify columns match AC8 and row count equals the number of transitions."
+
+## Definition of Done
+
+- [ ] Code reviewed and approved
+- [ ] Unit tests passing (≥ 85% coverage on new code)
+- [ ] E2E test for Status Summary panel and flapping indicator
+- [ ] Mock data includes a flapping device and a decommissioned device
+- [ ] Storybook variants published
+- [ ] WCAG 2.1 AA — status badges and chips have screen-reader text
+- [ ] No new database tables introduced (derivation-only verified)
+- [ ] TypeScript strict — no `any` types
+- [ ] Compliance check green

--- a/Docs/epics/epic-27/tech-spec.md
+++ b/Docs/epics/epic-27/tech-spec.md
@@ -1,0 +1,359 @@
+# Epic 27 — Tech Spec: Device Lifecycle 360 & Cross-Domain Timeline
+
+## Architectural Premise
+
+**This epic adds NO new systems of record.** Every surface in Epic 27 is a **projection** over existing data: the audit log (Epic 8), CDC events (Story 20.8), firmware assignments (Story 26.9), service orders (Epic 5), and digital twin snapshots (Epic 15). The only writes this epic adds are **three optional string fields** on existing entities (Story 27.4).
+
+Therefore, the tech spec is dominated by **read-path composition** — view-models, aggregation hooks, derivation helpers, and resilience patterns. There are no new tables, no new event streams, no new permissions.
+
+## File Layout
+
+### New Types (`src/lib/types.ts` — appended, no replacements)
+
+```typescript
+// Story 27.1
+export type DeviceLifecycleCategory = "Firmware" | "Service" | "Ownership" | "Status" | "Audit";
+
+export interface DeviceLifecycleEvent {
+  id: string; // stable synthetic — `${sourceEntityType}:${sourceEntityId}:${timestamp}`
+  deviceId: string;
+  category: DeviceLifecycleCategory;
+  action: string; // e.g., "firmware.deployed", "order.closed", "status.changed"
+  actor: { userId: string; displayName: string } | { userId: "system"; displayName: "System" };
+  timestamp: string; // ISO-8601
+  summary: string; // human-readable one-liner
+  sourceEntityType: "FirmwareAssignment" | "ServiceOrder" | "AuditLog" | "DigitalTwinSnapshot";
+  sourceEntityId: string;
+  metadata?: Record<string, unknown>;
+}
+
+// Story 27.3
+export interface DeviceOwnershipRecord {
+  customerId: string;
+  customerName: string;
+  siteId?: string;
+  siteName?: string;
+  startAt: string; // ISO-8601
+  endAt: string | null; // null => current
+  durationDays: number; // computed; for open intervals = now - startAt
+  transferredBy: { userId: string; displayName: string };
+  transferReason?: string;
+}
+
+// Story 27.5
+export type DeviceStatusSource = "user" | "system" | "device" | "unknown";
+
+export interface DeviceStatusTransition {
+  status: DeviceStatus; // existing enum
+  startAt: string;
+  endAt: string | null;
+  durationMs: number;
+  actor: string; // userId | "system" | "device" | "unknown"
+  source: DeviceStatusSource;
+  reason?: string;
+}
+
+// Story 27.4 — field additions to existing types
+// Firmware / FirmwareVersion gains: approvalComment?: string; rejectionReason?: string;
+// FirmwareAssignment gains:         rollbackReason?: string;
+```
+
+### New Hooks
+
+```
+src/lib/hooks/
+├── use-device-lifecycle.ts          ← Story 27.1
+├── use-device-ownership-chain.ts    ← Story 27.3
+└── use-device-status-history.ts     ← Story 27.5
+```
+
+### New Mappers / Pure Helpers
+
+```
+src/lib/mappers/
+├── device-lifecycle.mapper.ts       ← Story 27.1 — event projections from each source
+├── device-ownership.mapper.ts       ← Story 27.3 — deriveOwnershipChainFromAuditLog()
+└── device-status.mapper.ts          ← Story 27.5 — derivation + computeAvailability + detectFlapping
+
+src/lib/firmware/
+└── firmware-version-utils.ts        ← Story 27.4 — isRollback() semver helper
+
+src/lib/rbac-lifecycle.ts            ← Story 27.2 — getDefaultLifecycleCategories() + getPermittedLifecycleCategories()
+```
+
+### New Components
+
+```
+src/app/components/devices/
+├── device-lifecycle-tab.tsx            ← Story 27.1 — container, filters, export
+├── device-lifecycle-timeline.tsx       ← Story 27.1 — vertical timeline renderer
+├── device-lifecycle-filters.tsx        ← Story 27.1 + 27.2 — date-range + category + persona defaults
+├── device-ownership-tab.tsx            ← Story 27.3
+├── device-ownership-card.tsx           ← Story 27.3
+└── device-status-summary.tsx           ← Story 27.5 — panel at top of Lifecycle tab
+```
+
+### Modified Components (existing — additive changes only)
+
+```
+src/app/components/devices/device-detail-page.tsx
+  + Add "Lifecycle" and "Ownership" tabs to existing tab list (Story 27.1, 27.3)
+
+src/app/components/firmware/firmware-approval-actions.tsx (or equivalent)
+  + Approval comment textarea (optional) — Story 27.4
+  + Rejection reason textarea (required, min 10) — Story 27.4
+
+src/app/components/firmware/firmware-assignment-modal.tsx (or equivalent)
+  + Rollback detection + required rollback reason textarea — Story 27.4
+
+src/app/components/firmware/firmware-version-timeline.tsx (from Story 20.6)
+  + Render approvalComment / rejectionReason inline with approval/rejection nodes — Story 27.4
+
+src/app/components/devices/device-reassignment-form.tsx (or equivalent)
+  + Optional transfer reason textarea; passed to mutation as metadata.transferReason — Story 27.3
+```
+
+## Aggregation Algorithm — `useDeviceLifecycle` (Story 27.1)
+
+### Parallel fetch via TanStack `useQueries`
+
+```typescript
+const results = useQueries({
+  queries: [
+    {
+      queryKey: ["lifecycle", deviceId, "audit", timeRange],
+      queryFn: () => apiProvider.getChangeHistory(deviceId, timeRange),
+    },
+    {
+      queryKey: ["lifecycle", deviceId, "firmware", timeRange],
+      queryFn: () => apiProvider.listFirmwareAssignments(deviceId, timeRange),
+    },
+    {
+      queryKey: ["lifecycle", deviceId, "service", timeRange],
+      queryFn: () => apiProvider.listServiceOrdersByDevice(deviceId, timeRange),
+    },
+  ],
+});
+```
+
+### Merge + sort
+
+Each source's raw records are projected to `DeviceLifecycleEvent[]` via a source-specific mapper in `device-lifecycle.mapper.ts`:
+
+- `projectAuditToLifecycle(entries): DeviceLifecycleEvent[]` — excludes entries already represented by a more specific source (e.g., firmware assignment changes handled by the firmware mapper, not duplicated as Audit)
+- `projectFirmwareAssignmentToLifecycle(assignments): DeviceLifecycleEvent[]` — produces Firmware-category events, including `action: "firmware.rolled_back"` when `rollbackReason` is set
+- `projectServiceOrdersToLifecycle(orders): DeviceLifecycleEvent[]` — produces Service-category events per status transition on the order
+
+Merged array is sorted by `timestamp` DESC; ties broken by category priority: `Firmware > Service > Ownership > Status > Audit`.
+
+### Resilience — partial failure
+
+If `results[i].isError === true` for any i, the hook returns:
+
+```typescript
+{
+  events: DeviceLifecycleEvent[],   // from successful sources
+  unavailableSources: ("Audit" | "Firmware" | "Service")[],
+  isLoading: boolean,
+}
+```
+
+The Lifecycle tab renders a warning banner listing `unavailableSources`, and continues to render whatever events ARE available. **A single source failure MUST NOT blank the timeline.**
+
+## Ownership Chain Derivation (Story 27.3)
+
+### Input
+
+- `AuditLogEntry[]` filtered to entries where `resourceType === "Device"`, `resourceId === deviceId`, and the change payload touched `customerId` or `siteId`
+- Device's `createdAt` and current `customerId` (anchor for the first record)
+
+### Algorithm (in `device-ownership.mapper.ts`)
+
+```typescript
+export function deriveOwnershipChainFromAuditLog(
+  entries: AuditLogEntry[],
+  device: Pick<Device, "createdAt" | "customerId" | "siteId">,
+): DeviceOwnershipRecord[] {
+  // 1. Sort entries ascending by timestamp
+  // 2. Seed the chain with an open-ended record from device.createdAt → (first change OR now)
+  //    using the customerId as of device.createdAt (read from entry.oldValue of first change, or current if none)
+  // 3. Iterate entries: for each customerId/siteId change, close the previous open record
+  //    (endAt = entry.timestamp), and open a new one
+  // 4. Final record has endAt = null (current)
+  // 5. Compute durationDays for each record (for open => now - startAt)
+  // 6. Enrich with customerName / siteName via a fetch keyed by customer IDs encountered
+}
+```
+
+### CustomerAdmin scoping
+
+After derivation, if the current user is a CustomerAdmin scoped to `customerId = X`, filter out records where `record.customerId !== X`. Enforced in the hook, not in UI — so mock dev data with multiple customers still tests this correctly.
+
+## Status History + Availability (Story 27.5)
+
+### Derivation
+
+Same pattern as ownership chain — filter audit entries to `resourceType === "Device"` + `changes.status`, group into half-open intervals.
+
+### Availability calculation
+
+```typescript
+export function computeAvailability(
+  transitions: DeviceStatusTransition[],
+  window: { start: string; end: string },
+): number {
+  const totalMs = Date.parse(window.end) - Date.parse(window.start);
+  if (totalMs <= 0) return 0;
+
+  const onlineMs = transitions
+    .filter((t) => t.status === "online")
+    .reduce((sum, t) => {
+      // clip each transition to window bounds
+      const startMs = Math.max(Date.parse(t.startAt), Date.parse(window.start));
+      const endMs = Math.min(t.endAt ? Date.parse(t.endAt) : Date.now(), Date.parse(window.end));
+      return sum + Math.max(0, endMs - startMs);
+    }, 0);
+
+  return (onlineMs / totalMs) * 100;
+}
+```
+
+Decommissioned devices return `NaN` (signaled as "N/A" in UI) — the caller checks `device.status === "decommissioned"` before calling.
+
+### Flapping detection
+
+```typescript
+export function detectFlapping(
+  transitions: DeviceStatusTransition[],
+  windowMs = 24 * 60 * 60 * 1000,
+  threshold = 5,
+): { count: number; isFlapping: boolean } {
+  const nowMs = Date.now();
+  const count = transitions.filter((t) => nowMs - Date.parse(t.startAt) <= windowMs).length;
+  return { count, isFlapping: count > threshold };
+}
+```
+
+## Persona → Category Mapping (Story 27.2)
+
+Defined in `src/lib/rbac-lifecycle.ts`:
+
+```typescript
+export const DEFAULT_LIFECYCLE_CATEGORIES_BY_ROLE: Record<UserRole, DeviceLifecycleCategory[]> = {
+  Admin:         ["Firmware", "Service", "Ownership", "Status", "Audit"],
+  Manager:       ["Firmware", "Service", "Ownership", "Status"],
+  Technician:    ["Firmware", "Service", "Status"],
+  Viewer:        ["Firmware", "Service", "Status"],
+  CustomerAdmin: ["Firmware", "Service", "Ownership"],
+};
+
+export const PERMITTED_LIFECYCLE_CATEGORIES_BY_ROLE: Record<UserRole, DeviceLifecycleCategory[]> = {
+  Admin:         ["Firmware", "Service", "Ownership", "Status", "Audit"],
+  Manager:       ["Firmware", "Service", "Ownership", "Status", "Audit"],
+  Technician:    ["Firmware", "Service", "Status"],
+  Viewer:        ["Firmware", "Service", "Status"],
+  CustomerAdmin: ["Firmware", "Service", "Ownership"],  // Audit hidden — tenant isolation
+};
+
+export function getDefaultLifecycleCategories(role: UserRole): DeviceLifecycleCategory[] { ... }
+export function getPermittedLifecycleCategories(role: UserRole): DeviceLifecycleCategory[] { ... }
+```
+
+### localStorage contract
+
+- **Key:** `lifecycle.filter.${role}.${deviceId}`
+- **Value:** JSON-encoded `DeviceLifecycleCategory[]` — only categories the role is permitted to see
+- **Write debounce:** 150 ms after the last toggle
+- **Reset:** delete the key; UI reapplies `getDefaultLifecycleCategories(role)`
+
+## Rollback Detection (Story 27.4)
+
+```typescript
+// src/lib/firmware/firmware-version-utils.ts
+import semver from "semver";
+
+export function isRollback(newVersion: string, previousVersion: string | null): boolean {
+  if (!previousVersion) return false;
+  // semver.coerce to tolerate non-strict versions present in mock/legacy data
+  const a = semver.coerce(newVersion);
+  const b = semver.coerce(previousVersion);
+  if (!a || !b) return false;
+  return semver.lt(a, b);
+}
+```
+
+**Edge cases covered in unit tests:**
+
+- `previousVersion === null` → false (first assignment cannot be a rollback)
+- Equal versions → false (re-assignment, not rollback)
+- Prerelease tags (e.g., `1.2.0-beta.1` → `1.1.0`) → true
+- Invalid strings (e.g., "unknown") → false (defensive)
+
+## Error Handling Strategy
+
+Errors from source queries in `useDeviceLifecycle` follow this classification — consistent with the existing `ApiError` pattern:
+
+| Error class             | Treatment in Lifecycle UI                                                                                   |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `NetworkError`          | Source excluded; banner "Audit log unavailable — network error". User can retry via a button in the banner. |
+| `AuthError`             | Source excluded; banner "Access denied for this data source". No retry.                                     |
+| `NotFoundError`         | Source excluded (treated as empty); no banner.                                                              |
+| `TimeoutError`          | Source excluded; banner includes "try again in a moment".                                                   |
+| Validation / unexpected | Source excluded; banner "Unexpected error — details logged". Error reported to logger per NIST AU-2.        |
+
+## NIST Compliance Notes
+
+- **AU-2 / AU-3:** Every timeline read is a read-only operation — no new audit writes required. However, CSV exports MUST emit an audit log entry of category `DATA_EXPORT` with `resourceType="Device"`, `resourceId=deviceId`, and metadata containing the time range and event count. Reuses the pattern from `audit-log-tab.tsx` CSV export.
+- **AC-3:** Ownership tab visibility routes through `canAccess("device.ownership", role)` — this permission must be added to `rbac.ts` if not already present. Viewer and Technician MUST return false.
+- **AC-5 (SoD):** The person writing an approval/rejection/rollback reason (Story 27.4) is the same person executing the action; no delegation in this story.
+- **SR-11 / CM-8:** Ownership chain CSV export is the compliance artifact for chain-of-custody evidence.
+
+## Testing Strategy
+
+### Unit tests (≥ 85% per story)
+
+- `device-lifecycle.mapper.test.ts` — projection correctness per source, ordering, tie-breaking
+- `use-device-lifecycle.test.ts` — merge behavior, partial-failure, empty-state, large-result pagination
+- `device-ownership.mapper.test.ts` — empty, single, multi-transfer, missing siteId, CustomerAdmin scoping
+- `device-status.mapper.test.ts` — availability math (including clipping at window bounds), flapping thresholds
+- `firmware-version-utils.test.ts` — isRollback edge cases
+- `rbac-lifecycle.test.ts` — default + permitted category mapping for all 5 roles
+
+### Integration tests
+
+- TanStack query cache invalidation on device or firmware mutation
+- localStorage persist/restore across page reloads
+- Error boundary resilience (simulate 500 from a single source)
+
+### E2E tests (Playwright Java)
+
+- `LifecycleTabSmokeTest` — tab visibility, events render, filter toggling, CSV export
+- `OwnershipChainE2ETest` — transfer with reason, chain display, CSV export, RBAC scoping
+- `FirmwareReasonCaptureE2ETest` — approve/reject/rollback flows with reason capture, display in firmware + device timelines
+- `StatusHistoryE2ETest` — Status Summary panel, flapping detection, decommissioned handling
+
+### Storybook coverage
+
+- `DeviceLifecycleTimeline` — empty, loading, mixed events, partial-failure, single category
+- `DeviceOwnershipCard` — active, historical, with/without reason, CustomerAdmin-scoped
+- `DeviceStatusSummary` — stable, flapping, decommissioned
+
+## What This Tech Spec Does NOT Cover
+
+Consistent with the epic's composition-only philosophy:
+
+- **No new DynamoDB table design** — all data sources already exist
+- **No new Lambda functions** — existing audit processor and mock adapters are sufficient
+- **No new AppSync resolvers** — reads use existing `getChangeHistory` / `listFirmwareAssignments` / `listServiceOrders`
+- **No new RBAC actions** beyond the single `device.ownership` view permission
+- **No new infra module in `infra/reference/aws-terraform/`** — zero infra changes
+
+## Delivery Order
+
+1. **Sprint 1 — Foundation**
+   - 27.1 (Per-Device Unified Lifecycle Timeline) — blocks 27.2, 27.5
+   - 27.2 (Persona-Aware Filtering) — straightforward overlay on 27.1
+2. **Sprint 2 — Derived Views + Field Additions**
+   - 27.3 (Ownership Chain)
+   - 27.4 (Approval Comments + Rollback Reasons)
+   - 27.5 (Status History) — depends on 27.1 for the Lifecycle tab host


### PR DESCRIPTION
## Summary

Adds planning artifacts for **Epic 27 — Device Lifecycle 360 & Cross-Domain Timeline**:

- `epic-27-overview.md` — vision, architecture principles, enterprise standards, 5-story roadmap, explicit out-of-scope list
- `story-27.1.md` — Per-Device Unified Lifecycle Timeline (8 pts, P0)
- `story-27.2.md` — Persona-Aware Timeline Filtering (5 pts, P0)
- `story-27.3.md` — Device Ownership / Custody Chain View (5 pts, P1)
- `story-27.4.md` — Firmware Approval Comments & Rollback Reasons (3 pts, P1)
- `story-27.5.md` — Device Status Transition History (3 pts, P1)
- `tech-spec.md` — types, hooks, derivation algorithms, error handling, NIST notes, test strategy

**Total: 24 story points, zero new database tables, zero new infra.**

## Composition philosophy

This epic is **presentation over capture**. Every story projects over existing systems of record:
- Audit log (Epic 8) — already captures all entity changes
- CDC events (Story 20.8 — closed) — already provides `getChangeHistory`
- `FirmwareAssignment` (Story 26.9) — already tracks firmware deployment history
- Service orders (Epic 5) — already queryable per device
- Digital Twin snapshots (Epic 15) — already retains 180-day state

Net-new additions are limited to three optional string fields (Story 27.4: `approvalComment`, `rejectionReason`, `rollbackReason`).

## Story Issues

- #417 — [Story 27.1]
- #418 — [Story 27.2]
- #419 — [Story 27.3]
- #420 — [Story 27.4]
- #421 — [Story 27.5]

## Test plan

- [ ] Review `epic-27-overview.md` for alignment with enterprise template vision
- [ ] Review `tech-spec.md` algorithms (aggregation, derivation, availability math)
- [ ] Verify each story's ACs are testable and have matching AutoGent prompts
- [ ] Confirm "Out of Scope" list in overview captures what was deliberately deferred (location history, config snapshots, temporal "state at T", optimistic locking)
- [ ] Verify epic numbering does not collide with existing labels (epic:27 now created)

Refs #417 #418 #419 #420 #421

Co-Authored-By: Claude Opus 4.6 (1M context)