### PR TITLE
[Story 27.4] Firmware approval/rollback reasons — Phase 1 (types + utils + mocks)

### DIFF
--- a/src/__tests__/lib/firmware/firmware-version-utils.test.ts
+++ b/src/__tests__/lib/firmware/firmware-version-utils.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import { isRollback, parseVersion } from "@/lib/firmware/firmware-version-utils";
+
+describe("parseVersion", () => {
+  it("parses plain semver", () => {
+    expect(parseVersion("1.2.3")).toEqual([1, 2, 3]);
+  });
+
+  it("strips a leading v", () => {
+    expect(parseVersion("v4.1.0")).toEqual([4, 1, 0]);
+    expect(parseVersion("V4.1.0")).toEqual([4, 1, 0]);
+  });
+
+  it("ignores prerelease and build metadata", () => {
+    expect(parseVersion("1.2.0-beta.1")).toEqual([1, 2, 0]);
+    expect(parseVersion("1.2.0+meta")).toEqual([1, 2, 0]);
+    expect(parseVersion("v1.2.0-rc.1+sha123")).toEqual([1, 2, 0]);
+  });
+
+  it("returns null for malformed strings", () => {
+    expect(parseVersion("unknown")).toBeNull();
+    expect(parseVersion("")).toBeNull();
+    expect(parseVersion("1.2")).toBeNull();
+    expect(parseVersion("v1")).toBeNull();
+    expect(parseVersion("abc.def.ghi")).toBeNull();
+  });
+});
+
+describe("isRollback", () => {
+  describe("returns false when rollback is not possible", () => {
+    it("no previous version (first assignment)", () => {
+      expect(isRollback("v1.0.0", null)).toBe(false);
+      expect(isRollback("v1.0.0", undefined)).toBe(false);
+      expect(isRollback("v1.0.0", "")).toBe(false);
+    });
+
+    it("equal versions (re-assignment, not rollback)", () => {
+      expect(isRollback("v1.2.3", "v1.2.3")).toBe(false);
+      expect(isRollback("1.2.3", "v1.2.3")).toBe(false);
+      expect(isRollback("v1.2.0-beta.1", "v1.2.0")).toBe(false);
+    });
+
+    it("forward upgrade (patch, minor, major)", () => {
+      expect(isRollback("v1.0.1", "v1.0.0")).toBe(false);
+      expect(isRollback("v1.1.0", "v1.0.5")).toBe(false);
+      expect(isRollback("v2.0.0", "v1.9.9")).toBe(false);
+    });
+
+    it("unparseable new version (defensive)", () => {
+      expect(isRollback("unknown", "v1.0.0")).toBe(false);
+      expect(isRollback("", "v1.0.0")).toBe(false);
+    });
+
+    it("unparseable previous version (defensive)", () => {
+      expect(isRollback("v1.0.0", "unknown")).toBe(false);
+    });
+  });
+
+  describe("returns true for genuine rollbacks", () => {
+    it("patch downgrade", () => {
+      expect(isRollback("v1.0.0", "v1.0.1")).toBe(true);
+      expect(isRollback("v4.0.2", "v4.1.0")).toBe(true);
+    });
+
+    it("minor downgrade", () => {
+      expect(isRollback("v1.0.5", "v1.1.0")).toBe(true);
+      expect(isRollback("v3.9.0", "v4.0.2")).toBe(true);
+    });
+
+    it("major downgrade", () => {
+      expect(isRollback("v1.9.9", "v2.0.0")).toBe(true);
+    });
+
+    it("prerelease new version to stable prior", () => {
+      // "1.2.0-beta.1" coerces to [1,2,0]; previous "1.3.0" → rollback.
+      expect(isRollback("1.2.0-beta.1", "1.3.0")).toBe(true);
+    });
+
+    it("handles mixed v-prefix on either side", () => {
+      expect(isRollback("1.0.0", "v2.0.0")).toBe(true);
+      expect(isRollback("v1.0.0", "2.0.0")).toBe(true);
+    });
+  });
+});

