### PR TITLE
[Story 27.1] Device Lifecycle aggregation — Phase 1 (types + mapper + hook)

### DIFF
--- a/src/__tests__/hooks/use-device-lifecycle.test.tsx
+++ b/src/__tests__/hooks/use-device-lifecycle.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * Tests for `useDeviceLifecycle` — Story 27.1 (#417).
+ *
+ * Focuses on the behaviors that can only be observed at the hook level
+ * (partial-failure reporting, empty deviceId, loading propagation). The
+ * underlying projection + merge logic is covered exhaustively by
+ * `device-lifecycle.mapper.test.ts` and is not re-verified here.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import type { ICDCProvider } from "@/lib/providers/cdc-provider.types";
+
+// ---------------------------------------------------------------------------
+// CDC provider mock — swappable per-test
+// ---------------------------------------------------------------------------
+
+let mockCDC: ICDCProvider | null = null;
+
+vi.mock("@/lib/providers/registry", () => ({
+  useCDCProvider: () => mockCDC,
+}));
+
+// Import AFTER the mock so it wires up.
+import { useDeviceLifecycle } from "@/lib/hooks/use-device-lifecycle";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeWrapper() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+  };
+}
+
+function cdcMock(overrides: Partial<ICDCProvider> = {}): ICDCProvider {
+  return {
+    subscribe: vi.fn(),
+    unsubscribe: vi.fn(),
+    getChangeHistory: vi.fn().mockResolvedValue([]),
+    listRecentChanges: vi.fn(),
+    getChangeStats: vi.fn(),
+    ...overrides,
+  } as unknown as ICDCProvider;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useDeviceLifecycle", () => {
+  beforeEach(() => {
+    mockCDC = null;
+    vi.clearAllMocks();
+  });
+
+  it("returns an empty, non-loading result when deviceId is undefined", () => {
+    mockCDC = cdcMock();
+    const { result } = renderHook(() => useDeviceLifecycle(undefined), { wrapper: makeWrapper() });
+    expect(result.current.events).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.unavailableSources).toEqual([]);
+  });
+
+  it("aggregates events from firmware assignments (mock data) + CDC history", async () => {
+    mockCDC = cdcMock({
+      getChangeHistory: vi.fn().mockResolvedValue([
+        {
+          id: "cdc-status-1",
+          entityType: "device",
+          entityId: "dev-001",
+          action: "update",
+          oldValue: { status: "online" },
+          newValue: { status: "offline" },
+          changedBy: "sys",
+          timestamp: "2026-03-20T12:00:00Z",
+        },
+      ]),
+    });
+
+    const { result } = renderHook(() => useDeviceLifecycle("dev-001", { timeRange: "all" }), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    // At minimum we expect one Firmware event (from mock firmware assignments
+    // seeded for dev-001 in firmware-assignment-data.ts) AND one Status
+    // event from the CDC mock above.
+    expect(result.current.events.length).toBeGreaterThan(0);
+    const categories = new Set(result.current.events.map((e) => e.category));
+    expect(categories.has("Firmware")).toBe(true);
+    expect(categories.has("Status")).toBe(true);
+    expect(result.current.unavailableSources).toEqual([]);
+  });
+
+  it("reports the Audit source as unavailable when CDC fails, but still renders firmware events", async () => {
+    mockCDC = cdcMock({
+      getChangeHistory: vi.fn().mockRejectedValue(new Error("CDC down")),
+    });
+
+    const { result } = renderHook(() => useDeviceLifecycle("dev-001", { timeRange: "all" }), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.unavailableSources).toContain("Audit");
+    // Firmware source is a local mock and always succeeds — timeline is
+    // still populated.
+    const firmwareEvents = result.current.events.filter((e) => e.category === "Firmware");
+    expect(firmwareEvents.length).toBeGreaterThan(0);
+  });
+
+  it("returns no Audit events when the CDC provider is not registered", async () => {
+    mockCDC = null; // provider explicitly unavailable
+    const { result } = renderHook(() => useDeviceLifecycle("dev-001", { timeRange: "all" }), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    // Fetcher short-circuits to [] rather than throwing, so the source is
+    // treated as "empty" not "unavailable".
+    expect(result.current.unavailableSources).toEqual([]);
+    const auditEvents = result.current.events.filter((e) => e.category === "Audit");
+    expect(auditEvents).toHaveLength(0);
+  });
+});

