### PR TITLE
docs: add Requirement, Implementation Plan, and GitHub Projects setup prompt

### DIFF
--- a/Docs/Implementation-Plan.md
+++ b/Docs/Implementation-Plan.md
@@ -1,0 +1,592 @@
+# IMS Gen 2 — Implementation Plan
+
+> **Audience:** Product Owners, Program Managers, Delivery Leads, Engineering Managers
+>
+> **Purpose:** Show _how_ the business requirements in `Requirement.md` are sequenced into deliverable increments. This document is the bridge between business scope and day-to-day execution in GitHub Projects.
+>
+> **Companion:** [`Requirement.md`](./Requirement.md) — the business requirements this plan delivers.
+>
+> **Source of truth for live status:** [GitHub Project #1 — _IMS Gen2 HLM Platform_](https://github.com/users/gauravmakkar29/projects/1). Issue counts, assignees, and status reflect the live board, not this document.
+
+---
+
+## Table of Contents
+
+1. [Delivery Approach](#1-delivery-approach)
+2. [Build Cycle Overview](#2-build-cycle-overview)
+3. [Requirement → Build → Epic → Story Traceability](#3-requirement--build--epic--story-traceability)
+4. [Build 1 — Core Platform](#4-build-1--core-platform)
+5. [Build 2 — Advanced Features](#5-build-2--advanced-features)
+6. [Build 3 — Enterprise Hardening](#6-build-3--enterprise-hardening)
+7. [Build 4 — Template & Infrastructure](#7-build-4--template--infrastructure)
+8. [Build 5 — Quality & Resilience](#8-build-5--quality--resilience)
+9. [Build 6 — Production Ready](#9-build-6--production-ready)
+10. [Cross-Build Dependency Map](#10-cross-build-dependency-map)
+11. [Milestones, Releases, Risk Register](#11-milestones-releases-risk-register)
+
+---
+
+## 1. Delivery Approach
+
+### 1.1 Principles
+
+- **Every feature starts with a GitHub Issue** — no code without a story.
+- **Stories are functional** (persona-driven acceptance criteria); technical detail lives in per-epic `tech-spec.md`.
+- **Build cycles are outcome-driven** — each cycle produces a demonstrable business outcome, not just code.
+- **Traceability is bi-directional** — requirement → build → epic → story → PR → test → release.
+- **CI gates every merge** — build, unit tests, E2E smoke, security checks.
+
+### 1.2 Cadence
+
+- 2-week iterations (configured as the `Sprint` iteration field on the GitHub Project).
+- Multiple iterations roll up into one Build Cycle.
+- Each Build Cycle closes with a stakeholder demo, a retrospective, and explicit exit-criteria sign-off.
+
+### 1.3 Artifact locations
+
+| Artifact                      | Location                                                                              |
+| ----------------------------- | ------------------------------------------------------------------------------------- |
+| Business requirements         | [`Docs/Requirement.md`](./Requirement.md)                                             |
+| Build / Epic / Story tracking | [GitHub Project #1](https://github.com/users/gauravmakkar29/projects/1)               |
+| Epic milestones               | [GitHub Milestones](https://github.com/gauravmakkar29/InventoryManagement/milestones) |
+| Story detail                  | `Docs/epics/epic-{N}/story-{N.M}.md`                                                  |
+| Per-epic tech spec            | `Docs/epics/epic-{N}/tech-spec.md`                                                    |
+| Master brief                  | `Docs/IMS-Gen2-Detailed-Project-Brief-For-Terraform.md`                               |
+
+---
+
+## 2. Build Cycle Overview
+
+IMS Gen 2 is delivered across **six build cycles**. Each cycle builds on the previous one; nothing in a later cycle can run without the capabilities delivered earlier.
+
+| Build | Name                          | Items | Epics             | Theme / Business Outcome                                                                                                                                                         |
+| ----- | ----------------------------- | ----: | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **1** | **Core Platform**             |    43 | 1–6               | Operator can sign in, see the fleet, manage firmware, schedule orders, track compliance, and review an audit trail. The product is _usable end-to-end_ at the end of this build. |
+| **2** | **Advanced Features**         |    41 | 7–12              | Executive analytics, full-text search, location intelligence, firmware supply-chain security, and first-class audit query — the product becomes _valuable to leadership_.        |
+| **3** | **Enterprise Hardening**      |    84 | 13–18, 25, 26     | Heatmaps, blast-radius, incident isolation, digital twin, theme polish, formal infrastructure, and session-security hardening — the product becomes _enterprise-grade_.          |
+| **4** | **Template & Infrastructure** |    52 | 19 (template), 26 | Extract the platform into a reusable enterprise template; formalize secure firmware distribution across tenants.                                                                 |
+| **5** | **Quality & Resilience**      |    18 | 21, 22            | Refactor state management and data layer for long-term maintainability and consistent behaviour under load.                                                                      |
+| **6** | **Production Ready**          |     5 | 23                | Final design-system consolidation and release-candidate polish for GA.                                                                                                           |
+
+> **Where this lives:** the `Release` single-select field on [GitHub Project #1](https://github.com/users/gauravmakkar29/projects/1) stores each item's build-cycle assignment. Filtering the board by `Release` reproduces the same grouping used below.
+
+---
+
+## 3. Requirement → Build → Epic → Story Traceability
+
+This is the key cross-reference. Every business requirement (`BR-XXX` from [`Requirement.md`](./Requirement.md)) is delivered by a specific epic in a specific build.
+
+| Requirement Group                               | Requirement IDs                            | Build Cycle                     | Epic(s)           |
+| ----------------------------------------------- | ------------------------------------------ | ------------------------------- | ----------------- |
+| Authentication & Access                         | BR-060 → BR-066                            | Build 1                         | Epic 1            |
+| Session & Auth Hardening                        | BR-061, BR-064, BR-066 (hardened)          | Build 3                         | Epic 25           |
+| Dashboard & KPIs                                | BR-050 → BR-054                            | Build 1, Build 2                | Epic 2, Epic 7    |
+| Executive Summary                               | BR-055                                     | Build 3                         | Epic 16           |
+| Device Inventory                                | BR-001 → BR-008                            | Build 1                         | Epic 3            |
+| Firmware Lifecycle (core)                       | BR-010 → BR-017                            | Build 1                         | Epic 4            |
+| Firmware Security (SoD formal)                  | BR-013, BR-014, BR-016, BR-017             | Build 2                         | Epic 11           |
+| Firmware Supply Chain (SBOM)                    | BR-098                                     | Build 2                         | Epic 12           |
+| Firmware Distribution (secure, multi-tenant)    | BR-101, BR-102                             | Build 3 / Build 4               | Epic 26           |
+| Service Orders                                  | BR-020 → BR-026                            | Build 1                         | Epic 5            |
+| Compliance & Vulnerability                      | BR-030 → BR-036                            | Build 1                         | Epic 6            |
+| Audit Trail (core)                              | BR-040 → BR-044                            | Build 1                         | Epic 4 (embedded) |
+| Audit Trail (formalized)                        | BR-040 → BR-044                            | Build 2                         | Epic 8            |
+| Analytics & Reporting                           | BR-050 → BR-055                            | Build 2                         | Epic 7            |
+| Geo-Location (static map)                       | BR-006, BR-090                             | Build 2                         | Epic 9            |
+| Location Intelligence (interactive, geofencing) | BR-006, BR-090                             | Build 2                         | Epic 10           |
+| Global Search                                   | BR-070 → BR-074                            | Build 2                         | Epic 18           |
+| Heatmaps & Blast Radius                         | BR-090, BR-091, BR-092                     | Build 3                         | Epic 13           |
+| Incident Isolation & Response                   | BR-093, BR-094, BR-095                     | Build 3                         | Epic 14           |
+| Digital Twin                                    | BR-096, BR-097                             | Build 3                         | Epic 15           |
+| Theme / Connectivity / KPI polish               | BR-055                                     | Build 3                         | Epic 16           |
+| Device Lifecycle 360 (passport)                 | BR-099, BR-100                             | Build 3 (Epic 27 where present) | Epic 27           |
+| Platform Infrastructure                         | (NFR: availability, scalability, security) | Build 3                         | Epic 17           |
+| External Integrations (CRM, Artifact, Scanner)  | BR-101                                     | Build 4                         | Epic 20           |
+| Reusable Template                               | (program-level goal)                       | Build 4                         | Epic 19           |
+| State Management consolidation                  | NFR: maintainability                       | Build 5                         | Epic 21           |
+| Data Layer consolidation                        | NFR: consistency                           | Build 5                         | Epic 22           |
+| Performance Optimization                        | NFR: performance                           | Build 5                         | Epic 24           |
+| Design System consolidation                     | NFR: UX, accessibility                     | Build 6                         | Epic 23           |
+
+> **How to read this table.** Pick any business requirement in `Requirement.md` → look up its group → see which build delivers it and which epic owns it. Every row ties a promise made in `Requirement.md` to a named deliverable on the GitHub board.
+
+---
+
+## 4. Build 1 — Core Platform
+
+### 4.1 Goal
+
+Deliver a **usable, end-to-end product**: an authenticated operator can see the fleet, manage firmware through a documented approval workflow, schedule service, track compliance, and review an audit trail. By the end of Build 1, the system satisfies every _core-workflow_ requirement in `Requirement.md` §7.1–§7.7.
+
+### 4.2 Exit criteria
+
+- All Epic 1–6 stories are merged and E2E tests pass on the smoke suite.
+- Stakeholder demo walks through Auth → Dashboard → Inventory → Firmware → Orders → Compliance with no blockers.
+- NIST 800-53 core controls (AC-3, AU-12, IA-2 basic, IA-5) verified.
+
+### 4.3 Epics & stories
+
+#### Epic 1 — Authentication & User Management
+
+_Secure sign-in, RBAC, and session lifecycle for every user._
+
+| Story | Persona     | Outcome                                                  |
+| ----- | ----------- | -------------------------------------------------------- |
+| 1.1   | Admin       | Log in securely with email and password                  |
+| 1.2   | Admin       | Set up multi-factor authentication via TOTP              |
+| 1.3   | Ops Manager | Maintain active sessions with automatic token refresh    |
+| 1.4   | Admin       | Enforce role-based access control across the platform    |
+| 1.5   | Admin       | Create and manage user accounts and group memberships    |
+| 1.6   | Ops Manager | Navigate protected routes with a persistent shell layout |
+
+#### Epic 2 — Dashboard & Executive Overview
+
+_Real-time KPI cards, quick actions, and system health at a glance._
+
+| Story | Persona     | Outcome                                              |
+| ----- | ----------- | ---------------------------------------------------- |
+| 2.1   | Ops Manager | View KPIs to assess fleet health                     |
+| 2.2   | Ops Manager | Access quick-action links with pending counts        |
+| 2.3   | Admin       | Monitor recent alerts and system status              |
+| 2.4   | Ops Manager | Receive real-time notifications in a slide-out panel |
+| 2.5   | Ops Manager | Mark notifications as read individually or in bulk   |
+| 2.6   | Ops Manager | Refresh dashboard data manually                      |
+
+#### Epic 3 — Inventory & Device Management
+
+_Searchable device catalogue with status filters, firmware view, and map._
+
+| Story | Persona     | Outcome                                            |
+| ----- | ----------- | -------------------------------------------------- |
+| 3.1   | Ops Manager | Search and filter devices in a sortable data table |
+| 3.2   | Ops Manager | View device firmware versions and health scores    |
+| 3.3   | Ops Manager | View device locations on an interactive world map  |
+| 3.4   | Ops Manager | Filter devices by status on the geographic map     |
+| 3.5   | Ops Manager | Export device inventory to CSV                     |
+| 3.6   | Ops Manager | Drill down on device details from any view         |
+
+#### Epic 4 — Deployment & Firmware Lifecycle
+
+_Multi-stage firmware approval with separation of duties and audit logging._
+
+| Story | Persona     | Outcome                                              |
+| ----- | ----------- | ---------------------------------------------------- |
+| 4.1   | Ops Manager | Upload firmware with checksum verification           |
+| 4.2   | Ops Manager | Advance firmware through Testing and Approval stages |
+| 4.3   | Admin       | Approve firmware with enforced separation of duties  |
+| 4.4   | Admin       | Deprecate outdated firmware versions                 |
+| 4.5   | Admin       | Search and filter audit logs by date range and user  |
+
+#### Epic 5 — Account & Service Orders
+
+_Kanban order management with calendar view and technician assignment._
+
+| Story | Persona     | Outcome                                              |
+| ----- | ----------- | ---------------------------------------------------- |
+| 5.1   | Ops Manager | Create new service orders with technician assignment |
+| 5.2   | Ops Manager | Manage order status via Kanban drag-and-drop         |
+| 5.3   | Ops Manager | View service orders on a monthly calendar            |
+| 5.4   | Ops Manager | Filter orders by status, priority, and date range    |
+| 5.5   | Ops Manager | Export service orders to CSV                         |
+
+#### Epic 6 — Compliance & Vulnerability Tracking
+
+_Compliance item lifecycle, vulnerability tracking, and regulatory reports._
+
+| Story | Persona            | Outcome                                                        |
+| ----- | ------------------ | -------------------------------------------------------------- |
+| 6.1   | Ops Manager        | Track compliance status per firmware version and certification |
+| 6.2   | Ops Manager        | View vulnerabilities linked to compliance items                |
+| 6.3   | Ops Manager        | Update vulnerability remediation status                        |
+| 6.4   | Admin              | Approve or deprecate compliance items                          |
+| 6.5   | Ops Manager        | Generate regulatory reports in CSV / JSON                      |
+| 6.6   | Compliance Auditor | Filter vulnerabilities by severity and remediation status      |
+
+### 4.4 Demoable outcome
+
+Executive walks into the office, signs in, looks at a map of 1,000 devices, drills into one, sees its firmware, views the approval chain, pulls up the compliance report, and exports the audit trail.
+
+---
+
+## 5. Build 2 — Advanced Features
+
+### 5.1 Goal
+
+Elevate the product from _usable_ to _valuable_ for leadership. Add executive analytics, cross-entity search, location intelligence, formal audit, firmware supply-chain security, and a first-class Aegis firmware-security pipeline.
+
+### 5.2 Exit criteria
+
+- Executive dashboard renders live KPIs with time-range filtering.
+- Global search returns sub-second results across all entities.
+- Formal SBOM upload and CVE matching workflow works end-to-end.
+- Location-aware features (geofencing, map clustering) demonstrated.
+
+### 5.3 Epics & stories
+
+#### Epic 7 — Analytics & Reporting
+
+_Executive analytics with KPI cards, charts, and time-range filtering._
+
+| Story | Persona     | Outcome                                                 |
+| ----- | ----------- | ------------------------------------------------------- |
+| 7.1   | Ops Manager | View 5 key metrics via KPI cards with trend indicators  |
+| 7.2   | Ops Manager | Visualize device status and compliance trends as charts |
+| 7.3   | Ops Manager | Filter analytics by time range (7d / 30d / 90d)         |
+| 7.4   | Ops Manager | Export audit-log data for compliance reporting          |
+| 7.5   | Ops Manager | View system performance metrics in a dashboard          |
+
+#### Epic 8 — Audit Trail (formalized)
+
+_Immutable, queryable audit logging with role-based access._
+
+| Story | Persona | Outcome                                                     |
+| ----- | ------- | ----------------------------------------------------------- |
+| 8.1   | Admin   | View audit logs for a date range with user / action filters |
+| 8.2   | Admin   | Export audit logs to CSV                                    |
+| 8.3   | Admin   | Search audit logs by user, resource, or timestamp           |
+
+#### Epic 9 — Geo-Location Formalization
+
+_Static world map with device clustering and status filtering._
+
+| Story | Persona     | Outcome                                           |
+| ----- | ----------- | ------------------------------------------------- |
+| 9.1   | Ops Manager | Plot devices on a world map by coordinates        |
+| 9.2   | Ops Manager | Filter map view by device status                  |
+| 9.3   | Ops Manager | Hover / click a marker for summary detail         |
+| 9.4   | Ops Manager | Resolve device coordinates from location names    |
+| 9.5   | Ops Manager | Access map from Inventory without page navigation |
+
+#### Epic 10 — Location Intelligence
+
+_Interactive map with geofencing, real-time tracking, and clustering._
+
+| Story | Persona     | Outcome                                         |
+| ----- | ----------- | ----------------------------------------------- |
+| 10.1  | Ops Manager | Interactive zoomable map with pan / rotate      |
+| 10.2  | Ops Manager | Search locations by name                        |
+| 10.3  | Ops Manager | Create and visualize geofence boundaries        |
+| 10.4  | Ops Manager | View device movement trail and position history |
+| 10.5  | Ops Manager | Receive geofence enter / exit alerts            |
+| 10.6  | Ops Manager | Cluster markers in dense areas for performance  |
+
+#### Epic 11 — Aegis Phase 1 (Firmware Security)
+
+_Formal firmware approval pipeline with SoD, vulnerability tracking, regulatory reporting._
+
+| Story | Persona     | Outcome                                              |
+| ----- | ----------- | ---------------------------------------------------- |
+| 11.1  | Ops Manager | Upload firmware and see SoD tracking                 |
+| 11.2  | Admin       | Enforce separation of duties through approval stages |
+| 11.3  | Ops Manager | Manage vulnerabilities linked to firmware            |
+| 11.4  | Ops Manager | Generate regulatory compliance reports               |
+| 11.5  | Ops Manager | View firmware version history with approval chain    |
+| 11.6  | Admin       | Trigger security review for high-risk firmware       |
+| 11.7  | Ops Manager | View detailed firmware metadata                      |
+
+#### Epic 12 — SBOM & Supply Chain Security
+
+_Software bill of materials parsing, component tracking, CVE matching, license compliance._
+
+| Story | Persona     | Outcome                                                  |
+| ----- | ----------- | -------------------------------------------------------- |
+| 12.1  | Ops Manager | Upload CycloneDX / SPDX SBOM files                       |
+| 12.2  | Ops Manager | View components and dependencies extracted from SBOM     |
+| 12.3  | Ops Manager | Track CVEs affecting each component                      |
+| 12.4  | Ops Manager | Review license compliance; flag non-compliant components |
+| 12.5  | Ops Manager | Update component remediation status                      |
+| 12.6  | Ops Manager | Export SBOM analysis in CSV / JSON                       |
+
+### 5.4 Demoable outcome
+
+The COO opens the Executive Summary, filters to last 30 days, sees the vulnerability trend, drills into the top CVE, clicks one component, and sees every device running it — all in under 60 seconds.
+
+---
+
+## 6. Build 3 — Enterprise Hardening
+
+### 6.1 Goal
+
+Make IMS Gen 2 **enterprise-grade**: heatmaps, blast-radius modelling, incident isolation, digital twin, hardened sessions, formal infrastructure-as-code, and a polished UI. This is the biggest build (84 items, ~10 epics).
+
+### 6.2 Exit criteria
+
+- Heatmap and blast-radius workflows complete.
+- Incident can be opened, scoped, quarantined, and closed end-to-end.
+- Digital twin simulates a firmware upgrade and predicts impact.
+- Infrastructure reproducible to dev / staging / production from code.
+- Session-security hardening review passes.
+
+### 6.3 Epics & stories
+
+#### Epic 13 — Environmental Heatmaps & Blast Radius
+
+| Story | Persona     | Outcome                                             |
+| ----- | ----------- | --------------------------------------------------- |
+| 13.1  | Ops Manager | View heatmap of device health / risk across regions |
+| 13.2  | Ops Manager | Filter heatmap by risk threshold                    |
+| 13.3  | Ops Manager | Calculate blast radius of a failure                 |
+| 13.4  | Ops Manager | Simulate what-if failure scenarios                  |
+| 13.5  | Ops Manager | View historical simulation results                  |
+| 13.6  | Ops Manager | Ingest telemetry and compute risk in real time      |
+
+#### Epic 14 — Incident Isolation & Lateral Movement
+
+| Story | Persona     | Outcome                                                |
+| ----- | ----------- | ------------------------------------------------------ |
+| 14.1  | Admin       | Create and manage incidents with severity / category   |
+| 14.2  | Admin       | Isolate affected devices to stop lateral movement      |
+| 14.3  | Ops Manager | View network topology of device relationships          |
+| 14.4  | Ops Manager | Analyze lateral-movement risk                          |
+| 14.5  | Admin       | Execute incident response playbooks with step tracking |
+| 14.6  | Ops Manager | View incident timeline with all status changes         |
+
+#### Epic 15 — Digital Twin
+
+| Story | Persona     | Outcome                                                 |
+| ----- | ----------- | ------------------------------------------------------- |
+| 15.1  | Ops Manager | View twin with composite health score and trend         |
+| 15.2  | Ops Manager | Simulate firmware upgrade impact before deployment      |
+| 15.3  | Ops Manager | Detect and resolve configuration drift                  |
+| 15.4  | Ops Manager | Replay device state at any historical timestamp         |
+| 15.5  | Ops Manager | View health factor breakdown and predicted failure date |
+
+#### Epic 16 — Dual-Theme UI, Connectivity & KPI
+
+| Story | Persona     | Outcome                                               |
+| ----- | ----------- | ----------------------------------------------------- |
+| 16.1  | Any User    | Toggle between light and dark themes (persistent)     |
+| 16.2  | Ops Manager | Monitor connectivity and latency of platform services |
+| 16.3  | Ops Manager | See alerts when services become degraded              |
+| 16.4  | Admin       | View Executive Summary for client presentations       |
+| 16.5  | Admin       | Export Executive Summary as PNG / PDF                 |
+| 16.6  | Ops Manager | Access KPI dashboard with server-side aggregations    |
+
+#### Epic 17 — Platform Infrastructure
+
+| Story | Persona | Outcome                                                  |
+| ----- | ------- | -------------------------------------------------------- |
+| 17.1  | DevOps  | Provision all cloud resources reproducibly               |
+| 17.2  | DevOps  | Deploy to dev / staging / production                     |
+| 17.3  | DevOps  | Configure env-specific settings (MFA / WAF / encryption) |
+| 17.4  | DevOps  | Monitor infra health via dashboards and alerts           |
+| 17.5  | DevOps  | CI / CD pipeline with automated testing and deployment   |
+| 17.6  | DevOps  | Manage infra state with locking                          |
+
+#### Epic 18 — OpenSearch & Global Search
+
+| Story | Persona     | Outcome                                                |
+| ----- | ----------- | ------------------------------------------------------ |
+| 18.1  | Any User    | Search across all entities via Cmd+K                   |
+| 18.2  | Any User    | Filter search results by entity type                   |
+| 18.3  | Ops Manager | Device-scoped search with status / location filters    |
+| 18.4  | Ops Manager | Search vulnerabilities by CVE / severity / component   |
+| 18.5  | Ops Manager | Request server-side aggregations for KPIs              |
+| 18.6  | Ops Manager | Execute geospatial queries (distance / bbox / heatmap) |
+
+#### Epic 25 — Auth & Session Security Hardening
+
+_Formal session lifecycle, token rotation, MFA enforcement in production, brute-force throttling._ 6 stories tracked in GitHub Project.
+
+#### Epic 26 — Secure Firmware Distribution & Version Audit Trail
+
+_One-time download links, tenant-scoped distribution, complete version audit history._ Story set spans Build 3 and Build 4.
+
+#### Epic 27 — Device Lifecycle 360 & Cross-Domain Timeline
+
+_Device passport — ownership chain, firmware timeline, persona-aware filtering._
+
+| Story | Persona     | Outcome                                                           |
+| ----- | ----------- | ----------------------------------------------------------------- |
+| 27.1  | Ops Manager | View complete lifecycle timeline from registration → decommission |
+| 27.2  | Ops Manager | Filter timeline by persona (Admin / Technician / Customer)        |
+| 27.3  | Ops Manager | Trace ownership / custody chain through transfers                 |
+| 27.4  | Ops Manager | View firmware approval comments and rollback reasons              |
+| 27.5  | Ops Manager | Track device status transitions with reasons                      |
+
+### 6.4 Demoable outcome
+
+A critical CVE is disclosed. The Admin opens an incident, the system shows the 380 devices affected, quarantines them, runs the response playbook, and produces an evidence pack — in under 10 minutes.
+
+---
+
+## 7. Build 4 — Template & Infrastructure
+
+### 7.1 Goal
+
+Extract the IMS platform into a **reusable enterprise template** so that future product lines can be stood up in weeks, not quarters. Formalize secure, multi-tenant firmware distribution.
+
+### 7.2 Exit criteria
+
+- Template scaffolding reproduces a working dev environment from scratch.
+- Pluggable provider pattern (artifact / CRM / scanner / DNS) works against real external systems.
+- Secure firmware distribution covers tenant-scoped links and complete version audit.
+
+### 7.3 Epics & stories
+
+#### Epic 19 — Reusable Enterprise Template
+
+_Extracted scaffolding: auth, API, session, observability, CI/CD, infra-as-code, UX primitives — portable to new product lines._ Delivered as ~49 template / scaffolding items on the board.
+
+#### Epic 20 — Pluggable External Integrations & Firmware Lifecycle
+
+| Story | Persona     | Outcome                                                |
+| ----- | ----------- | ------------------------------------------------------ |
+| 20.1  | DevOps      | Define and implement an Artifact Provider interface    |
+| 20.2  | DevOps      | Integrate multiple artifact sources as providers       |
+| 20.3  | DevOps      | Define and implement a CRM Provider interface          |
+| 20.4  | Ops Manager | Route firmware approvals to external change-management |
+| 20.5  | DevOps      | Integrate compliance scanner providers                 |
+| 20.6  | Ops Manager | View complete firmware version timeline                |
+| 20.7  | Ops Manager | Associate firmware versions with customers / sites     |
+| 20.8  | DevOps      | Stream change-data events to external systems          |
+| 20.9  | Ops Manager | Generate secure one-time download links                |
+| 20.10 | DevOps      | Support multiple DNS providers                         |
+
+#### Epic 26 (continued) — Secure Firmware Distribution & Version Audit Trail
+
+_Remaining tenant-scoped distribution, per-customer access policy, and cross-tenant audit continuity._
+
+### 7.4 Demoable outcome
+
+A new product line is bootstrapped from the template: auth, dashboards, inventory, and firmware pipeline running against the team's own cloud account in one afternoon.
+
+---
+
+## 8. Build 5 — Quality & Resilience
+
+### 8.1 Goal
+
+Pay down the architectural debt accumulated during rapid feature delivery. Stabilize state management and the data layer so that future changes are _safe, fast, and predictable_.
+
+### 8.2 Exit criteria
+
+- Single, consistent state-management pattern across the app.
+- Single, consistent data-access pattern; no one-off queries left.
+- Performance budgets enforced in CI; no regressions in the top 10 user flows.
+
+### 8.3 Epics & stories
+
+#### Epic 21 — State Management Refactor
+
+_Consolidate to a single state-management approach across every page._ 8 stories on the board — scoped after Build 2 feedback.
+
+#### Epic 22 — Data Layer & API Integration
+
+_Single data-access pattern, consistent caching, error classification, and pagination._ 10 stories on the board.
+
+#### Epic 24 — Performance Optimization (rollup)
+
+_Enforce bundle budgets, memoization rules, virtualization for long lists, and animation performance._ Tracked under Milestone 19 on GitHub.
+
+### 8.4 Demoable outcome
+
+Side-by-side perf test: Build 2 vs Build 5. All ten flagship pages hit p95 page-interactive under 2.5 seconds; zero state-related defects opened in the last iteration.
+
+---
+
+## 9. Build 6 — Production Ready
+
+### 9.1 Goal
+
+Final polish: consolidate the design system, resolve any accessibility gaps, close all P0 / P1 defects, and stamp the Release Candidate for General Availability.
+
+### 9.2 Exit criteria
+
+- Design system has one canonical component per concern; no drift.
+- WCAG 2.1 AA audit passes on all 10 primary pages.
+- Zero open P0 defects; zero open P1 defects older than one iteration.
+- GA sign-off from Product, Engineering, and Security leads.
+
+### 9.3 Epics & stories
+
+#### Epic 23 — Component Design System & UI Primitives
+
+_Canonical primitives (Button, Input, Table, Card, Modal) with documented props, variants, and accessibility contracts._ 5 stories (and 1 spillover from Build 3) tracked on the board.
+
+### 9.4 Demoable outcome
+
+The Release Candidate build is signed off and promoted. A customer onboards against the production environment end-to-end with no blockers.
+
+---
+
+## 10. Cross-Build Dependency Map
+
+```
+                       ┌─ Build 1 ─┐
+                       │  Core     │──────┐
+                       │  Platform │      │
+                       └───────────┘      │
+                              │           │
+                              ▼           ▼
+                  ┌─ Build 2 ──────────────────────┐
+                  │ Analytics · Search · Location  │
+                  │ SBOM · Aegis · Audit formal    │
+                  └────────────────────────────────┘
+                              │
+                              ▼
+       ┌──────────────── Build 3 ─────────────────────┐
+       │ Heatmaps · Incident · Twin · Infra · Hardening│
+       └──────────────────────────────────────────────┘
+               │                    │
+               ▼                    ▼
+       ┌── Build 4 ──┐      ┌── Build 5 ──┐
+       │ Template &  │      │ Quality &   │
+       │ Integrations│      │ Resilience  │
+       └─────────────┘      └─────────────┘
+                                 │
+                                 ▼
+                          ┌── Build 6 ──┐
+                          │ Production  │
+                          │ Ready (GA)  │
+                          └─────────────┘
+```
+
+### Key dependency rules
+
+1. **Nothing ships without Build 1.** Auth, RBAC, Inventory, Firmware Lifecycle, Service Orders, and the audit spine are foundational.
+2. **Build 2 is sequential on Build 1.** Analytics reads Build-1 entities; global search indexes Build-1 data; SBOM extends Build-1 firmware.
+3. **Build 3 depends on Build 2.** Blast radius reads vulnerability data (Build 2). Incident isolation reads device topology. Digital twin consumes firmware history.
+4. **Build 4 is partially parallelizable with Build 3.** The template extraction can begin once Build 2 closes; integration providers must wait for Build 3's firmware-distribution work.
+5. **Build 5 follows all feature builds.** Refactors cannot be planned until the surface area stops changing.
+6. **Build 6 is a gate, not a phase.** It resolves only _after_ every earlier build closes.
+
+---
+
+## 11. Milestones, Releases, Risk Register
+
+### 11.1 Release stages
+
+| Release                       | Backed By      | Promise                                                               |
+| ----------------------------- | -------------- | --------------------------------------------------------------------- |
+| **Alpha**                     | End of Build 1 | Internal demo; core workflows functional end-to-end                   |
+| **Beta**                      | End of Build 2 | Design-partner pilot; executive dashboard + search + SBOM live        |
+| **Enterprise Preview**        | End of Build 3 | Enterprise prospects can evaluate incident / heatmap / infra maturity |
+| **RC (Release Candidate)**    | End of Build 5 | Production candidates; perf + resilience verified                     |
+| **GA (General Availability)** | End of Build 6 | Public launch                                                         |
+
+### 11.2 Risk register (build-level)
+
+| Build | Risk                                                        | Mitigation                                                                             |
+| ----- | ----------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| 1     | Auth / RBAC mis-scoped → rework touches every later feature | Security-review checkpoint at story 1.4; end-to-end role tests before Build 2 opens    |
+| 1     | Firmware SoD bypassable                                     | SoD enforcement written and tested before story 4.3 closes; compliance dry-run         |
+| 2     | Search performance poor at scale                            | Load-test with 50K records before Build 3 opens                                        |
+| 2     | SBOM formats vary wildly                                    | Pilot with one real customer SBOM at each of CycloneDX and SPDX before 12.2            |
+| 3     | Infrastructure-as-code drift between environments           | All environments reproduced from the same source; parity test in CI                    |
+| 3     | Incident response playbooks too rigid                       | Playbook model is data-driven, not hard-coded; edit-in-UI from day one                 |
+| 4     | External provider integrations block core path              | Providers are _pluggable_ — the platform works without them; integrations are additive |
+| 5     | Refactor introduces regressions                             | Freeze feature work during Build 5; full E2E regression each sprint                    |
+| 6     | Last-mile accessibility gaps                                | WCAG audit scheduled _during_ Build 5, not at the end of Build 6                       |
+
+### 11.3 How this document stays accurate
+
+- **Source of truth for live status is GitHub** — this document captures structure and intent, not day-to-day progress.
+- Any change to the build-cycle boundaries, epic membership, or scope must be reflected here **and** on the Project `Release` field — otherwise traceability breaks.
+- Every iteration's retrospective asks: "does the build-cycle plan still reflect reality?" If not, this file is updated before the next sprint.
+
+---
+
+_End of Implementation Plan._
+_For the business context behind each build, see [`Requirement.md`](./Requirement.md)._
+_For live status, see [GitHub Project #1](https://github.com/users/gauravmakkar29/projects/1)._

--- a/Docs/Requirement.md
+++ b/Docs/Requirement.md
@@ -1,0 +1,425 @@
+# IMS Gen 2 — Business Requirements Document
+
+> **Audience:** Product Owners, Product Managers, Business Analysts, Customer Stakeholders, Compliance Leads
+>
+> **Purpose:** This document states _what_ IMS Gen 2 delivers and _why_, in purely business terms. It is the single source of truth for product decisions, scope conversations, and acceptance negotiation. It contains **no** technology, architecture, API, or implementation detail — those live in per-epic tech specs.
+>
+> **Companion Document:** `Implementation-Plan.md` — shows how the business requirements below are mapped to build cycles, epics, and stories.
+
+---
+
+## Table of Contents
+
+1. [Executive Summary](#1-executive-summary)
+2. [Business Context & Problem Statement](#2-business-context--problem-statement)
+3. [Users & Personas](#3-users--personas)
+4. [Business Goals & Success Metrics](#4-business-goals--success-metrics)
+5. [Scope — In (Gen 2 Commits To)](#5-scope--in-gen-2-commits-to)
+6. [Scope — Out / Deferred](#6-scope--out--deferred)
+7. [Functional Requirements](#7-functional-requirements)
+8. [Business Rules & Policies](#8-business-rules--policies)
+9. [Non-Functional Expectations](#9-non-functional-expectations)
+10. [Assumptions, Dependencies, Risks](#10-assumptions-dependencies-risks)
+11. [Glossary](#11-glossary)
+
+---
+
+## 1. Executive Summary
+
+**IMS Gen 2** (Inventory Management System, Generation 2) is an enterprise **Hardware Lifecycle Management platform** that gives equipment-centric organizations end-to-end control over large, distributed device fleets.
+
+In one place, it lets operations teams **track every device**, **deploy firmware safely** through multi-step approval gates, **prove regulatory readiness** with an immutable audit trail, **respond to incidents** with quarantine and blast-radius analysis, and **schedule field service** against a shared calendar and Kanban board — all while enforcing strict access controls and tenant data isolation.
+
+It replaces the spreadsheets, ticket threads, and fragmented tools that today leave organizations blind to their own fleet, at risk of unsafe firmware rollouts, and unprepared for audits.
+
+---
+
+## 2. Business Context & Problem Statement
+
+### Who this is for
+
+Manufacturers and service providers responsible for distributed hardware — solar inverters, industrial IoT, networked energy equipment, connected appliances — where firmware safety, regulatory certification, and operational visibility are material to revenue and liability.
+
+### The pain today
+
+- **Visibility gaps.** No single system answers "how many devices do we have, where are they, which firmware do they run, and which are healthy?"
+- **Unsafe firmware rollouts.** Firmware is pushed without a documented review trail, creating security exposure and regulatory risk.
+- **Audit scramble.** Compliance evidence is manually assembled from emails, spreadsheets, and ad-hoc exports. Auditors flag gaps.
+- **Incident response is slow.** When a critical vulnerability is disclosed, operations cannot quickly answer "which of our devices are affected?"
+- **Field execution drift.** Technicians don't know their assignments in real time; managers cannot see live progress; SLAs slip.
+
+### The commitment of Gen 2
+
+Close every one of those gaps with a single web platform designed for enterprise rigor — authority, compliance, and operator efficiency — not consumer polish.
+
+---
+
+## 3. Users & Personas
+
+| Persona    | Role                    | Primary Goals                                                         | Key Pain Points                                                                        |
+| ---------- | ----------------------- | --------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| **Sarah**  | Platform Admin          | System oversight; enforce firmware governance; manage users and roles | Manual approval workflows; no automated separation-of-duties; audit evidence scattered |
+| **Raj**    | Operations Manager      | Coordinate schedules; track SLAs; report fleet health to customers    | No real-time device visibility; cannot see team workload or job status live            |
+| **Mike**   | Field Technician        | Execute assigned service orders; update status in the field           | No mobile-friendly job queue; slow to report completion                                |
+| **Lisa**   | Compliance Auditor      | Prove regulatory readiness; track CVEs; produce audit reports         | Exports scattered across tools; vulnerability data is manual                           |
+| **Chen**   | Customer Admin (tenant) | Monitor own organization's fleet health and orders                    | Cannot self-serve data; must request reports from the vendor                           |
+| **DevOps** | Infrastructure Engineer | Reliable environments, safe releases, zero-downtime deploys           | Manual environment setup; drift between dev, staging, and production                   |
+
+---
+
+## 4. Business Goals & Success Metrics
+
+| #   | Goal                                                            | Measurable Outcome                                                                                             |
+| --- | --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| G1  | **Operational efficiency** — shrink field-issue resolution time | –40% mean time to resolve (MTTR) within 6 months of launch                                                     |
+| G2  | **Regulatory risk mitigation** — every change auditable         | 100% of create/update/delete actions captured in the audit trail; evidence available within 1 hour of request  |
+| G3  | **Firmware safety** — zero unauthorized deploys                 | 0 firmware versions reaching "Approved" without passing through the enforced review chain                      |
+| G4  | **Platform reliability** — always-on for operations teams       | 99.9% uptime; recovery target under 1 hour; data-loss window under 5 minutes                                   |
+| G5  | **Scalability** — grow with customers                           | Support up to 50,000 devices, 500 concurrent users, 5,000 service orders/month without performance degradation |
+| G6  | **Self-service reduces support load**                           | 30% reduction in compliance-report support tickets by month 6                                                  |
+| G7  | **Release cadence**                                             | Features shipped every 2 weeks with zero downtime                                                              |
+| G8  | **Customer retention**                                          | Enable CustomerAdmin self-service to drive renewal and expansion                                               |
+
+---
+
+## 5. Scope — In (Gen 2 Commits To)
+
+Gen 2 delivers nine business capability areas. Each area is elaborated in Section 7.
+
+1. **Device Inventory & Asset Tracking** — catalog, search, filter, map, export.
+2. **Firmware Lifecycle Management** — upload, review, approval, deprecation with enforced separation of duties.
+3. **Service Order Management** — creation, Kanban execution, calendar scheduling, CSV export.
+4. **Compliance & Vulnerability Tracking** — certifications, CVE tracking, regulatory reports.
+5. **Audit Trail** — immutable record of every change, searchable and exportable.
+6. **Analytics & Executive Reporting** — dashboards, KPI cards, trend charts, exportable executive summary.
+7. **Authentication & Access Control** — RBAC, MFA, session policy, tenant isolation.
+8. **Global Search & Command Palette** — full-text discovery across every entity.
+9. **Enterprise UX** — themes, responsive layout, accessibility, notifications, keyboard-centric workflows.
+
+Advanced capabilities (heatmaps, incident isolation, digital twin, supply-chain/SBOM analysis, enterprise integrations, lifecycle 360) are also in Gen 2 scope, delivered in later build cycles — see `Implementation-Plan.md` for the sequencing.
+
+---
+
+## 6. Scope — Out / Deferred
+
+The following are **explicitly out** of the Gen 2 release window:
+
+- **Offline-first** operation (continuous internet connectivity is assumed).
+- **Native mobile apps** — mobile support is via the responsive web app only.
+- **Multi-region active-active** — Gen 2 runs in a single primary region.
+- **Third-party productivity integrations** (Slack, PagerDuty, Jira, email-to-ticket). Placeholder only.
+- **ISO 27001 / SOC 2 certification tracking** — Gen 2 targets NIST 800-53 as the primary compliance frame.
+- **AI-driven predictive maintenance** beyond the basic health-score trend.
+- **Customer billing / invoicing / monetization** modules.
+- **Public-facing customer portal** beyond the CustomerAdmin view.
+
+---
+
+## 7. Functional Requirements
+
+Requirements are numbered `BR-XXX`. Each is written in user-value form — _"Users must be able to [capability] so that [business outcome]."_
+
+### 7.1 Device Inventory
+
+| ID     | Requirement                                                                                                                         |
+| ------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| BR-001 | Users must be able to create, edit, and delete device records so that the fleet record remains accurate.                            |
+| BR-002 | Users must be able to search devices by name, serial number, or model so that they can locate any device in seconds.                |
+| BR-003 | Users must be able to filter devices by status (Online, Offline, Maintenance) so that they can isolate problem equipment.           |
+| BR-004 | Users must be able to filter devices by customer and location so that multi-tenant and regional views are possible.                 |
+| BR-005 | Users must be able to view device health scores at a glance so that they can prioritize maintenance.                                |
+| BR-006 | Users must be able to view the full device fleet on an interactive world map so that they understand geographic distribution.       |
+| BR-007 | Users must be able to export any filtered device list to CSV so that they can share it with customers, auditors, or internal teams. |
+| BR-008 | Users must be able to drill into a single device from any view (table, grid, map) to see complete detail.                           |
+
+### 7.2 Firmware Lifecycle
+
+| ID     | Requirement                                                                                                                                             |
+| ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| BR-010 | Users must be able to upload firmware packages with version, target model, and integrity checksum so that every release is identifiable.                |
+| BR-011 | Users must be able to view all firmware grouped by status (Active, Deprecated, In Review) so that they understand deployment readiness.                 |
+| BR-012 | Authorized users must be able to advance firmware through review stages — Uploaded → Testing → Approved — so that every release is explicitly reviewed. |
+| BR-013 | The platform must enforce that no single person can upload, test, and approve the same firmware — these three roles must be different individuals.      |
+| BR-014 | Users must be able to see _who_ uploaded, tested, and approved each firmware version so that accountability is unambiguous.                             |
+| BR-015 | Authorized users must be able to deprecate firmware so that legacy versions are flagged as no longer recommended.                                       |
+| BR-016 | Uploaded firmware files must be stored such that they cannot be modified after upload — only read or archived.                                          |
+| BR-017 | Users must be able to view approval progress as a visual stage indicator so that workflow state is obvious at a glance.                                 |
+
+### 7.3 Service Orders
+
+| ID     | Requirement                                                                                                                |
+| ------ | -------------------------------------------------------------------------------------------------------------------------- |
+| BR-020 | Managers must be able to create service orders with technician, type, location, date, time, and priority.                  |
+| BR-021 | Technicians must be able to view their own assigned service orders so that they know their schedule.                       |
+| BR-022 | Technicians must be able to update order status via drag-and-drop on a Kanban board (Scheduled → In Progress → Completed). |
+| BR-023 | Managers must be able to view service orders on a monthly calendar so that conflicts and gaps are visible.                 |
+| BR-024 | Users must be able to filter orders by status, technician, priority, and date range.                                       |
+| BR-025 | Users must be able to export service orders to CSV.                                                                        |
+| BR-026 | Technicians must be notified the moment they are assigned a new order so that no job sits unseen.                          |
+
+### 7.4 Compliance & Vulnerability
+
+| ID     | Requirement                                                                                                                                         |
+| ------ | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| BR-030 | Users must be able to create compliance records linking a firmware version and device model to a certification type (e.g., IEC 62109).              |
+| BR-031 | Users must be able to submit compliance items for review so that an Admin can approve or reject.                                                    |
+| BR-032 | Admins must be able to approve or deprecate compliance items.                                                                                       |
+| BR-033 | Users must be able to record vulnerabilities (CVE ID, severity, affected component, remediation status) against compliance records.                 |
+| BR-034 | Users must be able to filter vulnerabilities by severity and remediation status so that they can focus on the most critical unresolved items.       |
+| BR-035 | Users must be able to generate **regulatory readiness reports** in CSV and JSON so that auditors can ingest evidence directly.                      |
+| BR-036 | Users must be able to search vulnerabilities globally by CVE ID or component name so that they can answer "which devices are affected?" in minutes. |
+
+### 7.5 Audit Trail
+
+| ID     | Requirement                                                                                                                    |
+| ------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| BR-040 | Every create, update, and delete action must be automatically logged with timestamp, user, affected resource, and action type. |
+| BR-041 | Authorized users must be able to query audit logs by date range, user, and resource type.                                      |
+| BR-042 | Audit logs must be **immutable** — no user, including Admins, may delete entries.                                              |
+| BR-043 | Audit logs must be retained for 90 days, then auto-purged, so that the retention policy is enforced automatically.             |
+| BR-044 | Users must be able to export audit logs to CSV so that evidence can be attached to formal audit reports.                       |
+
+### 7.6 Analytics & Reporting
+
+| ID     | Requirement                                                                                                                                                                   |
+| ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| BR-050 | Users must be able to see a dashboard of top-level KPIs — total devices, online devices, active deployments, pending approvals — so that fleet health is readable in seconds. |
+| BR-051 | Users must be able to see device status distribution and compliance status distribution as chart visualizations.                                                              |
+| BR-052 | Users must be able to see deployment trends over time (weekly and monthly).                                                                                                   |
+| BR-053 | Users must be able to see the top vulnerabilities ranked by prevalence so that patching is prioritized.                                                                       |
+| BR-054 | Users must be able to filter every analytic by time range (7, 30, 90 days).                                                                                                   |
+| BR-055 | Admins must be able to generate and export an **Executive Summary** suitable for board- and customer-level presentations.                                                     |
+
+### 7.7 Authentication & Authorization
+
+| ID     | Requirement                                                                                                                                       |
+| ------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| BR-060 | Users must be able to sign in with email and password.                                                                                            |
+| BR-061 | Users must be able to enable multi-factor authentication so that their account is protected from credential theft.                                |
+| BR-062 | Admins must be able to assign users to one of five roles — Admin, Manager, Technician, Viewer, CustomerAdmin — so that access is least-privilege. |
+| BR-063 | The platform must enforce role-specific permissions across every page and action.                                                                 |
+| BR-064 | Sessions must auto-expire after 15 minutes of inactivity so that unattended terminals cannot be exploited.                                        |
+| BR-065 | Customers (CustomerAdmin role) must only see data belonging to their own organization — cross-tenant leakage is a P0 defect.                      |
+| BR-066 | Admins must be able to create, enable, disable, and assign roles to user accounts.                                                                |
+
+### 7.8 Global Search
+
+| ID     | Requirement                                                                                                                |
+| ------ | -------------------------------------------------------------------------------------------------------------------------- |
+| BR-070 | Users must be able to open a global search palette via a universal keyboard shortcut from anywhere in the app.             |
+| BR-071 | Users must be able to search across devices, firmware, service orders, compliance items, and vulnerabilities in one query. |
+| BR-072 | Users must see partial-match / fuzzy results so that small typos do not block discovery.                                   |
+| BR-073 | Search results must be grouped by entity type and show instant suggestions as the user types.                              |
+| BR-074 | Search results must highlight matching keywords so that relevance is visible.                                              |
+
+### 7.9 Notifications
+
+| ID     | Requirement                                                                                                              |
+| ------ | ------------------------------------------------------------------------------------------------------------------------ |
+| BR-080 | The platform must notify Admins and Managers when firmware completes approval so that deployment readiness is broadcast. |
+| BR-081 | The platform must notify a technician the instant they are assigned a service order.                                     |
+| BR-082 | The platform must notify Managers when an order is completed so that downstream handoffs can happen in real time.        |
+| BR-083 | The platform must notify Admins and Managers when a critical-severity vulnerability is published.                        |
+| BR-084 | The platform must notify relevant users when a device goes offline.                                                      |
+| BR-085 | The platform must show a bell icon with unread count and open a slide-out panel so notifications are ambient.            |
+| BR-086 | Clicking a notification must deep-link to the originating entity so that action is one click away.                       |
+
+### 7.10 Advanced Operations (Later Build Cycles)
+
+| ID     | Requirement                                                                                                                                                             |
+| ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| BR-090 | Users must be able to view device fleet health as a geographic heatmap so that regional risk is readable at a glance.                                                   |
+| BR-091 | Users must be able to calculate **blast radius** — the set of devices affected by a specific vulnerability or failure — so that incident scope is known.                |
+| BR-092 | Users must be able to simulate "what-if" failure scenarios so that incident response is rehearsed, not improvised.                                                      |
+| BR-093 | Admins must be able to open an **incident record**, classify severity, and quarantine affected devices so that lateral movement is stopped.                             |
+| BR-094 | Users must be able to view network topology showing device relationships so that dependencies and impact are visible.                                                   |
+| BR-095 | Admins must be able to attach a **response playbook** to an incident, execute steps, and track completion.                                                              |
+| BR-096 | Users must be able to view a **Digital Twin** — a virtual replica of a device — to simulate firmware upgrades before rolling out.                                       |
+| BR-097 | Users must be able to view a **composite health score** with a predicted failure date so that preventive maintenance is possible.                                       |
+| BR-098 | Users must be able to upload an **SBOM** (Software Bill of Materials) and see every component, dependency, and license flagged against known vulnerabilities.           |
+| BR-099 | Users must be able to view a **complete device passport** — registration → ownership changes → firmware history → service events → decommission — as a single timeline. |
+| BR-100 | Users must be able to filter the device timeline by persona (Admin, Technician, Customer) so that each audience sees what is relevant to them.                          |
+| BR-101 | Admins must be able to route firmware approvals to an external change-management system so that enterprise change control is respected.                                 |
+| BR-102 | Admins must be able to generate secure, one-time firmware download links so that distribution is controlled and auditable.                                              |
+
+---
+
+## 8. Business Rules & Policies
+
+### 8.1 Firmware Governance (Separation of Duties)
+
+- **BP-01** No person may both upload and approve the same firmware version.
+- **BP-02** No person may both test and approve the same firmware version.
+- **BP-03** Firmware cannot skip from "Uploaded" directly to "Approved" — the "Testing" stage is mandatory.
+- **BP-04** Only the Admin role can set the final approval decision.
+
+### 8.2 Audit Immutability & Retention
+
+- **BP-10** Audit log entries cannot be deleted by any role under any condition.
+- **BP-11** Audit log retention is 90 days, after which records are automatically purged.
+- **BP-12** Every audit entry must capture user identity, action, resource type, resource ID, and timestamp.
+
+### 8.3 Service Order Policy
+
+- **BP-20** Only Managers can create or reassign service orders.
+- **BP-21** A service order's scheduled date cannot be in the past at creation time.
+- **BP-22** Only the assigned Technician may update the status of their own order (Manager override allowed).
+
+### 8.4 Compliance Policy
+
+- **BP-30** Compliance items follow a one-way transition: **Pending → Approved** or **Pending → Deprecated**.
+- **BP-31** Only Admins may approve compliance items.
+- **BP-32** Deprecated compliance items are excluded from active compliance dashboards.
+
+### 8.5 Vulnerability Remediation Policy
+
+- **BP-40** Every recorded vulnerability must carry a severity (Critical, High, Medium, Low).
+- **BP-41** Remediation status must be one of: Open, In Progress, Resolved.
+- **BP-42** When remediation transitions to Resolved, the resolution timestamp is auto-captured.
+
+### 8.6 Multi-Tenant Isolation
+
+- **BP-50** Every device, order, and compliance record carries a Customer ID.
+- **BP-51** Queries are scoped to the authenticated user's Customer ID — cross-tenant access is prohibited.
+- **BP-52** A CustomerAdmin cannot escalate privilege to view other tenants' data under any circumstance.
+
+### 8.7 Session & Credential Policy
+
+- **BP-60** Passwords must be at least 12 characters and include upper, lower, number, and symbol.
+- **BP-61** Active sessions expire after 15 minutes of inactivity.
+- **BP-62** Extended sessions expire after 7 days, requiring a full sign-in.
+- **BP-63** MFA is **required** for Admins in Production; **optional** elsewhere.
+
+### 8.8 Data Retention & Archival
+
+- **BP-70** Audit logs: 90 days then purged.
+- **BP-71** Firmware binaries: archived to cold storage after 365 days.
+- **BP-72** Notifications: auto-expire after 30 days.
+- **BP-73** Deleted firmware: retained recoverable for 30 days, then permanently removed.
+
+---
+
+## 9. Non-Functional Expectations
+
+Stated as **business outcomes**, not technical targets.
+
+### 9.1 Performance — what users feel
+
+- Pages open and are usable within **3.5 seconds** on a typical 4G connection.
+- Data tables of 100 rows render without visible lag.
+- An interactive map with 1,000 device markers is fully usable within **2 seconds**.
+- Global search suggestions appear within **150 milliseconds** of typing.
+- Exporting 10,000 records to CSV completes within **30 seconds**.
+- Navigating between pages feels instant (under 100 milliseconds).
+
+### 9.2 Availability & Reliability
+
+- **99.9% uptime** — at most 8.7 hours of unplanned downtime per year.
+- Recovery from catastrophic failure completes in **under 1 hour**.
+- Worst-case data loss is bounded at **under 5 minutes**.
+- When search services are degraded, the platform falls back to structured filtering — it never "goes dark."
+- Real-time notifications are delivered within **1 minute** of the triggering event.
+
+### 9.3 Scalability
+
+- Supports **500 concurrent users** without visible slowdown.
+- Manages **50,000 device records** with search remaining sub-second.
+- Sustains **500 API operations per second** at peak.
+- Audit trail remains query-fast at **10 million+ records**.
+- Deployments ship **with zero downtime**.
+
+### 9.4 Security & Compliance
+
+- All data — in transit and at rest — is encrypted.
+- Firmware binaries cannot be modified after upload.
+- Every user action is recorded for audit.
+- Access is governed by role; separation-of-duties is automated, not advisory.
+- Sessions auto-lock after 15 minutes of inactivity.
+- Brute-force login attempts are throttled by the platform.
+- Platform aligns with **NIST 800-53** control framework as the primary compliance target.
+
+### 9.5 Accessibility
+
+- Meets **WCAG 2.1 Level AA**.
+- Every interactive element is operable via keyboard alone.
+- Colour contrast meets minimum 4.5:1 for body text.
+- Respects users who prefer reduced motion (animations disabled).
+- Works at up to 200% browser zoom without breaking layout.
+- All form inputs are labelled for screen readers.
+
+### 9.6 Browser & Device Support
+
+- Chrome, Firefox, Safari, and Edge — the two most recent major versions of each.
+- Mobile Chrome and Mobile Safari on iOS.
+- Responsive from **320 pixels** (phones) to **2560 pixels** (large displays).
+- Field technicians can complete core workflows on a phone.
+
+---
+
+## 10. Assumptions, Dependencies, Risks
+
+### 10.1 Assumptions
+
+- Users operate with stable internet connectivity — offline workflows are not promised in Gen 2.
+- Firmware file sizes are bounded at 2 GB.
+- Initial customer deployments are below 50,000 devices; scale beyond that triggers an infrastructure review.
+- Users are comfortable with cloud-based SaaS — no desktop client is provided.
+- **NIST 800-53** is the primary compliance target; ISO 27001 and SOC 2 are deferred.
+
+### 10.2 External Dependencies
+
+- Cloud infrastructure provider (specific platform is an implementation detail — business continuity depends on the provider's SLAs).
+- DNS and email delivery services for account lifecycle (password reset, MFA).
+- External change-management system (customer-chosen) for firmware approval routing — only in advanced build cycles.
+- External artifact repository (customer-chosen) as an optional firmware source — only in advanced build cycles.
+
+### 10.3 Risks & Mitigations
+
+| #   | Risk                              | Business Impact                                     | Mitigation                                                                                                    |
+| --- | --------------------------------- | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| R1  | Cross-tenant data leakage         | Loss of customer trust; potential regulatory breach | Tenant ID enforced on every query; penetration testing before production; explicit test coverage on isolation |
+| R2  | Firmware approval bypass          | Unsafe firmware reaches the field; liability        | Automated separation-of-duties; no override path; full audit trail of every stage                             |
+| R3  | Audit tampering                   | Regulatory non-compliance                           | Audit records are immutable at the platform level; no user has delete rights; independent retention timer     |
+| R4  | Prolonged outage                  | Operations halt; customer SLA penalties             | 99.9% availability target; documented recovery procedure; continuous backups                                  |
+| R5  | Field users cannot work on mobile | Technicians abandon the tool                        | Mandatory responsive design review per release; technician usability testing before Build 2 closes            |
+| R6  | Compliance reports incomplete     | Audit failure                                       | Report generator covers CSV and JSON; auditor dry-run scheduled before GA                                     |
+| R7  | Adoption stalls                   | Product goodwill loss                               | Early design-partner pilot; feedback loop before GA; UX polish built into every build cycle                   |
+
+---
+
+## 11. Glossary
+
+| Term                           | Definition                                                                                                                                                                       |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Audit Trail**                | The chronological, tamper-proof record of every change made in the platform. Used for compliance, forensics, and dispute resolution.                                             |
+| **Blast Radius**               | The set of devices impacted by a specific vulnerability, failure, or firmware issue. Answers "how bad is this?"                                                                  |
+| **Certification**              | A regulatory or standards approval tied to a firmware version and device model (e.g., IEC 62109 for solar inverters).                                                            |
+| **Command Palette**            | A keyboard-driven search overlay opened from anywhere in the app.                                                                                                                |
+| **Compliance Item**            | A record linking a firmware version and device model to a certification type and a review status.                                                                                |
+| **CVE**                        | Common Vulnerabilities and Exposures — the industry-standard identifier for a known security flaw.                                                                               |
+| **Customer**                   | An organization that uses the platform to manage its own fleet. The platform supports many customers simultaneously (multi-tenant).                                              |
+| **CustomerAdmin**              | A role that grants a customer's own staff read-and-manage access to their own organization's data only.                                                                          |
+| **Digital Twin**               | A virtual replica of a physical device, used for firmware simulation, drift detection, and historical replay.                                                                    |
+| **Executive Summary**          | A one-page, export-ready overview of KPIs, status, and trends, suitable for board or customer presentation.                                                                      |
+| **Incident**                   | A recorded event requiring investigation and response — e.g., a detected vulnerability or device compromise.                                                                     |
+| **Kanban Board**               | A visual workflow board with columns (Scheduled, In Progress, Completed) where cards are dragged between columns.                                                                |
+| **MFA**                        | Multi-Factor Authentication — a second credential (typically a time-based code from a phone app) required in addition to the password.                                           |
+| **NIST 800-53**                | The U.S. federal catalog of security and privacy controls. The primary compliance frame for Gen 2.                                                                               |
+| **RBAC**                       | Role-Based Access Control — permissions are granted by role, not by individual.                                                                                                  |
+| **Response Playbook**          | A pre-defined checklist of steps executed when a specific incident category occurs.                                                                                              |
+| **RPO**                        | Recovery Point Objective — the maximum acceptable window of data that may be lost in an outage. Gen 2 target: 5 minutes.                                                         |
+| **RTO**                        | Recovery Time Objective — the maximum acceptable time to restore service after an outage. Gen 2 target: 1 hour.                                                                  |
+| **SBOM**                       | Software Bill of Materials — a complete inventory of every component and dependency inside a firmware package.                                                                   |
+| **Separation of Duties (SoD)** | A governance principle requiring that no single person can complete all steps of a sensitive process (e.g., firmware upload, test, and approval must be three different people). |
+| **Service Order**              | A scheduled task for a field technician — install, repair, inspect — with location, date/time, priority, and status.                                                             |
+| **SLA**                        | Service Level Agreement — the platform's commitment on uptime, response time, and availability.                                                                                  |
+| **Status (Device)**            | Online, Offline, or Maintenance.                                                                                                                                                 |
+| **Status (Firmware)**          | Uploaded, Testing, Approved, or Deprecated.                                                                                                                                      |
+| **Status (Service Order)**     | Scheduled, In Progress, or Completed.                                                                                                                                            |
+| **Tenant Isolation**           | The guarantee that data belonging to one customer is never visible to another customer.                                                                                          |
+| **WCAG 2.1 AA**                | Web Content Accessibility Guidelines, Level AA — the accessibility standard targeted by Gen 2.                                                                                   |
+
+---
+
+_End of Business Requirements Document._
+_Companion: see `Implementation-Plan.md` for how these requirements map to build cycles, epics, and stories._

--- a/Docs/github-projects-setup-prompt.md
+++ b/Docs/github-projects-setup-prompt.md
@@ -1,0 +1,1058 @@
+# GitHub Projects V2 — Automated Setup Prompt
+
+> **Audience:** Any PDM, tech lead, or developer bootstrapping a new project.
+>
+> **How it works:** Copy the prompt from Section 2, fill in your config, paste into any
+> AI IDE (Claude Code, Cursor, GitHub Copilot Chat). The AI executes all CLI commands.
+> Then follow the Manual Steps guide (Section 3) for the 5 things GitHub has no API for.
+
+---
+
+## Jira ↔ GitHub Terminology Alignment
+
+If you are migrating from Jira, use this mapping to translate concepts. Everything in
+this guide uses the **GitHub** column — mentally swap in your Jira term as you read.
+
+> Replace `ORG`, `REPO`, and `N` (project number) in the URLs below with your actual
+> values. The placeholder URLs will 404 until the setup prompt has been run.
+
+| Jira term          | GitHub equivalent                                          | Where to see it (demo link)                                                                                                                                                                                        | Notes                                                                        |
+| ------------------ | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
+| Story / Task / Bug | **Issue** (with label)                                     | [Issues list](https://github.com/REPO/issues) · [New Issue chooser](https://github.com/REPO/issues/new/choose)                                                                                                     | One issue type in GitHub; differentiate via `story` / `bug` / `task` labels  |
+| Epic               | **Milestone** (or `epic:N` label)                          | [Milestones](https://github.com/REPO/milestones) · [Labels](https://github.com/REPO/labels)                                                                                                                        | Milestones group issues toward a target date; labels enable filtering        |
+| Sprint             | **Iteration** (Project field)                              | [Current Sprint view](https://github.com/orgs/ORG/projects/N/views/1) · [Project Settings → Sprint](https://github.com/orgs/ORG/projects/N/settings)                                                               | Configured on the project's Sprint field (Manual Step 1)                     |
+| Release / Version  | **Milestone** (release)                                    | [Milestones](https://github.com/REPO/milestones) · [Release Roadmap view](https://github.com/orgs/ORG/projects/N/views/6)                                                                                          | Same primitive as epics — separated by naming convention (`v1.0.0 — MVP`)    |
+| Story Points       | **Story Points** (Number field)                            | [Velocity chart (Insights)](https://github.com/orgs/ORG/projects/N/insights)                                                                                                                                       | Custom project field (Step 8b)                                               |
+| Priority           | **Priority** (Single Select)                               | [Backlog view (grouped by Priority)](https://github.com/orgs/ORG/projects/N/views/2) · [Labels](https://github.com/REPO/labels)                                                                                    | Custom project field + `P0`–`P3` labels (Step 8a)                            |
+| Status / Workflow  | **Status** (Single Select)                                 | [Current Sprint board](https://github.com/orgs/ORG/projects/N/views/1) · [Project Workflows](https://github.com/orgs/ORG/projects/N/workflows)                                                                     | Backlog → Sprint Ready → In Development → In Review → In QA → Done → Blocked |
+| Assignee           | **Assignee**                                               | [My Work view](https://github.com/orgs/ORG/projects/N/views/3) · [My open issues](https://github.com/REPO/issues/assigned/@me)                                                                                     | Native on every issue                                                        |
+| Components         | **Labels** (`infra`, `test`, …)                            | [Labels](https://github.com/REPO/labels)                                                                                                                                                                           | Use type/area labels to categorize                                           |
+| Board              | **Project (V2) View**                                      | [Project home](https://github.com/orgs/ORG/projects/N) · [By Epic view](https://github.com/orgs/ORG/projects/N/views/4)                                                                                            | Board / Table / Roadmap layouts on the same project                          |
+| JQL                | **Filter syntax** (`is:open label:bug iteration:@current`) | [Bug Triage view](https://github.com/orgs/ORG/projects/N/views/5) · [GitHub search syntax docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/filtering-and-searching-issues-and-pull-requests) | Similar semantics, different grammar                                         |
+| Parent link        | **Task list / Issue reference** (`#123`, `- [ ] #123`)     | [Issues list](https://github.com/REPO/issues) · [Milestone detail](https://github.com/REPO/milestone/1)                                                                                                            | Tracked via issue body checklists and milestone membership                   |
+| Reports / Gadgets  | **Insights charts**                                        | [Insights](https://github.com/orgs/ORG/projects/N/insights)                                                                                                                                                        | Sprint burn-up, velocity, bug trend, epic progress (Manual Step 4)           |
+| Automation rules   | **Built-in Workflows**                                     | [Project Workflows](https://github.com/orgs/ORG/projects/N/workflows)                                                                                                                                              | Auto-add to project, status on close/merge/review (Manual Step 3)            |
+| Permission scheme  | **CODEOWNERS + Branch protection**                         | [CODEOWNERS](https://github.com/REPO/blob/main/.github/CODEOWNERS) · [Branch rules](https://github.com/REPO/settings/branches)                                                                                     | Reviewer enforcement + merge gating                                          |
+
+**Quick rule of thumb:** _Stories become Issues, Epics become Milestones, Sprints become
+Iterations._ Everything else is a field, label, or native GitHub primitive.
+
+### Demo walkthrough (open tabs in this order)
+
+Mirrors a typical Jira walkthrough — Backlog → Create Story → Epics → Sprint Board → Reports → Automation.
+
+1. [Issues list](https://github.com/REPO/issues) — "this is our backlog"
+2. [New Issue chooser](https://github.com/REPO/issues/new/choose) — show story/bug/task templates
+3. [Milestones](https://github.com/REPO/milestones) — epics and releases with progress bars
+4. [Project board — Current Sprint](https://github.com/orgs/ORG/projects/N/views/1) — daily standup board
+5. [Project views (By Epic, Roadmap, My Work)](https://github.com/orgs/ORG/projects/N) — cycle through tabs
+6. [Insights](https://github.com/orgs/ORG/projects/N/insights) — burn-up, velocity, bug trend
+7. [Project Workflows](https://github.com/orgs/ORG/projects/N/workflows) — automation rules
+8. [CODEOWNERS](https://github.com/REPO/blob/main/.github/CODEOWNERS) + [Branch protection](https://github.com/REPO/settings/branches) — governance
+
+---
+
+## Table of Contents
+
+1. [Prerequisites](#1-prerequisites)
+2. [The Automation Prompt](#2-the-automation-prompt)
+3. [Manual Steps After Automation](#3-manual-steps-after-automation)
+4. [Verification Checklist](#4-verification-checklist)
+5. [Troubleshooting](#5-troubleshooting)
+
+---
+
+## 1. Prerequisites
+
+Complete these **before** running the prompt.
+
+### Required Tools
+
+| Tool              | Install                                                     | Verify          |
+| ----------------- | ----------------------------------------------------------- | --------------- |
+| GitHub CLI (`gh`) | `winget install GitHub.cli` (Win) / `brew install gh` (Mac) | `gh --version`  |
+| Git               | Should already be installed                                 | `git --version` |
+
+`jq` is NOT required — the prompt avoids it.
+
+### Authentication
+
+```bash
+gh auth login
+# Choose: GitHub.com > HTTPS > Login with a web browser
+# Verify:
+gh auth status
+```
+
+**Required scopes:** `repo`, `project`, `read:org`. If missing:
+
+```bash
+gh auth refresh -s repo,project,read:org
+```
+
+### Permissions
+
+You need these GitHub permissions:
+
+- **Repo:** Write access (to create labels, milestones, push templates)
+- **Org:** Member (to create org-level projects)
+- **Project:** Admin on the project (automatic if you create it)
+
+---
+
+## 2. The Automation Prompt
+
+Copy everything between the `---START---` and `---END---` markers below.
+Edit the **CONFIGURATION** section, then paste the entire thing into your AI IDE.
+
+---START---
+
+````markdown
+## Task: Bootstrap a complete GitHub Projects V2 setup
+
+You are setting up a GitHub Projects V2 board for a software team. Execute every step
+below using `gh` CLI commands and file writes. Run all commands yourself — do not ask
+me to run anything manually.
+
+**Rules:**
+
+- If a command fails with "already exists" (HTTP 422 or "already exists" in stderr), skip it and continue.
+- If `gh auth status` fails, tell me to run `gh auth login` and stop immediately.
+- Quote all label names in commands (labels may contain spaces).
+- Use `||true` after delete commands so failures don't halt the script.
+- After all steps, print the summary and the manual-steps checklist.
+
+---
+
+### CONFIGURATION
+
+Replace every placeholder below with your actual values.
+
+```
+ORG=your-org
+REPO=your-org/your-repo
+PROJECT_NAME=My Project Board
+PROJECT_DESCRIPTION=One-line description of your project
+
+EPICS:
+  1 = Project Bootstrap & Auth
+  2 = Core Inventory CRUD
+  3 = Location & Hierarchy
+  4 = Work Order System
+  5 = Firmware Management
+
+SPRINT_START_DATE=2026-05-01
+SPRINT_COUNT=12
+SPRINT_DURATION_WEEKS=2
+
+RELEASES:
+  v1.0.0 — MVP         | due: 2026-08-01 | Minimum viable product
+  v1.1.0 — Analytics    | due: 2026-10-01 | Dashboard and reporting
+
+TEAM:
+  leads    = lead-username
+  frontend = dev1, dev2
+  infra    = devops1
+  qa       = qa1
+```
+
+---
+
+### STEP 0 — Pre-flight checks
+
+Run both commands. If either fails, stop and tell me what went wrong.
+
+```bash
+gh auth status
+```
+
+```bash
+gh repo view "REPO" --json name -q ".name"
+```
+
+---
+
+### STEP 1 — Delete default labels
+
+Remove GitHub's default labels that clutter the list. Run each as a separate command.
+Failures are OK (label may not exist).
+
+```bash
+gh label delete "good first issue" --repo "REPO" --yes || true
+gh label delete "help wanted" --repo "REPO" --yes || true
+gh label delete "invalid" --repo "REPO" --yes || true
+gh label delete "question" --repo "REPO" --yes || true
+gh label delete "wontfix" --repo "REPO" --yes || true
+```
+
+---
+
+### STEP 2 — Create all labels
+
+Run each `gh label create` command below. Use `--force` flag on every command so it
+updates the label if it already exists (makes this step idempotent).
+
+Replace `REPO` with the actual repo value from config.
+
+**Type labels:**
+
+```bash
+gh label create "story" --color "1D76DB" --description "User story with acceptance criteria" --repo "REPO" --force
+gh label create "bug" --color "D73A4A" --description "Something is broken" --repo "REPO" --force
+gh label create "enhancement" --color "A2EEEF" --description "Improvement to existing feature" --repo "REPO" --force
+gh label create "tech-debt" --color "F9D0C4" --description "Refactoring or code quality improvement" --repo "REPO" --force
+gh label create "infra" --color "BFD4F2" --description "Infrastructure / Terraform / DevOps" --repo "REPO" --force
+gh label create "task" --color "E4E669" --description "General task or chore" --repo "REPO" --force
+gh label create "documentation" --color "0075CA" --description "Documentation only changes" --repo "REPO" --force
+gh label create "test" --color "C5DEF5" --description "Test-only change (unit, E2E, perf)" --repo "REPO" --force
+```
+
+**Priority labels:**
+
+```bash
+gh label create "P0-critical" --color "B60205" --description "Drop everything, fix immediately" --repo "REPO" --force
+gh label create "P1-high" --color "D93F0B" --description "Must fix this sprint" --repo "REPO" --force
+gh label create "P2-medium" --color "FBCA04" --description "Plan for next sprint" --repo "REPO" --force
+gh label create "P3-low" --color "0E8A16" --description "Nice to have, backlog" --repo "REPO" --force
+```
+
+**Epic labels — generate one per epic from the EPICS config:**
+
+```bash
+gh label create "epic:1" --color "6F42C1" --description "Epic 1 — Project Bootstrap & Auth" --repo "REPO" --force
+gh label create "epic:2" --color "6F42C1" --description "Epic 2 — Core Inventory CRUD" --repo "REPO" --force
+gh label create "epic:3" --color "6F42C1" --description "Epic 3 — Location & Hierarchy" --repo "REPO" --force
+gh label create "epic:4" --color "6F42C1" --description "Epic 4 — Work Order System" --repo "REPO" --force
+gh label create "epic:5" --color "6F42C1" --description "Epic 5 — Firmware Management" --repo "REPO" --force
+```
+
+(Generate additional `epic:N` commands if the EPICS config has more entries.)
+
+**Status / process labels:**
+
+```bash
+gh label create "qa-plan" --color "C5DEF5" --description "QA test plan approved" --repo "REPO" --force
+gh label create "e2e-coverage" --color "C5DEF5" --description "E2E tests written and passing" --repo "REPO" --force
+gh label create "needs-review" --color "FBCA04" --description "Waiting for code review" --repo "REPO" --force
+gh label create "blocked" --color "B60205" --description "Blocked by external dependency" --repo "REPO" --force
+gh label create "duplicate" --color "CFD3D7" --description "Duplicate of another issue" --repo "REPO" --force
+```
+
+**Size labels:**
+
+```bash
+gh label create "XS" --color "C2E0C6" --description "Trivial (1 point) — config change, typo fix" --repo "REPO" --force
+gh label create "S" --color "C2E0C6" --description "Small (2 points) — simple feature or fix" --repo "REPO" --force
+gh label create "M" --color "FEF2C0" --description "Medium (3-5 points) — standard story" --repo "REPO" --force
+gh label create "L" --color "F9D0C4" --description "Large (8 points) — complex feature" --repo "REPO" --force
+gh label create "XL" --color "E99695" --description "Extra Large (13 points) — should be broken down" --repo "REPO" --force
+```
+
+**E2E / CI labels:**
+
+```bash
+gh label create "nightly-failure" --color "D73A4A" --description "Failed in nightly E2E run" --repo "REPO" --force
+gh label create "smoke-failure" --color "D93F0B" --description "Failed in smoke suite" --repo "REPO" --force
+gh label create "regression-failure" --color "FBCA04" --description "Failed in regression suite" --repo "REPO" --force
+```
+
+**After running all commands, print:** "Created N labels on REPO."
+
+---
+
+### STEP 3 — Create sprint milestones
+
+Create one milestone per sprint. Calculate dates yourself — do NOT use `date -d`
+(it is not portable). Instead, compute dates by adding (sprint_number - 1) \* 14 days
+to SPRINT_START_DATE. Use `gh api` with ISO 8601 dates.
+
+For each sprint 1 through SPRINT_COUNT:
+
+```bash
+gh api repos/REPO/milestones --method POST \
+  --field title="Sprint 1 (2026-05-01 - 2026-05-14)" \
+  --field due_on="2026-05-14T23:59:59Z" \
+  --field description="Sprint 1"
+```
+
+```bash
+gh api repos/REPO/milestones --method POST \
+  --field title="Sprint 2 (2026-05-15 - 2026-05-28)" \
+  --field due_on="2026-05-28T23:59:59Z" \
+  --field description="Sprint 2"
+```
+
+(Continue for all sprints. Calculate the actual dates — do not use placeholder dates.)
+
+**Then create release milestones from the RELEASES config:**
+
+```bash
+gh api repos/REPO/milestones --method POST \
+  --field title="v1.0.0 — MVP" \
+  --field due_on="2026-08-01T23:59:59Z" \
+  --field description="Minimum viable product"
+```
+
+(One command per release entry.)
+
+If any milestone already exists (HTTP 422), skip it and continue.
+
+**After running all commands, print:** "Created N sprint milestones + N release milestones."
+
+---
+
+### STEP 4 — Create issue templates
+
+Write these files to the repo. If the file already exists, **skip it** and print a
+notice — do not overwrite existing templates.
+
+**4a. Write `.github/ISSUE_TEMPLATE/story.yml`**
+
+Content — generate the epic dropdown options from the EPICS config:
+
+```yaml
+name: Story
+description: Create a new user story
+labels: ["story"]
+body:
+  - type: dropdown
+    id: epic
+    attributes:
+      label: Epic
+      description: Which epic does this story belong to?
+      options:
+        - "Epic 1 — Project Bootstrap & Auth"
+        - "Epic 2 — Core Inventory CRUD"
+        - "Epic 3 — Location & Hierarchy"
+        - "Epic 4 — Work Order System"
+        - "Epic 5 — Firmware Management"
+    validations:
+      required: true
+
+  - type: input
+    id: story-id
+    attributes:
+      label: Story ID
+      description: "Unique story identifier (e.g., S-1.1)"
+      placeholder: "S-X.Y"
+    validations:
+      required: true
+
+  - type: input
+    id: story-points
+    attributes:
+      label: Story Points
+      description: "Estimated effort (1, 2, 3, 5, 8, 13)"
+      placeholder: "3"
+    validations:
+      required: true
+
+  - type: textarea
+    id: user-story
+    attributes:
+      label: User Story
+      description: "As a [role], I want [capability] so that [benefit]."
+      placeholder: "As a technician, I want to scan a device barcode so that I can quickly pull up its details."
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: "Checkboxes for each acceptance criterion"
+      value: |
+        - [ ] Criterion 1
+        - [ ] Criterion 2
+        - [ ] Criterion 3
+    validations:
+      required: true
+
+  - type: textarea
+    id: e2e-coverage
+    attributes:
+      label: E2E Test Coverage
+      description: "List the E2E test scenarios that should cover this story"
+      placeholder: |
+        - e2e/specs/inventory/create-device.spec.ts
+        - Verify form validation
+        - Verify success notification
+    validations:
+      required: false
+
+  - type: textarea
+    id: definition-of-done
+    attributes:
+      label: Definition of Done
+      description: "Checklist for completeness"
+      value: |
+        - [ ] Code reviewed and approved
+        - [ ] Unit tests passing (>= 85% coverage)
+        - [ ] E2E tests passing
+        - [ ] No lint errors
+        - [ ] Accessibility checked (WCAG 2.1 AA)
+        - [ ] Documentation updated (if applicable)
+    validations:
+      required: false
+```
+
+**4b. Write `.github/ISSUE_TEMPLATE/bug.yml`**
+
+```yaml
+name: Bug Report
+description: Report a bug or defect
+labels: ["bug"]
+body:
+  - type: input
+    id: parent-story
+    attributes:
+      label: Parent Story
+      description: "Reference the related story issue (e.g., #42)"
+      placeholder: "#"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: How severe is this bug?
+      options:
+        - "Critical — System unusable / data loss"
+        - "High — Major feature broken, no workaround"
+        - "Medium — Feature impaired, workaround exists"
+        - "Low — Minor issue, cosmetic"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: browser
+    attributes:
+      label: Browser
+      description: Which browser(s) are affected?
+      multiple: true
+      options:
+        - Chrome
+        - Firefox
+        - Safari / WebKit
+        - Edge
+        - All
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: "Clear description of the bug"
+      placeholder: "When I click X, Y happens instead of Z."
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: "Numbered steps to reproduce the bug"
+      value: |
+        1. Go to '...'
+        2. Click on '...'
+        3. Scroll down to '...'
+        4. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: "Screenshots, console errors, network traces, or E2E test output"
+      placeholder: "Paste screenshots or error logs here"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Environment
+      description: Which environment did this occur in?
+      options:
+        - Local development
+        - Dev (AWS)
+        - Staging (AWS)
+        - Production (AWS)
+    validations:
+      required: true
+```
+
+**4c. Write `.github/ISSUE_TEMPLATE/task.yml`**
+
+```yaml
+name: Task
+description: Technical task, chore, or tech debt item
+labels: ["task"]
+body:
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      description: What kind of task is this?
+      options:
+        - "Tech Debt — Refactoring or cleanup"
+        - "Infrastructure — CI/CD, Terraform, DevOps"
+        - "Documentation — Docs, ADRs, guides"
+        - "Testing — Test coverage, framework improvements"
+        - "Dependency — Library updates, security patches"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: "What needs to be done and why?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Done When
+      description: "How do we know this is complete?"
+      value: |
+        - [ ] Criterion 1
+        - [ ] Criterion 2
+    validations:
+      required: true
+```
+
+**4d. Write `.github/ISSUE_TEMPLATE/config.yml`**
+
+Replace ORG and REPO with actual values:
+
+```yaml
+blank_issues_enabled: false
+contact_links:
+  - name: Project Board
+    url: https://github.com/orgs/ORG/projects/1
+    about: View the project board for current sprint status
+  - name: Documentation
+    url: https://github.com/REPO/tree/main/Docs
+    about: Browse project documentation and specs
+```
+
+---
+
+### STEP 5 — Create PR template
+
+Write `.github/PULL_REQUEST_TEMPLATE.md`:
+
+```markdown
+## Summary
+
+<!-- 1-3 sentences: what changed and why -->
+
+## Changes
+
+-
+-
+-
+
+## Testing
+
+- [ ] Unit tests passing (>= 85% coverage on changed files)
+- [ ] E2E tests passing (if UI change)
+- [ ] Manual smoke test completed
+- [ ] No lint errors
+- [ ] Build succeeds
+
+## Accessibility
+
+- [ ] Keyboard navigation works
+- [ ] Screen reader tested (if new UI)
+- [ ] Color contrast meets WCAG 2.1 AA
+
+## Screenshots
+
+<!-- Before/after screenshots for UI changes. Delete if not applicable. -->
+
+## Related Issues
+
+Closes #
+```
+
+---
+
+### STEP 6 — Create CODEOWNERS
+
+Write `.github/CODEOWNERS` using the TEAM config values. Replace placeholders with
+actual GitHub usernames:
+
+```
+# Default — team leads review everything not covered below
+*                           @lead-username
+
+# Frontend
+src/                        @dev1 @dev2
+
+# Infrastructure
+infra/                      @devops1
+.github/workflows/          @devops1 @lead-username
+
+# E2E tests
+e2e/                        @qa1
+
+# Documentation
+Docs/                       @lead-username
+```
+
+---
+
+### STEP 7 — Create the GitHub Project
+
+```bash
+gh project create --owner "ORG" --title "PROJECT_NAME"
+```
+
+After this command succeeds, retrieve the project number:
+
+```bash
+gh project list --owner "ORG" --format json
+```
+
+Find the project with the matching title in the JSON output and note its `number` field.
+You will need this number for Step 8.
+
+---
+
+### STEP 8 — Create custom fields on the project
+
+Use the project number from Step 7 in every command below. Replace PROJECT_NUMBER.
+
+**8a. Priority field (Single Select):**
+
+```bash
+gh project field-create PROJECT_NUMBER --owner "ORG" --name "Priority" --data-type "SINGLE_SELECT"
+```
+
+After creation, retrieve the field ID:
+
+```bash
+gh project field-list PROJECT_NUMBER --owner "ORG" --format json
+```
+
+Find the field named "Priority" and note its `id`. Then add the options via GraphQL:
+
+```bash
+gh api graphql -f query='
+mutation($projectId: ID!, $fieldId: ID!) {
+  updateProjectV2Field(input: {
+    projectId: $projectId
+    fieldId: $fieldId
+    singleSelectOptions: [
+      {name: "P0-Critical", color: RED, description: "Drop everything"}
+      {name: "P1-High", color: ORANGE, description: "Must fix this sprint"}
+      {name: "P2-Medium", color: YELLOW, description: "Plan for next sprint"}
+      {name: "P3-Low", color: GREEN, description: "Nice to have"}
+    ]
+  }) {
+    projectV2Field {
+      ... on ProjectV2SingleSelectField { id name }
+    }
+  }
+}' -f projectId="PROJECT_ID" -f fieldId="PRIORITY_FIELD_ID"
+```
+
+Replace PROJECT*ID with the project's node ID (from `gh project list --format json`,
+look for the `id` field — it starts with `PVT*`).
+
+**8b. Story Points field (Number):**
+
+```bash
+gh project field-create PROJECT_NUMBER --owner "ORG" --name "Story Points" --data-type "NUMBER"
+```
+
+**8c. Epic field (Single Select):**
+
+```bash
+gh project field-create PROJECT_NUMBER --owner "ORG" --name "Epic" --data-type "SINGLE_SELECT"
+```
+
+Then retrieve the Epic field ID from `gh project field-list` and add options via GraphQL,
+one per EPICS config entry:
+
+```bash
+gh api graphql -f query='
+mutation($projectId: ID!, $fieldId: ID!) {
+  updateProjectV2Field(input: {
+    projectId: $projectId
+    fieldId: $fieldId
+    singleSelectOptions: [
+      {name: "Epic 1 — Project Bootstrap & Auth", color: PURPLE}
+      {name: "Epic 2 — Core Inventory CRUD", color: PURPLE}
+      {name: "Epic 3 — Location & Hierarchy", color: PURPLE}
+      {name: "Epic 4 — Work Order System", color: PURPLE}
+      {name: "Epic 5 — Firmware Management", color: PURPLE}
+    ]
+  }) {
+    projectV2Field {
+      ... on ProjectV2SingleSelectField { id name }
+    }
+  }
+}' -f projectId="PROJECT_ID" -f fieldId="EPIC_FIELD_ID"
+```
+
+**8d. Sprint field (Iteration):**
+
+```bash
+gh project field-create PROJECT_NUMBER --owner "ORG" --name "Sprint" --data-type "ITERATION"
+```
+
+NOTE: The iteration start date and duration CANNOT be set via the API. This must be
+configured manually in the GitHub UI after creation. Flag this in the manual steps output.
+
+**8e. Status field options:**
+
+The Status field is auto-created with every project. Retrieve its field ID from
+`gh project field-list`, then update its options to match the team's workflow:
+
+```bash
+gh api graphql -f query='
+mutation($projectId: ID!, $fieldId: ID!) {
+  updateProjectV2Field(input: {
+    projectId: $projectId
+    fieldId: $fieldId
+    singleSelectOptions: [
+      {name: "Backlog", color: GRAY, description: "Not yet planned"}
+      {name: "Sprint Ready", color: BLUE, description: "Groomed and estimated"}
+      {name: "In Development", color: YELLOW, description: "Currently being coded"}
+      {name: "In Review", color: ORANGE, description: "PR open, awaiting review"}
+      {name: "In QA", color: PURPLE, description: "Merged, being tested"}
+      {name: "Done", color: GREEN, description: "Accepted and deployed"}
+      {name: "Blocked", color: RED, description: "Cannot proceed"}
+    ]
+  }) {
+    projectV2Field {
+      ... on ProjectV2SingleSelectField { id name }
+    }
+  }
+}' -f projectId="PROJECT_ID" -f fieldId="STATUS_FIELD_ID"
+```
+
+---
+
+### STEP 9 — Set branch protection on main
+
+```bash
+gh api repos/REPO/branches/main/protection --method PUT \
+  --input - <<'EOF'
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["build-and-test"]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 1,
+    "dismiss_stale_reviews": true,
+    "require_code_owner_reviews": true
+  },
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false
+}
+EOF
+```
+
+If this fails with 403 (insufficient permissions), print:
+"Branch protection requires admin access. See manual steps."
+
+---
+
+### STEP 10 — Commit and push all new files
+
+Stage only the files created in this session:
+
+```bash
+git add .github/ISSUE_TEMPLATE/story.yml .github/ISSUE_TEMPLATE/bug.yml .github/ISSUE_TEMPLATE/task.yml .github/ISSUE_TEMPLATE/config.yml .github/PULL_REQUEST_TEMPLATE.md .github/CODEOWNERS
+git commit -m "chore: bootstrap GitHub Projects setup — templates, labels, CODEOWNERS"
+git push
+```
+
+---
+
+### STEP 11 — Verify setup
+
+Run these verification commands and print the results:
+
+```bash
+echo "=== Labels ==="
+gh label list --repo "REPO" --limit 100
+
+echo "=== Milestones ==="
+gh api repos/REPO/milestones --jq '.[].title'
+
+echo "=== Project ==="
+gh project list --owner "ORG"
+
+echo "=== Project Fields ==="
+gh project field-list PROJECT_NUMBER --owner "ORG"
+```
+
+---
+
+### STEP 12 — Print summary and manual steps
+
+After ALL automated steps complete, print this exact output:
+
+```
+================================================================
+  SETUP COMPLETE — Automated Steps
+================================================================
+
+  Labels created:     ~35 (type, priority, epic, status, size, E2E)
+  Milestones created: SPRINT_COUNT sprints + N releases
+  Issue templates:    story.yml, bug.yml, task.yml, config.yml
+  PR template:        PULL_REQUEST_TEMPLATE.md
+  CODEOWNERS:         .github/CODEOWNERS
+  Project:            PROJECT_NAME (with Status, Priority, Story Points, Epic, Sprint fields)
+  Branch protection:  main (require PR + review + status checks)
+
+================================================================
+  MANUAL STEPS REQUIRED — Complete in GitHub web UI
+  (GitHub has no API for these — they must be done by hand)
+================================================================
+
+  See the "Manual Steps After Automation" section in:
+  Docs/github-projects-setup-prompt.md (Section 3)
+
+================================================================
+```
+````
+
+---END---
+
+---
+
+## 3. Manual Steps After Automation
+
+These 5 tasks **cannot be automated** because GitHub provides no API for them.
+Complete them in the GitHub web UI after running the prompt above.
+
+**Estimated time:** 15-20 minutes total.
+
+---
+
+### Manual Step 1: Configure Sprint Iterations (5 min)
+
+The prompt created the Sprint field, but iteration dates must be set in the UI.
+
+1. Open your project board: `https://github.com/orgs/ORG/projects/N`
+2. Click the **three-dot menu** (top-right) and select **Settings**
+3. In the left sidebar, click the **Sprint** field
+4. Set **Duration** to your sprint length (e.g., 2 weeks)
+5. Set **Start date** to your first sprint date (matches `SPRINT_START_DATE` from config)
+6. GitHub auto-generates sequential iterations. Rename each one if needed:
+   - Click the iteration name to edit it
+   - Rename to match your milestones: `Sprint 1 (2026-05-01 - 2026-05-14)`, etc.
+7. Click **Save changes**
+
+**How to verify:** The Sprint field should show in Table view as a dropdown with
+dated iterations. Filter `iteration:@current` should return items in today's sprint.
+
+---
+
+### Manual Step 2: Create Project Views (5 min)
+
+Create 7 views — one for each team activity.
+
+For each view below:
+
+1. Click the **"+"** tab at the top of the project board
+2. Select the **Layout** type (Table, Board, or Roadmap)
+3. Click the tab name to rename it
+4. Apply the **Filter** using the filter bar at the top
+5. Set **Group By** from the view menu (funnel icon)
+6. The view auto-saves
+
+| #   | View Name        | Layout  | Filter                           | Group By  | Purpose               |
+| --- | ---------------- | ------- | -------------------------------- | --------- | --------------------- |
+| 1   | Current Sprint   | Board   | `iteration:@current`             | (none)    | Daily standup board   |
+| 2   | Backlog          | Table   | `status:Backlog`                 | Priority  | Backlog grooming      |
+| 3   | My Work          | Table   | `assignee:@me is:open`           | Status    | Personal task list    |
+| 4   | By Epic          | Table   | `is:open`                        | Epic      | Cross-epic visibility |
+| 5   | Bug Triage       | Table   | `label:bug is:open`              | Priority  | Bug management        |
+| 6   | Release Roadmap  | Roadmap | (all items)                      | Milestone | Stakeholder timeline  |
+| 7   | Done This Sprint | Table   | `iteration:@current status:Done` | (none)    | Sprint review prep    |
+
+**How to verify:** Click through each tab. The view should show the correct subset of items.
+
+---
+
+### Manual Step 3: Enable Built-In Workflows (3 min)
+
+1. Open the project board
+2. Click **three-dot menu** (top-right) > **Settings**
+3. Click **Workflows** in the left sidebar
+4. For each workflow below, click it, toggle **On**, configure the action, and click **Save**:
+
+| #   | Workflow               | Toggle | Action                                                                    |
+| --- | ---------------------- | ------ | ------------------------------------------------------------------------- |
+| 1   | Auto-add to project    | **On** | Repository: your repo. Filter: `label:story,bug`. Set Status: **Backlog** |
+| 2   | Item closed            | **On** | Set Status to **Done**                                                    |
+| 3   | Item reopened          | **On** | Set Status to **Sprint Ready**                                            |
+| 4   | Pull request merged    | **On** | Set Status to **Done**                                                    |
+| 5   | Code review approved   | **On** | Set Status to **In QA**                                                   |
+| 6   | Code changes requested | **On** | Set Status to **In Development**                                          |
+
+**How to verify:** Create a test issue with the `story` label. It should automatically
+appear on the project board in the "Backlog" column. Close it — it should move to "Done."
+
+---
+
+### Manual Step 4: Create Insights Charts (5 min)
+
+1. Open the project board
+2. Click the **Insights** tab (bar-chart icon, next to the view tabs)
+3. For each chart below, click **New chart**, configure it, and click **Save**:
+
+| #   | Chart Name      | Type       | X-Axis    | Y-Axis              | Group By | Filter               |
+| --- | --------------- | ---------- | --------- | ------------------- | -------- | -------------------- |
+| 1   | Sprint Burn-Up  | Historical | Time      | Count of items      | Status   | `iteration:@current` |
+| 2   | Velocity Trend  | Current    | Iteration | Sum of Story Points | (none)   | `status:Done`        |
+| 3   | Status Overview | Current    | Status    | Count of items      | (none)   | (none)               |
+| 4   | Bug Trend       | Historical | Time      | Count of items      | Priority | `label:bug`          |
+| 5   | Epic Progress   | Current    | Epic      | Count of items      | Status   | (none)               |
+| 6   | Team Workload   | Current    | Assignee  | Count of items      | Status   | `is:open`            |
+
+**How to verify:** Each chart should render. The Sprint Burn-Up will be empty until
+issues are assigned to the current iteration.
+
+---
+
+### Manual Step 5: Verify Branch Protection (1 min)
+
+If the automated branch protection command (Step 9) succeeded, verify it:
+
+1. Go to: `Repo > Settings > Branches > Branch protection rules`
+2. Click the rule for `main`
+3. Confirm these are checked:
+   - [x] Require a pull request before merging
+   - [x] Require approvals (1)
+   - [x] Require review from Code Owners
+   - [x] Require status checks to pass (build-and-test)
+   - [x] Do not allow force pushes
+   - [x] Do not allow deletions
+
+If the automated command failed (403), create the rule manually by checking the boxes above.
+
+---
+
+## 4. Verification Checklist
+
+After completing both automated AND manual steps, use this checklist to confirm
+everything is set up correctly.
+
+### Quick verification commands
+
+```bash
+# Count labels (expect ~35)
+gh label list --repo "REPO" --limit 100 | wc -l
+
+# Count milestones (expect SPRINT_COUNT + number of releases)
+gh api repos/REPO/milestones | python -c "import sys,json; print(len(json.load(sys.stdin)))"
+
+# Verify project exists
+gh project list --owner "ORG"
+
+# Verify templates exist
+ls .github/ISSUE_TEMPLATE/
+# Expected: story.yml  bug.yml  task.yml  config.yml
+
+# Verify PR template exists
+ls .github/PULL_REQUEST_TEMPLATE.md
+
+# Verify CODEOWNERS exists
+ls .github/CODEOWNERS
+```
+
+### Full checklist
+
+| Category         | Item                                            | Check |
+| ---------------- | ----------------------------------------------- | ----- |
+| **Labels**       | Type labels exist (story, bug, enhancement...)  | [ ]   |
+| **Labels**       | Priority labels exist (P0-P3)                   | [ ]   |
+| **Labels**       | Epic labels exist (epic:1 through epic:N)       | [ ]   |
+| **Labels**       | Size labels exist (XS, S, M, L, XL)             | [ ]   |
+| **Labels**       | Status labels exist (qa-plan, blocked...)       | [ ]   |
+| **Milestones**   | Sprint milestones created with correct dates    | [ ]   |
+| **Milestones**   | Release milestones created with due dates       | [ ]   |
+| **Templates**    | Story template renders in "New Issue" chooser   | [ ]   |
+| **Templates**    | Bug template renders in "New Issue" chooser     | [ ]   |
+| **Templates**    | Task template renders in "New Issue" chooser    | [ ]   |
+| **Templates**    | Blank issues disabled (config.yml)              | [ ]   |
+| **Templates**    | PR template renders on new PR creation          | [ ]   |
+| **CODEOWNERS**   | File exists and has correct team assignments    | [ ]   |
+| **Project**      | Project visible at org level                    | [ ]   |
+| **Project**      | Status field has 7 options (Backlog...Blocked)  | [ ]   |
+| **Project**      | Priority field has 4 options (P0...P3)          | [ ]   |
+| **Project**      | Story Points field exists (Number type)         | [ ]   |
+| **Project**      | Epic field has N options (matches EPICS config) | [ ]   |
+| **Project**      | Sprint field exists (Iteration type)            | [ ]   |
+| **Project**      | Sprint iterations have correct dates            | [ ]   |
+| **Views**        | 7 views created (Sprint, Backlog, My Work...)   | [ ]   |
+| **Workflows**    | 6 workflows enabled and configured              | [ ]   |
+| **Charts**       | 6 Insights charts created                       | [ ]   |
+| **Branch rules** | main branch requires PR + review + CI           | [ ]   |
+
+---
+
+## 5. Troubleshooting
+
+### "Resource not accessible by integration" (403)
+
+Your `gh` token is missing scopes. Run:
+
+```bash
+gh auth refresh -s repo,project,read:org,admin:org
+```
+
+### "Validation Failed" (422) on milestone creation
+
+The milestone already exists. This is safe to ignore — the prompt handles it.
+
+### "Could not resolve to a ProjectV2" on field-create
+
+The project number is wrong. Re-check with:
+
+```bash
+gh project list --owner "ORG"
+```
+
+Use the **number** column, not the ID.
+
+### Labels not appearing on the project board
+
+Labels are repo-level, not project-level. They appear on issues, not directly on the
+board. Use `label:X` in the board's filter bar to see them.
+
+### Sprint field shows no iterations
+
+You need to complete Manual Step 1 (Configure Sprint Iterations). The API cannot set
+iteration dates — only the UI can.
+
+### CODEOWNERS not enforced on PRs
+
+Branch protection must be configured with "Require review from Code Owners" checked.
+See Manual Step 5.
+
+### GraphQL mutation fails for field options
+
+The `updateProjectV2Field` mutation requires the project's **node ID** (starts with
+`PVT_`), not the project number. Get it from:
+
+```bash
+gh project list --owner "ORG" --format json
+```
+
+Look for the `id` field in the JSON output.


### PR DESCRIPTION
## Summary

Adds three companion documents for Product / Delivery stakeholders:

- **`Docs/Requirement.md`** — Purely business-facing requirements document (PO / PDM view). 102 numbered business requirements (`BR-001` → `BR-102`), 8 policy groups (`BP-*`), personas, OKRs, non-functional expectations stated in business language, and a glossary. No technology, architecture, or implementation detail.
- **`Docs/Implementation-Plan.md`** — Shows how the requirements are delivered across the 6 build cycles already present on [GitHub Project #1](https://github.com/users/gauravmakkar29/projects/1) (`Release` field). Includes a Requirement → Build → Epic → Story traceability matrix, per-build exit criteria, cross-build dependency map, and release/risk register.
- **`Docs/github-projects-setup-prompt.md`** — Reusable automation prompt for bootstrapping a GitHub Projects V2 board on any repo (labels, milestones, templates, CODEOWNERS, branch protection, views). Includes Jira ↔ GitHub terminology alignment + demo link list.

No code changes. Documentation-only PR.

## Test plan

- [ ] Open `Docs/Requirement.md` — renders cleanly, all section anchors work
- [ ] Open `Docs/Implementation-Plan.md` — traceability table + per-build sections render
- [ ] Open `Docs/github-projects-setup-prompt.md` — tables render, link placeholders (`ORG`, `REPO`, `N`) are clearly flagged as such

🤖 Generated with [Claude Code](https://claude.com/claude-code)