--- a/src/lib/firmware/firmware-version-utils.ts
+++ b/src/lib/firmware/firmware-version-utils.ts
@@ -1,0 +1,73 @@
+/**
+ * Firmware version utilities — pure helpers for working with semver strings
+ * produced by the firmware pipeline.
+ *
+ * These utilities are deliberately self-contained (no `semver` npm dep) because
+ * our version strings come from a controlled internal source and only ever need
+ * major.minor.patch ordering for the handful of operations called out by the
+ * Story 27.4 (#420) and Epic 4 firmware flows.
+ *
+ * @see Story 27.4 — Firmware Approval Comments & Rollback Reasons (#420)
+ */
+
+/**
+ * Parses a firmware version string into a [major, minor, patch] tuple.
+ *
+ * Accepts (and strips):
+ *   - optional leading `v` / `V` (e.g. `v4.1.0`)
+ *   - optional prerelease / build suffix (e.g. `1.2.0-beta.1`, `1.2.0+meta`)
+ *
+ * Returns `null` for malformed input so callers can fall back safely.
+ *
+ * @example
+ *   parseVersion("v4.1.0")         // [4, 1, 0]
+ *   parseVersion("1.2.0-beta.1")   // [1, 2, 0]
+ *   parseVersion("unknown")        // null
+ */
+export function parseVersion(v: string): readonly [number, number, number] | null {
+  const match = v.match(/^[vV]?(\d+)\.(\d+)\.(\d+)/);
+  if (!match) return null;
+  const [, major, minor, patch] = match;
+  return [Number(major), Number(minor), Number(patch)];
+}
+
+/**
+ * Returns `true` when `newVersion` is strictly older (lower semver) than
+ * `previousVersion` — i.e. the assignment is a rollback.
+ *
+ * Policy:
+ *   - `previousVersion === null | undefined` → `false` (first assignment is
+ *     never a rollback)
+ *   - Equal versions → `false` (re-assignment of the same version is not a
+ *     rollback)
+ *   - Unparseable version strings → `false` (defensive; let the UI treat
+ *     the assignment as an ordinary forward move and require explicit user
+ *     confirmation if needed)
+ *
+ * Used by the firmware assignment flow to decide whether to require the
+ * `rollbackReason` field per Story 27.4 (#420) AC5.
+ *
+ * @example
+ *   isRollback("v1.0.0", "v1.2.0")       // true
+ *   isRollback("v1.2.0", "v1.2.0")       // false
+ *   isRollback("v1.2.0", "v1.0.0")       // false (forward)
+ *   isRollback("v1.0.0", null)           // false (first assignment)
+ *   isRollback("1.2.0-beta.1", "1.1.0")  // true (prerelease strips)
+ *   isRollback("unknown", "v1.0.0")      // false (defensive)
+ */
+export function isRollback(
+  newVersion: string,
+  previousVersion: string | null | undefined,
+): boolean {
+  if (!previousVersion) return false;
+  const next = parseVersion(newVersion);
+  const prev = parseVersion(previousVersion);
+  if (!next || !prev) return false;
+  for (let i = 0; i < 3; i++) {
+    const n = next[i]!;
+    const p = prev[i]!;
+    if (n < p) return true;
+    if (n > p) return false;
+  }
+  return false; // equal
+}

--- a/src/lib/mock-data/firmware-assignment-data.ts
+++ b/src/lib/mock-data/firmware-assignment-data.ts
@@ -122,6 +122,27 @@ export const MOCK_FIRMWARE_ASSIGNMENTS: FirmwareAssignment[] = [
     assignedAt: "2025-09-12T09:15:00Z",
     assignmentMethod: "OTA",
   },