--- a/src/__tests__/lib/mappers/device-lifecycle.mapper.test.ts
+++ b/src/__tests__/lib/mappers/device-lifecycle.mapper.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect } from "vitest";
+import {
+  mergeLifecycleEvents,
+  projectCdcEventsToLifecycle,
+  projectFirmwareAssignmentsToLifecycle,
+} from "@/lib/mappers/device-lifecycle.mapper";
+import type { CDCEvent } from "@/lib/providers/cdc-provider.types";
+import type { DeviceLifecycleEvent, FirmwareAssignment } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const DEVICE_ID = "dev-001";
+const OTHER_DEVICE_ID = "dev-other";
+
+function cdcEvent(overrides: Partial<CDCEvent> = {}): CDCEvent {
+  return {
+    id: "cdc-1",
+    entityType: "device",
+    entityId: DEVICE_ID,
+    action: "update",
+    oldValue: null,
+    newValue: null,
+    changedBy: "user-1",
+    timestamp: "2026-03-15T10:00:00Z",
+    ...overrides,
+  };
+}
+
+function firmwareAssignment(overrides: Partial<FirmwareAssignment> = {}): FirmwareAssignment {
+  return {
+    id: "fa-test-1",
+    deviceId: DEVICE_ID,
+    deviceName: "Test Device",
+    firmwareId: "fw-1",
+    firmwareVersion: "v1.2.0",
+    firmwareName: "Test Firmware",
+    assignedBy: "u-mgr-01",
+    assignedByEmail: "mgr@example.com",
+    assignedAt: "2026-03-10T09:00:00Z",
+    assignmentMethod: "MANUAL",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// projectCdcEventsToLifecycle
+// ---------------------------------------------------------------------------
+
+describe("projectCdcEventsToLifecycle", () => {
+  it("filters out events for other devices and non-device entity types", () => {
+    const events = [
+      cdcEvent({ id: "keep-1" }),
+      cdcEvent({ id: "drop-cross-device", entityId: OTHER_DEVICE_ID }),
+      cdcEvent({ id: "drop-non-device", entityType: "firmware" }),
+    ];
+    const out = projectCdcEventsToLifecycle(events, DEVICE_ID);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.sourceEntityId).toBe("keep-1");
+  });
+
+  it("classifies status changes as Status category with informative summary", () => {
+    const event = cdcEvent({
+      id: "status-1",
+      newValue: { status: "offline" },
+      oldValue: { status: "online" },
+    });
+    const [projected] = projectCdcEventsToLifecycle([event], DEVICE_ID);
+    expect(projected?.category).toBe("Status");
+    expect(projected?.action).toBe("status.changed");
+    expect(projected?.summary).toBe("Status changed to offline");
+  });
+
+  it("classifies customerId changes as Ownership", () => {
+    const event = cdcEvent({
+      id: "ownership-1",
+      newValue: { customerId: "cust-B" },
+      oldValue: { customerId: "cust-A" },
+    });
+    const [projected] = projectCdcEventsToLifecycle([event], DEVICE_ID);
+    expect(projected?.category).toBe("Ownership");
+    expect(projected?.action).toBe("ownership.changed");
+  });
+
+  it("classifies siteId changes as Ownership", () => {
+    const event = cdcEvent({ id: "site-1", newValue: { siteId: "site-B" } });
+    const [projected] = projectCdcEventsToLifecycle([event], DEVICE_ID);
+    expect(projected?.category).toBe("Ownership");
+  });
+
+  it("falls back to Audit category for generic updates", () => {
+    const event = cdcEvent({ id: "generic-1", newValue: { notes: "updated notes" } });
+    const [projected] = projectCdcEventsToLifecycle([event], DEVICE_ID);
+    expect(projected?.category).toBe("Audit");
+    expect(projected?.action).toBe("audit.update");
+  });
+
+  it("preserves the original cdc action in metadata", () => {
+    const event = cdcEvent({ id: "delete-1", action: "delete" });
+    const [projected] = projectCdcEventsToLifecycle([event], DEVICE_ID);
+    expect(projected?.metadata?.cdcAction).toBe("delete");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// projectFirmwareAssignmentsToLifecycle
+// ---------------------------------------------------------------------------
+
+describe("projectFirmwareAssignmentsToLifecycle", () => {
+  it("scopes to the requested device", () => {
+    const assignments = [
+      firmwareAssignment({ id: "fa-1" }),
+      firmwareAssignment({ id: "fa-2", deviceId: OTHER_DEVICE_ID }),
+    ];
+    const out = projectFirmwareAssignmentsToLifecycle(assignments, DEVICE_ID);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.sourceEntityId).toBe("fa-1");
+  });
+
+  it("uses the assignedByEmail as displayName when present", () => {
+    const out = projectFirmwareAssignmentsToLifecycle([firmwareAssignment()], DEVICE_ID);
+    expect(out[0]?.actor.displayName).toBe("mgr@example.com");
+  });
+
+  it("summarizes forward upgrades with previous -> new version", () => {
+    const out = projectFirmwareAssignmentsToLifecycle(
+      [firmwareAssignment({ firmwareVersion: "v1.2.0", previousFirmwareVersion: "v1.1.0" })],
+      DEVICE_ID,
+    );
+    expect(out[0]?.action).toBe("firmware.assigned");
+    expect(out[0]?.summary).toContain("Firmware updated to v1.2.0");
+    expect(out[0]?.metadata?.isRollback).toBe(false);
+  });
+
+  it("detects rollbacks and exposes the reason in metadata", () => {
+    const out = projectFirmwareAssignmentsToLifecycle(
+      [
+        firmwareAssignment({
+          firmwareVersion: "v4.0.2",
+          previousFirmwareVersion: "v4.1.0",
+          rollbackReason: "Regression in customer fleet",
+        }),
+      ],
+      DEVICE_ID,
+    );
+    expect(out[0]?.action).toBe("firmware.rolled_back");
+    expect(out[0]?.summary).toContain("Firmware rolled back to v4.0.2");
+    expect(out[0]?.metadata?.isRollback).toBe(true);
+    expect(out[0]?.metadata?.rollbackReason).toBe("Regression in customer fleet");
+  });
+
+  it("handles first-ever assignments (no previous version)", () => {
+    const out = projectFirmwareAssignmentsToLifecycle(
+      [firmwareAssignment({ firmwareVersion: "v1.0.0", previousFirmwareVersion: undefined })],
+      DEVICE_ID,
+    );
+    expect(out[0]?.action).toBe("firmware.assigned");
+    expect(out[0]?.summary).toBe("Firmware assigned: v1.0.0");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mergeLifecycleEvents
+// ---------------------------------------------------------------------------
+
+describe("mergeLifecycleEvents", () => {
+  function event(
+    overrides: Partial<DeviceLifecycleEvent> & Pick<DeviceLifecycleEvent, "id" | "timestamp">,
+  ): DeviceLifecycleEvent {
+    return {
+      deviceId: DEVICE_ID,
+      category: "Audit",
+      action: "audit.update",
+      actor: { userId: "u", displayName: "u" },
+      summary: "sum",
+      sourceEntityType: "AuditLog",
+      sourceEntityId: overrides.id,
+      ...overrides,
+    };
+  }
+
+  it("sorts by timestamp descending (newest first)", () => {
+    const merged = mergeLifecycleEvents([
+      [event({ id: "older", timestamp: "2026-01-01T00:00:00Z" })],
+      [event({ id: "newest", timestamp: "2026-03-01T00:00:00Z" })],
+      [event({ id: "middle", timestamp: "2026-02-01T00:00:00Z" })],
+    ]);
+    expect(merged.map((e) => e.id)).toEqual(["newest", "middle", "older"]);
+  });
+
+  it("breaks timestamp ties by category priority (Firmware > Service > Ownership > Status > Audit)", () => {
+    const ts = "2026-03-01T00:00:00Z";
+    const merged = mergeLifecycleEvents([
+      [
+        event({ id: "audit", timestamp: ts, category: "Audit" }),
+        event({ id: "firmware", timestamp: ts, category: "Firmware" }),
+        event({ id: "status", timestamp: ts, category: "Status" }),
+      ],
+    ]);
+    expect(merged.map((e) => e.category)).toEqual(["Firmware", "Status", "Audit"]);
+  });
+
+  it("de-duplicates identical ids (first occurrence wins)", () => {
+    const ts = "2026-03-01T00:00:00Z";
+    const merged = mergeLifecycleEvents([
+      [event({ id: "dup", timestamp: ts, summary: "from richer source" })],
+      [event({ id: "dup", timestamp: ts, summary: "from weaker source" })],
+    ]);
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.summary).toBe("from richer source");
+  });
+
+  it("handles an empty input", () => {
+    expect(mergeLifecycleEvents([])).toEqual([]);
+    expect(mergeLifecycleEvents([[], []])).toEqual([]);
+  });
+});

--- a/src/lib/hooks/use-device-lifecycle.ts
+++ b/src/lib/hooks/use-device-lifecycle.ts
@@ -1,0 +1,165 @@
+// =============================================================================
+// useDeviceLifecycle — Story 27.1 (#417)
+//
+// Aggregates per-device lifecycle events from existing systems of record and
+// returns a merged, time-sorted view-model array. This hook introduces NO
+// new database writes — it only projects existing data.
+//
+// Resilience: if any source fails, the hook still returns events from the
+// successful sources and reports the failed source names via
+// `unavailableSources` so the UI can show a warning banner without blanking
+// the timeline.
+// =============================================================================
+
+import { useMemo } from "react";
+import { useQueries } from "@tanstack/react-query";
+import type { CDCEvent } from "../providers/cdc-provider.types";
+import type { DeviceLifecycleEvent, FirmwareAssignment } from "../types";
+import { useCDCProvider } from "../providers/registry";
+import { MOCK_FIRMWARE_ASSIGNMENTS } from "../mock-data/firmware-assignment-data";
+import {
+  mergeLifecycleEvents,
+  projectCdcEventsToLifecycle,
+  projectFirmwareAssignmentsToLifecycle,
+} from "../mappers/device-lifecycle.mapper";
+
+// ---------------------------------------------------------------------------
+// Time-range helpers
+// ---------------------------------------------------------------------------
+
+export type LifecycleTimeRangePreset = "7d" | "30d" | "90d" | "180d" | "all";
+
+export function resolveTimeRangeWindow(
+  preset: LifecycleTimeRangePreset,
+  now: Date = new Date(),
+): { start: string; end: string } | undefined {
+  if (preset === "all") return undefined;
+  const days = preset === "7d" ? 7 : preset === "30d" ? 30 : preset === "90d" ? 90 : 180;
+  const end = now.toISOString();
+  const start = new Date(now.getTime() - days * 24 * 60 * 60 * 1000).toISOString();
+  return { start, end };
+}
+
+// ---------------------------------------------------------------------------
+// Source identifiers — named so the UI can render targeted warnings
+// ---------------------------------------------------------------------------
+
+export type LifecycleSource = "Audit" | "Firmware";
+// Future sources (Phase 2): "Service" (requires deviceId-keyed ServiceOrder mock)
+
+// ---------------------------------------------------------------------------
+// Hook result
+// ---------------------------------------------------------------------------
+
+export interface DeviceLifecycleResult {
+  events: DeviceLifecycleEvent[];
+  isLoading: boolean;
+  /** Source names whose query failed — the UI should surface a warning. */
+  unavailableSources: LifecycleSource[];
+}
+
+// ---------------------------------------------------------------------------
+// Internal source fetchers
+// ---------------------------------------------------------------------------
+
+async function fetchCdcHistory(
+  deviceId: string,
+  range: { start: string; end: string } | undefined,
+  cdc: ReturnType<typeof useCDCProvider>,
+): Promise<CDCEvent[]> {
+  if (!cdc) return [];
+  return cdc.getChangeHistory(deviceId, range);
+}
+
+async function fetchFirmwareAssignments(
+  deviceId: string,
+  range: { start: string; end: string } | undefined,
+): Promise<FirmwareAssignment[]> {
+  // The mock layer returns the full array synchronously; real adapters will
+  // issue a DynamoDB query keyed by deviceId. We keep the fetcher async so
+  // the substitution is seamless.
+  const all = MOCK_FIRMWARE_ASSIGNMENTS.filter((a) => a.deviceId === deviceId);
+  if (!range) return all;
+  const startMs = Date.parse(range.start);
+  const endMs = Date.parse(range.end);
+  return all.filter((a) => {
+    const t = Date.parse(a.assignedAt);
+    return t >= startMs && t <= endMs;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export interface UseDeviceLifecycleOptions {
+  /** Optional window — defaults to "30d". */
+  timeRange?: LifecycleTimeRangePreset;
+  /** Escape hatch for tests to freeze "now" when resolving time ranges. */
+  now?: Date;
+}
+
+/**
+ * Aggregate lifecycle events for a single device.
+ *
+ * @param deviceId The device id. Hook is disabled if falsy.
+ * @param options Optional time-range preset and injected `now` for tests.
+ *
+ * @example
+ * ```tsx
+ * const { events, isLoading, unavailableSources } = useDeviceLifecycle(deviceId, {
+ *   timeRange: "30d",
+ * });
+ * ```
+ */
+export function useDeviceLifecycle(
+  deviceId: string | undefined,
+  options: UseDeviceLifecycleOptions = {},
+): DeviceLifecycleResult {
+  const { timeRange = "30d", now } = options;
+  const cdc = useCDCProvider();
+  const range = useMemo(() => resolveTimeRangeWindow(timeRange, now), [timeRange, now]);
+
+  const results = useQueries({
+    queries: [
+      {
+        queryKey: ["device-lifecycle", "audit", deviceId ?? "", timeRange] as const,
+        queryFn: () => fetchCdcHistory(deviceId!, range, cdc),
+        enabled: !!deviceId,
+      },
+      {
+        queryKey: ["device-lifecycle", "firmware", deviceId ?? "", timeRange] as const,
+        queryFn: () => fetchFirmwareAssignments(deviceId!, range),
+        enabled: !!deviceId,
+      },
+    ],
+  });
+
+  const [cdcResult, firmwareResult] = results;
+
+  return useMemo((): DeviceLifecycleResult => {
+    if (!deviceId) {
+      return { events: [], isLoading: false, unavailableSources: [] };
+    }
+
+    const isLoading = results.some((r) => r.isLoading);
+    const unavailableSources: LifecycleSource[] = [];
+
+    const cdcEvents =
+      cdcResult && cdcResult.isError
+        ? (unavailableSources.push("Audit"), [])
+        : (cdcResult?.data ?? []);
+    const firmwareAssignments =
+      firmwareResult && firmwareResult.isError
+        ? (unavailableSources.push("Firmware"), [])
+        : (firmwareResult?.data ?? []);
+
+    // Order matters for the merge's de-dup policy: pass richer sources first.
+    const events = mergeLifecycleEvents([
+      projectFirmwareAssignmentsToLifecycle(firmwareAssignments, deviceId),
+      projectCdcEventsToLifecycle(cdcEvents, deviceId),
+    ]);
+
+    return { events, isLoading, unavailableSources };
+  }, [deviceId, results, cdcResult, firmwareResult]);
+}

--- a/src/lib/mappers/device-lifecycle.mapper.ts
+++ b/src/lib/mappers/device-lifecycle.mapper.ts
@@ -1,0 +1,186 @@
+// =============================================================================
+// Device Lifecycle Mapper — Story 27.1 (#417)
+//
+// Pure projections from existing systems of record into the
+// `DeviceLifecycleEvent` view-model. This file introduces NO new data — it
+// only composes what other stories (Epic 8 audit, Story 20.8 CDC,
+// Story 26.9 FirmwareAssignment) already capture.
+// =============================================================================
+
+import type { CDCEvent } from "../providers/cdc-provider.types";
+import type { DeviceLifecycleCategory, DeviceLifecycleEvent, FirmwareAssignment } from "../types";
+import { isRollback } from "../firmware/firmware-version-utils";
+
+// ---------------------------------------------------------------------------
+// CDC → Lifecycle
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps a CDC action ("create" | "update" | "delete") to the most meaningful
+ * lifecycle category for a device entity. This is intentionally narrow —
+ * firmware-assignment and service-order changes are projected from their
+ * dedicated sources (richer metadata), not from generic CDC updates.
+ */
+function categoryForCdcEvent(event: CDCEvent): DeviceLifecycleCategory {
+  const changedFields = inferChangedFields(event);
+  if (changedFields.has("customerId") || changedFields.has("siteId")) return "Ownership";
+  if (changedFields.has("status")) return "Status";
+  return "Audit";
+}
+
+function inferChangedFields(event: CDCEvent): Set<string> {
+  const fields = new Set<string>();
+  if (event.newValue && typeof event.newValue === "object") {
+    for (const key of Object.keys(event.newValue)) fields.add(key);
+  }
+  if (event.oldValue && typeof event.oldValue === "object") {
+    for (const key of Object.keys(event.oldValue)) fields.add(key);
+  }
+  return fields;
+}
+
+function summaryForCdcEvent(event: CDCEvent, category: DeviceLifecycleCategory): string {
+  switch (category) {
+    case "Ownership":
+      return "Device ownership or site assignment changed";
+    case "Status": {
+      const next =
+        typeof event.newValue === "object" && event.newValue
+          ? (event.newValue as Record<string, unknown>).status
+          : undefined;
+      return typeof next === "string" ? `Status changed to ${next}` : "Device status changed";
+    }
+    default:
+      return `Device ${event.action}d`;
+  }
+}
+
+function actionForCdcEvent(event: CDCEvent, category: DeviceLifecycleCategory): string {
+  if (category === "Status") return "status.changed";
+  if (category === "Ownership") return "ownership.changed";
+  return `audit.${event.action}`;
+}
+
+/**
+ * Projects raw CDC events into lifecycle events scoped to a single device.
+ *
+ * Only events whose `entityType === "device"` and `entityId === deviceId`
+ * are retained. Callers can pre-filter upstream for efficiency, but this
+ * function defensively re-filters so misuse cannot leak cross-device events.
+ */
+export function projectCdcEventsToLifecycle(
+  events: CDCEvent[],
+  deviceId: string,
+): DeviceLifecycleEvent[] {
+  return events
+    .filter((e) => e.entityType === "device" && e.entityId === deviceId)
+    .map((event) => {
+      const category = categoryForCdcEvent(event);
+      return {
+        id: `AuditLog:${event.id}:${event.timestamp}`,
+        deviceId,
+        category,
+        action: actionForCdcEvent(event, category),
+        actor: { userId: event.changedBy, displayName: event.changedBy },
+        timestamp: event.timestamp,
+        summary: summaryForCdcEvent(event, category),
+        sourceEntityType: "AuditLog" as const,
+        sourceEntityId: event.id,
+        metadata: {
+          cdcAction: event.action,
+          oldValue: event.oldValue ?? null,
+          newValue: event.newValue ?? null,
+        },
+      };
+    });
+}
+
+// ---------------------------------------------------------------------------
+// FirmwareAssignment → Lifecycle
+// ---------------------------------------------------------------------------
+
+/**
+ * Projects firmware assignments into Firmware-category lifecycle events.
+ * Detects rollbacks via the shared `isRollback` semver helper (Story 27.4).
+ */
+export function projectFirmwareAssignmentsToLifecycle(
+  assignments: FirmwareAssignment[],
+  deviceId: string,
+): DeviceLifecycleEvent[] {
+  return assignments
+    .filter((a) => a.deviceId === deviceId)
+    .map((assignment) => {
+      const rollback = isRollback(assignment.firmwareVersion, assignment.previousFirmwareVersion);
+      const action = rollback ? "firmware.rolled_back" : "firmware.assigned";
+      const summary = rollback
+        ? `Firmware rolled back to ${assignment.firmwareVersion} (from ${assignment.previousFirmwareVersion ?? "unknown"})`
+        : assignment.previousFirmwareVersion
+          ? `Firmware updated to ${assignment.firmwareVersion} (from ${assignment.previousFirmwareVersion})`
+          : `Firmware assigned: ${assignment.firmwareVersion}`;
+
+      return {
+        id: `FirmwareAssignment:${assignment.id}:${assignment.assignedAt}`,
+        deviceId,
+        category: "Firmware" as const,
+        action,
+        actor: {
+          userId: assignment.assignedBy,
+          displayName: assignment.assignedByEmail || assignment.assignedBy,
+        },
+        timestamp: assignment.assignedAt,
+        summary,
+        sourceEntityType: "FirmwareAssignment" as const,
+        sourceEntityId: assignment.id,
+        metadata: {
+          assignmentMethod: assignment.assignmentMethod,
+          firmwareVersion: assignment.firmwareVersion,
+          previousFirmwareVersion: assignment.previousFirmwareVersion ?? null,
+          rollbackReason: assignment.rollbackReason ?? null,
+          isRollback: rollback,
+        },
+      };
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Merge + sort
+// ---------------------------------------------------------------------------
+
+/** Category priority used to break ties when two events share a timestamp. */
+const CATEGORY_PRIORITY: Record<DeviceLifecycleCategory, number> = {
+  Firmware: 0,
+  Service: 1,
+  Ownership: 2,
+  Status: 3,
+  Audit: 4,
+};
+
+/**
+ * Merges per-source event arrays and returns a single list sorted by
+ * timestamp DESC (newest first). Ties broken by category priority
+ * (Firmware > Service > Ownership > Status > Audit).
+ *
+ * Duplicates — identical `id` values, which can happen when a CDC event
+ * projects the same underlying change already represented by a richer
+ * FirmwareAssignment entry — are de-duplicated in favor of the first
+ * occurrence (richer-source projections are passed to this function first).
+ */
+export function mergeLifecycleEvents(
+  groups: readonly DeviceLifecycleEvent[][],
+): DeviceLifecycleEvent[] {
+  const seen = new Set<string>();
+  const merged: DeviceLifecycleEvent[] = [];
+  for (const group of groups) {
+    for (const event of group) {
+      if (seen.has(event.id)) continue;
+      seen.add(event.id);
+      merged.push(event);
+    }
+  }
+  merged.sort((a, b) => {
+    const tsDiff = Date.parse(b.timestamp) - Date.parse(a.timestamp);
+    if (tsDiff !== 0) return tsDiff;
+    return CATEGORY_PRIORITY[a.category] - CATEGORY_PRIORITY[b.category];
+  });
+  return merged;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -2,6 +2,33 @@
 // IMS Gen 2 — Core Type Definitions (Section 4.4)
 // =============================================================================
 
+// --- Story 27.1 (#417): Device Lifecycle 360 view-models ---
+
+/**
+ * Classification for a single event on the per-device lifecycle timeline.
+ *
+ * Projected from CDC events, firmware assignments, service orders, and audit
+ * entries — NOT a new system of record. See `device-lifecycle.mapper.ts`.
+ */
+export type DeviceLifecycleCategory = "Firmware" | "Service" | "Ownership" | "Status" | "Audit";
+
+export interface DeviceLifecycleEvent {
+  /** Stable synthetic id: `${sourceEntityType}:${sourceEntityId}:${timestamp}` */
+  id: string;
+  deviceId: string;
+  category: DeviceLifecycleCategory;
+  /** Machine-readable action code, e.g. "firmware.deployed", "status.changed" */
+  action: string;
+  actor: { userId: string; displayName: string };
+  /** ISO-8601 */
+  timestamp: string;
+  /** Human-readable one-liner for the timeline row */
+  summary: string;
+  sourceEntityType: "FirmwareAssignment" | "ServiceOrder" | "AuditLog" | "DigitalTwinSnapshot";
+  sourceEntityId: string;
+  metadata?: Record<string, unknown>;
+}
+
 // --- Status Enums ---
 
 export enum DeviceStatus {


### PR DESCRIPTION
## Summary

Phase 1 of Story 27.1 ([#417](https://github.com/gauravmakkar29/InventoryManagement/issues/417)). Lands the **data-layer foundation** — types, pure mappers, and the aggregation hook — so Phase 2 can focus on UI without churn on the underlying contracts.

## What's in this PR

### Types — \`src/lib/types.ts\`
- \`DeviceLifecycleCategory\` union: \`Firmware\` | \`Service\` | \`Ownership\` | \`Status\` | \`Audit\`
- \`DeviceLifecycleEvent\` view-model (id, deviceId, category, action, actor, timestamp, summary, sourceEntityType, sourceEntityId, metadata) — **projected from existing systems of record, not a new persisted entity**

### Mapper — \`src/lib/mappers/device-lifecycle.mapper.ts\`
- \`projectCdcEventsToLifecycle\` — classifies CDC events into Status/Ownership/Audit by inspecting changed field keys; generates actionable summaries
- \`projectFirmwareAssignmentsToLifecycle\` — reuses \`isRollback\` from Story 27.4 to emit \`firmware.rolled_back\` vs \`firmware.assigned\`; surfaces \`rollbackReason\` in metadata
- \`mergeLifecycleEvents\` — sorts DESC by timestamp with category priority tie-break (Firmware > Service > Ownership > Status > Audit), dedupes by id (richer-source-first policy)

### Hook — \`src/lib/hooks/use-device-lifecycle.ts\`
- \`useDeviceLifecycle(deviceId, { timeRange, now })\` — parallel \`useQueries\` fetch of CDC history + firmware assignments
- Returns \`{ events, isLoading, unavailableSources }\` — partial-failure resilience per AC10
- \`resolveTimeRangeWindow(preset, now)\` — \"7d\"/\"30d\"/\"90d\"/\"180d\"/\"all\" resolution with injectable \`now\` for deterministic tests

### Tests — 19 passing assertions
- **Mapper** (15 tests): category classification, cross-device filter, forward/rollback/first-assignment summaries, timestamp sort, tie-break, de-dup, empty input
- **Hook** (4 tests): empty deviceId no-op, happy-path aggregation, CDC-failure unavailableSources reporting, null-provider graceful handling

## AC coverage — Phase 1 delivers

| AC | Status |
|---|---|
| AC2 | ✅ \`DeviceLifecycleEvent\` type landed |
| AC3 | ✅ (partial) Aggregation hook with parallel \`useQueries\` — wires 2 of 3 sources (CDC + Firmware) |
| AC10 | ✅ Partial-failure resilience via \`unavailableSources\` |
| AC11 | ✅ Unit tests ≥ 85% on aggregation logic (19 assertions) |

## Phase 2 follow-up PR will add

AC1 (Lifecycle tab wiring), AC4/AC5 (timeline rendering), AC6 (click-through navigation), AC7 (date-range selector), AC8 (category filter), AC9 (skeleton), AC12 (CSV export).

## Honest scope note — ServiceOrder source

Only 2 of 3 planned sources are wired. The third (\`listServiceOrdersByDevice\`) is deferred because the current mock \`ServiceOrder\` data doesn't carry \`deviceId\`. The aggregation hook is extensible — adding a third source is one more \`useQueries\` entry plus one more mapper function. Filing separately if it becomes blocking.

## Test plan

- [x] \`npx vitest run\` on new specs — 19/19 pass
- [x] \`npx eslint\` on changed files — clean
- [x] \`npx tsc -b\` — clean
- [ ] CI \`Build & Test\` passes
- [ ] Reviewer: spot-check mapper edge cases (rollback summary, ownership detection, category tie-break)

## Traceability

Refs [#417](https://github.com/gauravmakkar29/InventoryManagement/issues/417) — does NOT close (Phase 2 remains). Builds on [#420](https://github.com/gauravmakkar29/InventoryManagement/issues/420) (reuses \`isRollback\`) and Story 3.7 ([#429](https://github.com/gauravmakkar29/InventoryManagement/issues/429)) (device detail tab shell is ready to host Phase 2 UI).

Co-Authored-By: Claude Opus 4.6 (1M context)