### PR TITLE
docs: clarify build cycles live in Project Release field, not milestones

### DIFF
--- a/Docs/Implementation-Plan.md
+++ b/Docs/Implementation-Plan.md
@@ -44,14 +44,17 @@
 
 ### 1.3 Artifact locations
 
-| Artifact                      | Location                                                                              |
-| ----------------------------- | ------------------------------------------------------------------------------------- |
-| Business requirements         | [`Docs/Requirement.md`](./Requirement.md)                                             |
-| Build / Epic / Story tracking | [GitHub Project #1](https://github.com/users/gauravmakkar29/projects/1)               |
-| Epic milestones               | [GitHub Milestones](https://github.com/gauravmakkar29/InventoryManagement/milestones) |
-| Story detail                  | `Docs/epics/epic-{N}/story-{N.M}.md`                                                  |
-| Per-epic tech spec            | `Docs/epics/epic-{N}/tech-spec.md`                                                    |
-| Master brief                  | `Docs/IMS-Gen2-Detailed-Project-Brief-For-Terraform.md`                               |
+> **Heads-up on Build Cycles vs Milestones.** Build cycles ("Build 1 — Core Platform", …) are **NOT** GitHub milestones. They live **only** as options on the `Release` single-select field inside [Project #1](https://github.com/users/gauravmakkar29/projects/1). The repo's [Milestones page](https://github.com/gauravmakkar29/InventoryManagement/milestones) is used exclusively for **epics** (one milestone per epic). To see build-cycle grouping, open the project board and group / filter by the `Release` field.
+
+| Artifact                  | Location                                                                                                                                            |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Business requirements     | [`Docs/Requirement.md`](./Requirement.md)                                                                                                           |
+| **Build cycles**          | [Project #1](https://github.com/users/gauravmakkar29/projects/1) → `Release` field (6 options: Build 1–6). Not in the Milestones page.              |
+| **Epic grouping**         | [GitHub Milestones](https://github.com/gauravmakkar29/InventoryManagement/milestones) — one milestone per epic (Epic 1 … Epic 27).                  |
+| Issue / Story tracking    | [Project #1 board](https://github.com/users/gauravmakkar29/projects/1) — sort, filter, and group by Status, Sprint, Priority, Release (build), etc. |
+| Story detail (functional) | `Docs/epics/epic-{N}/story-{N.M}.md`                                                                                                                |
+| Per-epic tech spec        | `Docs/epics/epic-{N}/tech-spec.md`                                                                                                                  |
+| Master brief              | `Docs/IMS-Gen2-Detailed-Project-Brief-For-Terraform.md`                                                                                             |
 
 ---
 
@@ -68,7 +71,7 @@ IMS Gen 2 is delivered across **six build cycles**. Each cycle builds on the pre
 | **5** | **Quality & Resilience**      |    18 | 21, 22            | Refactor state management and data layer for long-term maintainability and consistent behaviour under load.                                                                      |
 | **6** | **Production Ready**          |     5 | 23                | Final design-system consolidation and release-candidate polish for GA.                                                                                                           |
 
-> **Where this lives:** the `Release` single-select field on [GitHub Project #1](https://github.com/users/gauravmakkar29/projects/1) stores each item's build-cycle assignment. Filtering the board by `Release` reproduces the same grouping used below.
+> **Where this lives.** Build cycles are stored as values of the `Release` single-select field on [GitHub Project #1](https://github.com/users/gauravmakkar29/projects/1) — **not** as GitHub Milestones. Open the project, group or filter the board by `Release`, and you'll see the same six-cycle grouping used in this document. The [Milestones page](https://github.com/gauravmakkar29/InventoryManagement/milestones) holds epics only.
 
 ---
 


### PR DESCRIPTION
## Summary

Reported confusion: the artifact-locations table in `Implementation-Plan.md` §1.3 placed **"Build / Epic / Story tracking"** and **"Epic milestones"** in adjacent rows, which read as if build cycles could also be found on the [Milestones page](https://github.com/gauravmakkar29/InventoryManagement/milestones). They cannot — milestones only hold **epics**; build cycles are the `Release` single-select field inside [Project #1](https://github.com/users/gauravmakkar29/projects/1).

### What changed

- **§1.3 Artifact locations** — split "Build cycles" and "Epic grouping" into their own rows with explicit descriptions of what each holds and where to click. Added a prominent heads-up callout above the table stating the distinction in one sentence.
- **§2 Build Cycle Overview — "Where this lives" note** — reworded to emphasise that build cycles are **not** milestones and to direct the reader to group/filter the project board by `Release`.

### Not changed

- The six build cycles, their naming, or their epic membership.
- The traceability matrix in §3.

## Test plan

- [ ] Click the [Milestones](https://github.com/gauravmakkar29/InventoryManagement/milestones) link from §1.3 → expect to see only epic milestones (no "Build 1", "Build 2", …).
- [ ] Click the [Project #1](https://github.com/users/gauravmakkar29/projects/1) link → open field settings → `Release` field shows the six Build options.
- [ ] Readers skimming §1.3 should no longer expect build cycles on the Milestones page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)