+
+  // --- Rollback example (Story 27.4, #420) ---
+  // Device 1 was briefly on v4.1.0 (fa-001 assigned 2026-04-04) but rolled back
+  // to v4.0.2 the next day after a regression was observed in the field. The
+  // `rollbackReason` field is required per Story 27.4 AC5.
+  {
+    id: "fa-009",
+    deviceId: "dev-001",
+    deviceName: "SG-3600-INV-001",
+    firmwareId: "fw-004",
+    firmwareVersion: "v4.0.2",
+    firmwareName: "INV-3200 Controller",
+    assignedBy: "u-admin-01",
+    assignedByEmail: "admin@hlm.com",
+    assignedAt: "2026-04-05T08:00:00Z",
+    assignmentMethod: "MANUAL",
+    previousFirmwareId: "fw-001",
+    previousFirmwareVersion: "v4.1.0",
+    rollbackReason:
+      "v4.1.0 caused intermittent MPPT disconnections at Shanghai HQ under peak-load conditions. Rolling back to last known-good v4.0.2 while engineering prepares a hotfix. Ref: incident INC-2026-0405-001.",
+  },
 ];
 
 /**

--- a/src/lib/mock-data/firmware-version-data.ts
+++ b/src/lib/mock-data/firmware-version-data.ts
@@ -35,6 +35,8 @@ const FAM1_V1_EVENTS: FirmwareVersionEvent[] = [
     timestamp: "2025-08-15T14:00:00Z",
     description: "Passed IEC 62443 compliance review",
     metadata: { reviewId: "GP-2025-1842", score: "94" },
+    approvalComment:
+      "Clean pass against IEC 62443-4-2 SL-2. Thermal envelope validated against extended-temp lab profile. No blocking findings.",
   },
   {
     id: "evt-104",
@@ -72,6 +74,8 @@ const FAM1_V1_1_EVENTS: FirmwareVersionEvent[] = [
     timestamp: "2025-10-08T16:00:00Z",
     description: "Failed — unsigned driver component detected",
     metadata: { reason: "Unsigned driver: pwr_ctrl_thermal.sys", reviewId: "GP-2025-2104" },
+    rejectionReason:
+      "Driver pwr_ctrl_thermal.sys is shipped unsigned — this breaks Windows kernel-mode driver signing enforcement on customer endpoints. Re-submit after signing with the production CA.",
   },
 ];
 
@@ -100,6 +104,8 @@ const FAM1_V1_2_EVENTS: FirmwareVersionEvent[] = [
     timestamp: "2025-10-22T11:00:00Z",
     description: "Passed compliance review — all drivers signed",
     metadata: { reviewId: "GP-2025-2201", score: "97" },
+    approvalComment:
+      "Re-submission resolves the unsigned-driver issue from v1.1.0. All binaries now signed by the production CA (cert: CA-PROD-2025-09). Approved for rollout.",
   },
   {
     id: "evt-124",
@@ -238,6 +244,8 @@ const FAM3_V3_0_EVENTS: FirmwareVersionEvent[] = [
     timestamp: "2026-01-14T11:00:00Z",
     description: "Passed IEC 62443 + NIST 800-53 review",
     metadata: { reviewId: "GP-2026-0102", score: "96" },
+    approvalComment:
+      "Full SL-2 + NIST AC/AU/SI alignment verified. Grid-synchronization module tested across all APAC frequency profiles. Approved for regulated customer deployment.",
   },
   {
     id: "evt-304",
@@ -269,11 +277,17 @@ const FAM3_V3_1_EVENTS: FirmwareVersionEvent[] = [
   },
   {
     id: "evt-313",
-    type: "NOTE",
+    type: "REJECTED",
     actor: "compliance.team@guidepoint.com",
     actorRole: "Admin",
-    timestamp: "2026-03-20T10:00:00Z",
-    description: "Review in progress — awaiting lab test results for grid sync module",
+    timestamp: "2026-03-25T10:00:00Z",
+    description: "Failed grid-sync lab test — anti-islanding threshold out of tolerance",
+    metadata: {
+      reason: "Anti-islanding disconnect time 2.4s (spec: <=2.0s)",
+      reviewId: "GP-2026-0318",
+    },
+    rejectionReason:
+      "Anti-islanding disconnect time measured at 2.4 seconds under 60 Hz profile; IEEE 1547 requires <= 2.0 s. Re-tune the grid_sync.c PLL coefficients and re-submit with updated lab certificate.",
   },
 ];
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -112,6 +112,10 @@ export interface Firmware {
   familyId?: string;
   /** Lifecycle state for secure distribution (#355) */
   lifecycleState?: FirmwareLifecycleState;
+  /** Optional approver's note captured at stage promotion (Story 27.4, #420) */
+  approvalComment?: string;
+  /** Required reason when firmware is rejected at any stage (Story 27.4, #420) */
+  rejectionReason?: string;
 }
 
 /** Firmware family — groups versions under a product line (#354) */
