### PR TITLE
[Story 27.4] Firmware approval/rejection reasons — Phase 2 (UI + timeline)

### DIFF
--- a/src/__tests__/components/firmware/firmware-transition-panel.test.tsx
+++ b/src/__tests__/components/firmware/firmware-transition-panel.test.tsx
@@ -1,0 +1,183 @@
+/**
+ * Tests for FirmwareTransitionPanel — focused on the Story 27.4 (#420)
+ * reason-capture behavior (textarea + char counter + required-on-destructive).
+ *
+ * Non-reason concerns (role gating, SoD enforcement, transitions table) are
+ * covered by the parent firmware-lifecycle flow's own tests / Storybook.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { FirmwareTransitionPanel } from "@/app/components/firmware/firmware-lifecycle";
+import { ApprovalStage, FirmwareLifecycleState, FirmwareStatus, type Firmware } from "@/lib/types";
+
+// Use the Admin role and a different user id than `firmware.uploadedBy`
+// so that role + SoD checks allow every transition under test.
+const ROLE = "Admin" as const;
+const CURRENT_USER_ID = "user-approver-01";
+
+const MOCK_FIRMWARE: Firmware = {
+  id: "fw-test-001",
+  version: "v1.0.0",
+  name: "Test Firmware",
+  status: FirmwareStatus.Testing,
+  approvalStage: ApprovalStage.Testing,
+  releaseNotes: "test",
+  fileSize: 1024,
+  checksum: "sha256:test",
+  uploadedBy: "user-uploader-02", // distinct from CURRENT_USER_ID
+  uploadedAt: "2026-01-01T00:00:00Z",
+  compatibleModels: ["TEST"],
+  targetDeviceCount: 0,
+  deployedDeviceCount: 0,
+};
+
+function renderPanel(
+  currentState: FirmwareLifecycleState = FirmwareLifecycleState.Screening,
+  onTransition = vi.fn(),
+) {
+  const result = render(
+    <FirmwareTransitionPanel
+      firmware={MOCK_FIRMWARE}
+      currentState={currentState}
+      role={ROLE}
+      currentUserId={CURRENT_USER_ID}
+      onTransition={onTransition}
+    />,
+  );
+  return { ...result, onTransition };
+}
+
+describe("FirmwareTransitionPanel — reason capture (Story 27.4 #420)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("non-destructive transition (comment optional)", () => {
+    it("opens the textarea with an 'optional' label and no min-char requirement", async () => {
+      const user = userEvent.setup();
+      renderPanel(FirmwareLifecycleState.Screening);
+
+      // Click "Promote to Staged" — non-destructive transition
+      await user.click(screen.getByRole("button", { name: /promote to staged/i }));
+
+      const textarea = screen.getByRole("textbox");
+      expect(textarea).toBeInTheDocument();
+      expect(textarea).toHaveAttribute("aria-required", "false");
+      expect(screen.getByText(/comment \(optional\)/i)).toBeInTheDocument();
+    });
+
+    it("enables confirm with an empty reason", async () => {
+      const user = userEvent.setup();
+      const { onTransition } = renderPanel(FirmwareLifecycleState.Screening);
+
+      await user.click(screen.getByRole("button", { name: /promote to staged/i }));
+      const confirmBtn = screen.getByRole("button", { name: /confirm promote to staged/i });
+      expect(confirmBtn).toBeEnabled();
+
+      await user.click(confirmBtn);
+      expect(onTransition).toHaveBeenCalledWith(
+        MOCK_FIRMWARE.id,
+        FirmwareLifecycleState.Staged,
+        undefined, // empty reason => undefined
+      );
+    });
+
+    it("passes a trimmed reason to onTransition when provided", async () => {
+      const user = userEvent.setup();
+      const { onTransition } = renderPanel(FirmwareLifecycleState.Screening);
+
+      await user.click(screen.getByRole("button", { name: /promote to staged/i }));
+      await user.type(screen.getByRole("textbox"), "  tested in sandbox  ");
+      await user.click(screen.getByRole("button", { name: /confirm promote to staged/i }));
+
+      expect(onTransition).toHaveBeenCalledWith(
+        MOCK_FIRMWARE.id,
+        FirmwareLifecycleState.Staged,
+        "tested in sandbox",
+      );
+    });
+  });
+
+  describe("destructive transition (reason required, min 10)", () => {
+    it("labels the textarea 'required' and marks aria-required", async () => {
+      const user = userEvent.setup();
+      renderPanel(FirmwareLifecycleState.Screening);
+
+      await user.click(screen.getByRole("button", { name: /recall/i }));
+
+      const textarea = screen.getByRole("textbox");
+      expect(textarea).toHaveAttribute("aria-required", "true");
+      expect(screen.getByText(/reason \(required/i)).toBeInTheDocument();
+    });
+
+    it("disables confirm until reason reaches the minimum length", async () => {
+      const user = userEvent.setup();
+      renderPanel(FirmwareLifecycleState.Screening);
+
+      await user.click(screen.getByRole("button", { name: /recall/i }));
+      const confirmBtn = screen.getByRole("button", { name: /confirm recall/i });
+
+      // Empty
+      expect(confirmBtn).toBeDisabled();
+
+      // Under 10 chars
+      await user.type(screen.getByRole("textbox"), "short");
+      expect(confirmBtn).toBeDisabled();
+
+      // Exactly 10 chars
+      await user.clear(screen.getByRole("textbox"));
+      await user.type(screen.getByRole("textbox"), "0123456789");
+      expect(confirmBtn).toBeEnabled();
+    });
+
+    it("shows a 'need N more' hint while under the minimum", async () => {
+      const user = userEvent.setup();
+      renderPanel(FirmwareLifecycleState.Screening);
+
+      await user.click(screen.getByRole("button", { name: /recall/i }));
+      await user.type(screen.getByRole("textbox"), "seven.."); // 7 chars
+
+      // Character counter should render the remaining-chars hint
+      expect(screen.getByText(/need 3 more/i)).toBeInTheDocument();
+    });
+
+    it("forwards the validated reason to onTransition", async () => {
+      const user = userEvent.setup();
+      const { onTransition } = renderPanel(FirmwareLifecycleState.Screening);
+
+      await user.click(screen.getByRole("button", { name: /recall/i }));
+      const reason = "CVE-2026-1234 introduced a remote-code-execution path — blocking immediately";
+      await user.type(screen.getByRole("textbox"), reason);
+      await user.click(screen.getByRole("button", { name: /confirm recall/i }));
+
+      expect(onTransition).toHaveBeenCalledWith(
+        MOCK_FIRMWARE.id,
+        FirmwareLifecycleState.Recalled,
+        reason,
+      );
+    });
+  });
+
+  describe("character counter", () => {
+    it("updates as the user types", async () => {
+      const user = userEvent.setup();
+      renderPanel(FirmwareLifecycleState.Screening);
+
+      await user.click(screen.getByRole("button", { name: /promote to staged/i }));
+      const textarea = screen.getByRole("textbox");
+
+      await user.type(textarea, "hello");
+      expect(screen.getByText(/5 \/ 1000/)).toBeInTheDocument();
+    });
+
+    it("caps input at the max length via maxLength attribute", async () => {
+      renderPanel(FirmwareLifecycleState.Screening);
+
+      fireEvent.click(screen.getByRole("button", { name: /promote to staged/i }));
+      const textarea = screen.getByRole("textbox");
+      expect(textarea).toHaveAttribute("maxLength", "1000");
+    });
+  });
+});

--- a/src/__tests__/components/version-timeline.test.tsx
+++ b/src/__tests__/components/version-timeline.test.tsx
@@ -112,6 +112,39 @@ describe("VersionTimeline", () => {
     expect(items).toHaveLength(3);
   });
 
+  describe("comment rendering (Story 27.4 #420)", () => {
+    it("renders the comment as a quote block when present", () => {
+      const eventsWithComment: TimelineEvent[] = [
+        {
+          ...MOCK_EVENTS[1]!,
+          comment: "Clean pass against IEC 62443-4-2 SL-2.",
+        },
+      ];
+      render(<VersionTimeline events={eventsWithComment} />);
+
+      const quote = screen.getByText(/IEC 62443-4-2 SL-2/i);
+      expect(quote).toBeInTheDocument();
+      expect(quote.closest("blockquote")).not.toBeNull();
+      expect(quote.closest("blockquote")).toHaveAttribute(
+        "aria-label",
+        `Note from ${MOCK_EVENTS[1]!.actor}`,
+      );
+    });
+
+    it("omits the quote block when comment is absent", () => {
+      render(<VersionTimeline events={MOCK_EVENTS} />);
+      expect(document.querySelector("blockquote")).toBeNull();
+    });
+
+    it("omits the quote block for whitespace-only comments", () => {
+      const eventsWithWhitespaceComment: TimelineEvent[] = [
+        { ...MOCK_EVENTS[1]!, comment: "   \n   " },
+      ];
+      render(<VersionTimeline events={eventsWithWhitespaceComment} />);
+      expect(document.querySelector("blockquote")).toBeNull();
+    });
+  });
+
   it("renders time elements with dateTime attribute", () => {
     render(<VersionTimeline events={MOCK_EVENTS} />);
 

--- a/src/app/components/firmware/firmware-detail-page.tsx
+++ b/src/app/components/firmware/firmware-detail-page.tsx
@@ -72,6 +72,8 @@ function mapVersionEvents(version: FirmwareVersion): TimelineEvent[] {
     description: evt.description,
     color: EVENT_COLOR_MAP[evt.type],
     metadata: evt.metadata,
+    // Story 27.4 (#420) — surface approver/rejecter note on the corresponding event
+    comment: evt.approvalComment ?? evt.rejectionReason,
   }));
 }
 

--- a/src/app/components/firmware/firmware-lifecycle.tsx
+++ b/src/app/components/firmware/firmware-lifecycle.tsx
@@ -295,15 +295,27 @@ export function FirmwareTransitionPanel({
     [role, firmware.uploadedBy, currentUserId],
   );
 
+  // Story 27.4 (#420) AC4: destructive transitions (Recall) require a reason
+  // with a minimum length so the audit trail carries actionable context.
+  const REASON_MIN_LENGTH = 10;
+  const REASON_MAX_LENGTH = 1000;
+
+  const trimmedReason = reason.trim();
+  const reasonRequired = confirmingTransition?.destructive ?? false;
+  const reasonValid = reasonRequired
+    ? trimmedReason.length >= REASON_MIN_LENGTH && trimmedReason.length <= REASON_MAX_LENGTH
+    : trimmedReason.length <= REASON_MAX_LENGTH;
+
   const handleConfirm = useCallback(() => {
     if (!confirmingTransition) return;
-    onTransition(firmware.id, confirmingTransition.to, reason || undefined);
+    if (!reasonValid) return; // safety net — button should already be disabled
+    onTransition(firmware.id, confirmingTransition.to, trimmedReason || undefined);
     toast.success(
       `Firmware ${firmware.name} transitioned to ${STATE_CONFIG[confirmingTransition.to].label}`,
     );
     setConfirmingTransition(null);
     setReason("");
-  }, [confirmingTransition, firmware, onTransition, reason]);
+  }, [confirmingTransition, firmware, onTransition, trimmedReason, reasonValid]);
 
   if (transitions.length === 0) {
     return (
@@ -323,27 +335,56 @@ export function FirmwareTransitionPanel({
           <div>
             <label
               htmlFor="transition-reason"
-              className="block text-[13px] font-medium text-muted-foreground mb-1"
+              className="mb-1 block text-[13px] font-medium text-muted-foreground"
             >
-              Reason (optional)
+              {reasonRequired
+                ? `Reason (required, min ${REASON_MIN_LENGTH} chars)`
+                : "Comment (optional)"}
             </label>
-            <input
+            <textarea
               id="transition-reason"
-              type="text"
+              rows={3}
               value={reason}
               onChange={(e) => setReason(e.target.value)}
-              placeholder="Enter reason for this transition..."
-              className="w-full rounded border border-border bg-card px-2.5 py-1.5 text-[14px] text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring/50"
+              maxLength={REASON_MAX_LENGTH}
+              placeholder={
+                reasonRequired
+                  ? "Required: why are you rejecting/recalling this firmware? (min 10 chars — e.g. 'v4.1.0 introduced MPPT disconnects at Shanghai HQ — rolling back pending hotfix')"
+                  : "Optional: note for the audit trail (e.g. 'tested against customer sandbox, all green')"
+              }
+              aria-describedby="transition-reason-counter"
+              aria-required={reasonRequired}
+              aria-invalid={reasonRequired && !reasonValid ? true : undefined}
+              className="w-full resize-y rounded border border-border bg-card px-2.5 py-1.5 text-[14px] text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring/50"
             />
+            <div
+              id="transition-reason-counter"
+              className={cn(
+                "mt-1 text-right text-[11px]",
+                trimmedReason.length > 900
+                  ? "text-warning-text"
+                  : reasonRequired && !reasonValid
+                    ? "text-danger-text"
+                    : "text-muted-foreground",
+              )}
+              aria-live="polite"
+            >
+              {trimmedReason.length} / {REASON_MAX_LENGTH}
+              {reasonRequired && trimmedReason.length < REASON_MIN_LENGTH && (
+                <span className="ml-2">(need {REASON_MIN_LENGTH - trimmedReason.length} more)</span>
+              )}
+            </div>
           </div>
           <div className="flex gap-2">
             <button
               onClick={handleConfirm}
+              disabled={!reasonValid}
               className={cn(
                 "rounded-lg px-3 py-1.5 text-[14px] font-medium text-white cursor-pointer",
                 confirmingTransition.destructive
                   ? "bg-danger hover:bg-danger"
                   : "bg-accent hover:bg-accent-hover",
+                !reasonValid && "cursor-not-allowed opacity-50",
               )}
             >
               Confirm {confirmingTransition.label}

--- a/src/app/components/shared/version-timeline.tsx
+++ b/src/app/components/shared/version-timeline.tsx
@@ -4,7 +4,7 @@
 // =============================================================================
 
 import { useMemo } from "react";
-import { Clock, User } from "lucide-react";
+import { Clock, MessageSquareQuote, User } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 // ---------------------------------------------------------------------------
@@ -22,6 +22,13 @@ export interface TimelineEvent {
   description: string;
   color: TimelineEventColor;
   metadata?: Record<string, string>;
+  /**
+   * Optional free-text comment attached to the event — used by Story 27.4 (#420)
+   * to surface firmware approval notes and rejection reasons inline with the
+   * corresponding timeline node. When present, rendered as a subtle quote-style
+   * block under the description.
+   */
+  comment?: string;
 }
 
 interface VersionTimelineProps {
@@ -115,6 +122,19 @@ function TimelineEntry({ event, isLast }: { event: TimelineEvent; isLast: boolea
         </div>
 
         <p className="mt-1 text-[14px] text-foreground">{event.description}</p>
+
+        {event.comment && event.comment.trim().length > 0 && (
+          <blockquote
+            className="mt-2 flex gap-2 rounded-md border-l-2 border-border bg-muted/40 px-3 py-2 text-[13px] text-muted-foreground"
+            aria-label={`Note from ${event.actor}`}
+          >
+            <MessageSquareQuote
+              className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground/70"
+              aria-hidden="true"
+            />
+            <span className="italic">{event.comment}</span>
+          </blockquote>
+        )}
 
         <div className="mt-1.5 flex flex-wrap items-center gap-3 text-[12px] text-muted-foreground">
           <span className="inline-flex items-center gap-1">


### PR DESCRIPTION
## Summary

Phase 2 of Story 27.4 ([#420](https://github.com/gauravmakkar29/InventoryManagement/issues/420)). Surfaces the reason fields landed in [#427](https://github.com/gauravmakkar29/InventoryManagement/pull/427) in the UI users actually see: the firmware state-transition panel and the firmware version timeline.

## What's in this PR

### FirmwareTransitionPanel (firmware-lifecycle.tsx)
- reason input upgraded from \`<input>\` to \`<textarea rows=3, resize-y, maxLength=1000>\`
- character counter \`N / 1000\` — turns amber at > 900 chars
- **destructive transitions (Recall)**: reason is **required** (min 10 chars). Confirm button disabled and \`aria-invalid\` until valid. A \"need N more\" hint appears below the counter.
- non-destructive transitions: reason remains optional, same UX
- trimmed reason passed to \`onTransition\` (empty → \`undefined\`)

**ACs covered:** AC3 (approve/optional comment), AC4 (reject/required reason)

### version-timeline.tsx (shared)
- \`TimelineEvent\` gains optional \`comment?\` field
- When present, rendered inline below description as a subtle quote block with \`MessageSquareQuote\` icon and \`aria-label=\"Note from <actor>\"\`
- Whitespace-only comments suppressed

**ACs covered:** AC8 (render comments in firmware version timeline)

### firmware-detail-page.tsx
- \`mapVersionEvents\` now forwards \`comment: evt.approvalComment ?? evt.rejectionReason\` — so the mock samples from #427 visibly surface on APPROVED/REJECTED nodes

### Tests — 12 new assertions across 2 files
- \`firmware-transition-panel.test.tsx\` (9 tests, new file) — optional vs required behavior, char counter, \"need N more\" hint, trimmed-reason forwarding, maxLength clamp, aria-required signaling
- \`version-timeline.test.tsx\` (3 new tests) — comment quote-block rendering, absent-when-missing, whitespace-only suppression

All 21 tests across the two files pass locally. Lint clean. \`tsc -b\` clean.

## Not in this PR — deferred

| AC | Scope | Why |
|----|-------|-----|
| AC5 | Rollback reason textarea on firmware-assignment modal | **No such modal exists** in the current codebase — needs a new component. Filing follow-up. |
| AC9 | Render rollback reason on device lifecycle timeline | **Blocked** — Story 27.1 (device detail page) isn't built yet |
| AC11 | E2E test | Blocked on FirmwareTransitionPanel being wired to a live page — currently orphaned (defined, not consumed) |

## Test plan

- [x] \`npx vitest run\` on changed specs — 21/21 pass
- [x] \`npx eslint\` on all changed files — clean
- [x] \`npx tsc -b\` — clean
- [ ] CI \`Build & Test\` passes
- [ ] Reviewer: spot-check textarea interaction in a render environment

## Traceability

Refs [#420](https://github.com/gauravmakkar29/InventoryManagement/issues/420) — builds on [#427](https://github.com/gauravmakkar29/InventoryManagement/pull/427). Story still not fully closed (AC5, AC9, AC11 pending).

Co-Authored-By: Claude Opus 4.6 (1M context)