@@ -161,6 +165,12 @@ export interface FirmwareAssignment {
   previousFirmwareId?: string;
   previousFirmwareVersion?: string;
   downloadTokenId?: string;
+  /**
+   * Required when the assignment downgrades the device to an older version
+   * (i.e. `isRollback(firmwareVersion, previousFirmwareVersion) === true`).
+   * Story 27.4, #420.
+   */
+  rollbackReason?: string;
 }
 
 export interface ServiceOrder {

--- a/src/lib/types/firmware-version.ts
+++ b/src/lib/types/firmware-version.ts
@@ -25,6 +25,18 @@ export interface FirmwareVersionEvent {
   timestamp: string; // ISO 8601
   description: string;
   metadata?: Record<string, string>;
+  /**
+   * Optional free-text comment captured on APPROVED events (Story 27.4, #420).
+   * Max 1000 chars. Persisted on the event itself so the timeline can render
+   * it inline with the approval node.
+   */
+  approvalComment?: string;
+  /**
+   * Required free-text reason captured on REJECTED events (Story 27.4, #420).
+   * Min 10, max 1000 chars. Persisted on the event itself so the timeline can
+   * render it inline with the rejection node.
+   */
+  rejectionReason?: string;
 }
 
 /** Color category for timeline rendering per AC7 */


### PR DESCRIPTION
## Summary

Phase 1 of Story 27.4 ([#420](https://github.com/gauravmakkar29/InventoryManagement/issues/420)). Lands the **data model, pure utilities, and mock samples** so the follow-up UI work (Phase 2) can wire up without further type/mock churn.

## What's in this PR

### Types
- \`Firmware\` — \`approvalComment?\`, \`rejectionReason?\` (AC1)
- \`FirmwareVersionEvent\` — \`approvalComment?\`, \`rejectionReason?\` (AC1, scoped to the specific APPROVED/REJECTED audit event)
- \`FirmwareAssignment\` — \`rollbackReason?\` (AC2)

### Utility — \`src/lib/firmware/firmware-version-utils.ts\`
- \`parseVersion()\` — semver coercion (strips \`v\`-prefix, prerelease, build metadata)
- \`isRollback()\` — strict lower-version detection with defensive fallbacks for null, equal, and unparseable versions (AC6)

**14 unit tests** covering: null/undefined previous version, equal versions, forward upgrades (patch/minor/major), major downgrade, prerelease coercion, mixed v-prefix on either side, and unparseable inputs. Coverage >= 85% on new code. (AC6, partial AC10)

### Mock data (AC7)
- 3 \`APPROVED\` events now carry \`approvalComment\` (evt-103, evt-123, evt-303)
- 2 \`REJECTED\` events carry \`rejectionReason\` (evt-113 existing + evt-313 promoted from \`NOTE\` to \`REJECTED\` for realism)
- New \`fa-009\` rollback assignment on \`dev-001\` (v4.1.0 -> v4.0.2) with realistic \`rollbackReason\` referencing a field incident

## Not in this PR — Phase 2 follow-up

| AC | Scope | Why deferred |
|----|-------|--------------|
| AC3 | Approve UI — optional comment textarea | Requires refactoring \`firmware-lifecycle.tsx\` approval flow |
| AC4 | Reject UI — required reason textarea | Same |
| AC5 | Rollback UI — required reason textarea | Requires the firmware assignment modal UI |
| AC8 | Render comments in firmware version timeline (20.6) | Pure UI, depends on AC3/AC4 wiring |
| AC9 | Render rollback reason in device lifecycle timeline | **Blocked** — Story 27.1 isn't built yet |
| AC11 | E2E test | Blocked on UI ACs |

## Test plan

- [x] \`npx vitest run src/__tests__/lib/firmware/\` — 14/14 pass locally
- [x] \`npx eslint\` on all changed files — clean
- [x] \`npx tsc -b\` — clean
- [ ] CI \`Build & Test\` passes
- [ ] Reviewer sanity-checks the mock sample realism

## Traceability

Refs [#420](https://github.com/gauravmakkar29/InventoryManagement/issues/420) — does NOT close; UI ACs remain for Phase 2.

Co-Authored-By: Claude Opus 4.6 (1M context)