### PR TITLE
[Epic 28 Phase 1] Compliance primitives library — Evidence, Checklist, Approval

### DIFF
--- a/Docs/epics/epic-28/epic-28-overview.md
+++ b/Docs/epics/epic-28/epic-28-overview.md
@@ -1,0 +1,87 @@
+# Epic 28 — Enterprise Compliance Workflow Patterns
+
+## Vision
+
+Ship a **reusable library of enterprise compliance primitives** on top of the IMS Gen 2 template — provider-abstracted, provider-swappable, domain-agnostic. Any team cloning the template for a regulated application (loan processing, clinical trials, contract lifecycle, GRC, release management, regulatory filings, etc.) gets the hard parts — immutable evidence storage, multi-document gated approvals, conditional exceptions with SLAs, scoped secure distribution, closed-loop provenance, and inverse dependency queries — out of the box. The IMS firmware flow is the **reference implementation** that exercises the patterns; the patterns themselves have no firmware knowledge.
+
+## Business Context
+
+Every regulated enterprise application rebuilds the same primitives badly:
+
+- A file store that is tamper-evident _on paper_ but where an admin can still delete under the hood
+- An approval workflow that is two-state (approved/rejected) when reality is four-state (including conditional/exception)
+- A "waiver" capability that has no SLA, no alert, and quietly becomes permanent
+- "Download link" features that are either not signed, not single-use, not MFA-gated, or not audit-logged
+- Distribution records that say "shipped" without a corresponding "installed / confirmed" — a broken chain of custody
+- "Impact analysis" features missing entirely — teams grep logs to find out which consumers run version X
+
+For a template that aspires to be enterprise-grade, these seven primitives are **table stakes**. They are what make the difference between "the auditor accepts this evidence" and "the auditor wants more." ISO 27001, SOC 2, HIPAA, PCI-DSS, and NIST 800-53 all touch at least three of them.
+
+This epic is explicitly **not Sungrow-specific, not firmware-specific, not IMS-specific**. The reference implementation uses firmware intake/review/distribute/confirm because that is the app in front of us, but the primitives are generic and the abstractions are provider-pluggable.
+
+## Architecture Principles
+
+1. **Provider abstraction first** — Every primitive is an interface with at least two implementations (a mock adapter and a reference cloud adapter). This extends the Epic 19 template pattern (`IAuthAdapter`, etc.) to compliance workflow adapters (`IEvidenceStore`, `IApprovalEngine`, `ISecureDistribution`, etc.).
+2. **Domain-agnostic types** — No type in this epic references `Firmware`, `Device`, `SBOM`, or any IMS entity. Types use generic parameters (`Evidence<T>`, `Approval<T>`, `Consumer<T>`).
+3. **Composable, not framework-ized** — Each primitive is independently useful. Consumers pick the pieces they need; there is no "enable the compliance framework" master switch.
+4. **Reference implementation inside IMS** — Stories ship with working wiring in the firmware flow so the patterns are demonstrable and load-tested, not theoretical.
+5. **Rulebook-compliant** — Every primitive honors `security-nist-rulebook.md` (AU-2/3 audit, AC-3 RBAC), `architecture-rulebook.md` (provider seams, error layering), `api-data-layer-rulebook.md` (TanStack Query, DTO/domain mapping), and `code-quality-rulebook.md` (no `any`, ≥85% coverage, file size limits).
+
+## Enterprise Standards (MUST match existing codebase quality)
+
+| Standard                                      | Reference Implementation                                   | Applies To                                                                                                               |
+| --------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| **Factory functions** (`createXxxProvider()`) | `createMockApiProvider()`, `createAmplifyAuthAdapter()`    | Every new primitive — `createS3EvidenceStore()`, `createMockEvidenceStore()`, etc.                                       |
+| **JSDoc with `@example`**                     | `IAuthAdapter` in `auth-adapter.ts`                        | Every new public interface, type, and factory                                                                            |
+| **TanStack Query integration**                | Existing `useQuery`/`useMutation` patterns                 | All read hooks use `useQuery` with stable cache keys; writes use `useMutation` with optimistic rollback where applicable |
+| **RBAC enforcement**                          | `canAccess()`, `canPerform()` in `src/lib/rbac.ts`         | Approval gates, waivers, and distribution MUST route through existing RBAC, not duplicate role logic                     |
+| **NIST compliance**                           | AU-2/AU-3 audit logging, AC-3 access enforcement, AC-5 SoD | Every state transition is audit-logged with actor + reason + timestamp; approval + self-request is blocked               |
+| **Readonly config properties**                | `refreshIntervalMs` in `IAuthAdapter`                      | All adapter config interfaces use `readonly`                                                                             |
+| **Accessibility**                             | Existing WCAG 2.1 AA + Storybook a11y addon                | All new surfaces keyboard-navigable; screen-reader-announced timers/alerts                                               |
+| **Error classification**                      | `api-data-layer-rulebook.md` §4                            | Each primitive surfaces typed errors (`EvidenceImmutabilityError`, `SlaBreachError`, etc.)                               |
+
+## Stories
+
+| Story | Title                                                    | Phase               | Points | Priority |
+| ----- | -------------------------------------------------------- | ------------------- | ------ | -------- |
+| 28.1  | Immutable Evidence Store — Provider Interface & Adapters | 1 — Foundation      | 8      | P0       |
+| 28.2  | Document Completeness Engine — Checklist Primitive       | 1 — Foundation      | 5      | P0       |
+| 28.3  | Gated Approval State Machine                             | 1 — Foundation      | 8      | P0       |
+| 28.4  | Conditional Approval with SLA Tracking                   | 2 — Exception Mgmt  | 5      | P1       |
+| 28.5  | Scoped One-Time Secure Distribution                      | 2 — Delivery        | 5      | P1       |
+| 28.6  | Two-Phase Action Confirmation (Chain of Custody)         | 3 — Provenance      | 5      | P2       |
+| 28.7  | Inverse Dependency Query — Version → Consumers           | 3 — Impact Analysis | 5      | P2       |
+
+**Total: 41 points across 3 phases.**
+
+## Dependencies
+
+- **Epic 19 (Template — Provider Pluggability)** — Story 19.7 (API client) and Story 19.15 (security/CSP) are sibling foundations; this epic extends the same provider-adapter pattern established there
+- **Epic 8 (Audit Trail)** — every state transition in this epic writes AUDIT# records through the existing pipeline
+- **Existing RBAC** (`src/lib/rbac.ts`) — approval authority, waiver authority, distribution authority are expressed as new actions in the existing RBAC table, not as a parallel system
+- **TanStack Query** — all read/write hooks follow the established pattern
+
+## Out of Scope (Explicitly Deferred)
+
+- **Domain-specific workflow UIs** — this epic delivers primitives and a reference wiring in the firmware flow; building compliance workflows for _other_ domains is downstream template-consumer work
+- **Cryptographic evidence signing / notarization chains** — WORM storage is sufficient for the 90% case; cryptographic signing is a Phase 4 stretch (out of scope here)
+- **Retention policy lifecycle management UI** — adapters honor retention settings at storage-provider level; a UI to modify retention policies per evidence class is deferred
+- **SLA escalation to external systems (PagerDuty, Slack)** — SLA alerts fire as in-app notifications + email; third-party escalation is a downstream integration
+- **Blast-radius visualization (graph render)** — Story 28.7 delivers the _query_ primitive and a tabular result UI; a graph/network visualization is deferred
+- **Multi-region evidence replication** — single-region immutable storage is sufficient for template; geo-replication is an infrastructure concern
+- **Workflow designer / BPMN UI** — the approval state machine in 28.3 is code-configurable; a drag-drop designer is out of scope
+
+## Delivery Sequence
+
+1. **Phase 1 — Foundation (P0):** Stories 28.1, 28.2, 28.3 — the three primitives every subsequent story depends on
+2. **Phase 2 — Exception & Delivery (P1):** Stories 28.4, 28.5 — layer on top of Phase 1
+3. **Phase 3 — Provenance & Impact (P2):** Stories 28.6, 28.7 — close the chain-of-custody loop and enable impact analysis
+
+## Success Metrics
+
+- Zero IMS/firmware/Sungrow type references in `src/lib/compliance/` public interfaces — verified by import-graph lint
+- At least two adapter implementations per primitive (mock + reference cloud), swappable via config without touching call sites
+- Reference firmware flow demonstrably uses every primitive end-to-end — auditor walkthrough passes in under 10 minutes
+- ≥ 85% unit test coverage on `src/lib/compliance/**` with both adapters exercised
+- Storybook surfaces for every new UI primitive (waiver dialog, SLA badge, approval state pill, impact query table)
+- Integration contract (`Docs/integration-contract.md`) updated with new env vars and adapter selection matrix

--- a/Docs/epics/epic-28/story-28.1.md
+++ b/Docs/epics/epic-28/story-28.1.md
@@ -1,0 +1,115 @@
+# Story 28.1: Immutable Evidence Store — Provider Interface & Adapters
+
+**Epic:** Epic 28 — Enterprise Compliance Workflow Patterns
+**Phase:** PHASE 1: FOUNDATION
+**Persona:** Compliance Officer (reference persona) / Template Consumer (audience)
+**Priority:** P0
+**Story Points:** 8
+**Status:** New
+
+## User Story
+
+As a compliance officer, I want every piece of evidence submitted to the platform to be stored in a tamper-evident, append-only store where no user — including platform administrators — can modify or delete the underlying bytes, so that the integrity of the audit trail is provable to an external auditor regardless of who later operates the system.
+
+## Preconditions
+
+- Epic 19 Story 19.5 (auth adapter pattern) established — this story extends the same provider-pluggability convention
+- `src/lib/rbac.ts` defines user roles and the `canPerform(action, resource)` primitive
+- Existing storage provider factory pattern documented in `Docs/integration-contract.md`
+- Feature flag `FEATURE_COMPLIANCE_LIB` available in runtime config
+
+## Context / Business Rules
+
+- **Immutability is a library invariant.** The `IEvidenceStore` interface does NOT expose `delete`, `update`, or `patch` methods. The type system, not a runtime check, prevents mutation.
+- **Retention modes:** `compliance` (cannot be overridden even by admin — matches S3 Object Lock COMPLIANCE mode); `governance` (admin override possible with audit trail — matches S3 Object Lock GOVERNANCE mode). Adapters document which modes they support.
+- **Content-addressed identity.** Every evidence record exposes a SHA-256 content hash. Two uploads of identical bytes produce the same hash, surfaced at the adapter level (deduplication is optional at the adapter level).
+- **Domain-free types.** No type in this story references firmware, device, SBOM, etc. `EvidenceMetadata` is generic and carries an optional `tags: Record<string, string>` for caller-specific labeling.
+- **Adapter parity.** The mock adapter and the S3 adapter pass identical behavioral tests. A parity harness is shipped as part of this story.
+- **Audit-logged operations.** Every `put` and every `getSignedReadUrl` writes an AUDIT# record with actor, evidenceId, contentHash, and timestamp (AU-2/AU-3).
+
+## Acceptance Criteria
+
+- [ ] AC1: `IEvidenceStore` interface is defined in `src/lib/compliance/evidence/evidence-store.interface.ts` with methods: `put(input)`, `get(id)`, `getSignedReadUrl(id, expiresInSeconds)`, `list(filter)`. No `delete`, `update`, or `patch` methods exist.
+- [ ] AC2: `EvidenceMetadata` type is defined with fields: `id`, `contentHash`, `mimeType`, `sizeBytes`, `uploadedAt`, `uploadedBy`, `retention` (mode + retainUntil), `tags` (record), `immutable: true`. All fields `readonly`.
+- [ ] AC3: `createMockEvidenceStore()` factory is implemented with in-memory storage that honors the interface; attempting to mutate a stored record via any means returns an `EvidenceImmutabilityError`.
+- [ ] AC4: `createS3EvidenceStore(config)` factory is implemented using AWS SDK v3 with `ObjectLockLegalHold` and `ObjectLockRetentionMode=COMPLIANCE` on every `PutObject` call. The adapter documents the required IAM policy and bucket configuration in a JSDoc block at the top of the file.
+- [ ] AC5: Both adapters compute SHA-256 of the payload client-side before upload and expose it on the returned `EvidenceMetadata.contentHash`.
+- [ ] AC6: A `useEvidence(id)` hook (TanStack Query) returns metadata with `staleTime: Infinity` — immutable records never stale.
+- [ ] AC7: A `useEvidenceSignedUrl(id, expiresInSeconds)` hook returns a signed read URL; the hook refreshes before expiry (safe margin = 30s).
+- [ ] AC8: A generic `<EvidenceViewer evidenceId={...}>` component renders read-only metadata, an inline preview for common mime types (pdf/image/json/text), a download button via signed URL, and an **"Immutable — cannot be modified or deleted"** badge with icon.
+- [ ] AC9: `EvidenceImmutabilityError` is thrown whenever any adapter rejects a modification attempt; error is classified and surfaced via the existing global error handler (Story 22.3).
+- [ ] AC10: Every `put` and every `getSignedReadUrl` writes an audit-log record with action + actor + evidenceId + contentHash via the existing audit pipeline (Epic 8).
+- [ ] AC11: RBAC: `canPerform("evidence.put", resource)` and `canPerform("evidence.read", resource)` are checked before adapter calls; unauthorized callers receive a classified `AccessDeniedError`.
+- [ ] AC12: An adapter parity test harness (`src/lib/compliance/evidence/evidence-store.parity.test.ts`) runs the identical 12-scenario test suite against both `createMockEvidenceStore()` and a localstack-backed `createS3EvidenceStore()`.
+- [ ] AC13: Reference wiring: firmware artifact upload in `src/app/components/firmware/firmware-intake-bundle.tsx` is refactored to call `useEvidenceStore().put(...)` instead of the legacy firmware-specific upload path. Legacy path remains behind `FEATURE_COMPLIANCE_LIB=off`.
+- [ ] AC14: Storybook stories for `EvidenceViewer` cover: pdf preview, image preview, json preview, unsupported mime (fallback), loading, error, unauthorized.
+- [ ] AC15: Unit tests cover interface implementations with ≥ 85% line coverage including error paths (immutability violation, unauthorized access, expired signed URL).
+
+## UI Behavior
+
+- **Evidence viewer** — header shows label + mime + size + upload actor + upload timestamp
+- **Immutability badge** — amber pill with a lock icon and tooltip "Stored under COMPLIANCE mode retention. No user can modify or delete this record."
+- **Download button** — primary action, triggers signed-URL flow; shows spinner while URL is minted; button disabled for 2 seconds after click to prevent double-download
+- **Preview area** — inline preview for pdf (iframe), image (img), json (syntax-highlighted), text (pre); unsupported types show "Preview unavailable — use Download" with mime type
+- **No edit/delete affordances are rendered anywhere** — enforced at the component level
+- **Error states:** unauthorized = locked-state card with "You do not have access to this evidence"; missing = "Evidence not found"; expired URL = auto-retry with new signed URL (user sees brief loading state)
+
+## Out of Scope
+
+- Multi-region replication of evidence (single-region is sufficient for this story)
+- Cryptographic signing or notarization of evidence (WORM storage is sufficient)
+- Evidence tagging/classification UI (tags are passed programmatically by callers)
+- Adapters for Azure Blob Immutable Storage or GCS Retention Policies (deferred; interface supports them)
+- Virus scanning (delegated to storage-provider features or a separate pre-signed scan pipeline)
+- Bulk upload UI (single-file `put` is the primitive; bulk UX is composed by callers)
+
+## Tech Spec Reference
+
+See [tech-spec.md](./tech-spec.md) §"File Layout → evidence/", §"Generic Types → Story 28.1", §"NIST 800-53 Mapping", §"Error Taxonomy".
+
+## Rulebook Compliance
+
+- **`security-nist-rulebook.md`** — AU-2/AU-3 (every put + signed URL audited), AC-3 (canPerform gating), SC-12 (KMS for S3 adapter), SI-10 (Zod validation on adapter boundaries), MP-6 (WORM sanitization constraint)
+- **`architecture-rulebook.md`** — provider interface + factory pattern, `src/lib/compliance/` placement, no UI→adapter direct imports (hooks only)
+- **`api-data-layer-rulebook.md`** — TanStack Query with stable cache key, `staleTime: Infinity` for immutable records, typed errors
+- **`code-quality-rulebook.md`** — no `any`, ≥ 85% coverage, file-size limits on adapters
+
+## Dev Checklist (NOT for QA)
+
+1. Create `src/lib/compliance/evidence/` folder
+2. Define interface, types, errors in dedicated files
+3. Implement `createMockEvidenceStore()` with immutable Map + throws on any mutation
+4. Implement `createS3EvidenceStore()` with `ObjectLockRetentionMode=COMPLIANCE` + KMS encryption
+5. Add `src/lib/compliance/evidence/index.ts` barrel
+6. Create `useEvidence` and `useEvidenceSignedUrl` hooks
+7. Create `<EvidenceViewer>` component + Storybook stories
+8. Add adapter factory resolver in `src/lib/compliance/index.ts` keyed on `EVIDENCE_STORE_PROVIDER`
+9. Wire firmware intake component to new primitive behind `FEATURE_COMPLIANCE_LIB`
+10. Add ESLint `no-restricted-imports` rule: `src/lib/compliance/**` cannot import from `src/lib/firmware/**`, `src/lib/device/**`, etc.
+11. Write parity test harness — shared scenarios run against every adapter
+12. Write unit tests for mock adapter, error paths, and hook behavior
+13. Update `Docs/integration-contract.md` with `EVIDENCE_STORE_PROVIDER` env var + IAM policy for S3 adapter
+
+## AutoGent Test Prompts
+
+1. **AC1 — Interface surface:** "Attempt to call `evidenceStore.delete('some-id')` — verify this is a TypeScript compile error. Attempt to call `evidenceStore.update(...)` — verify compile error."
+2. **AC3-AC4 — Put and retrieve:** "Using the mock adapter, call `put()` with a test PDF. Verify returned metadata has a non-empty `contentHash`, `immutable === true`, and `retention.mode === 'compliance'`. Call `get()` with the returned id. Verify identical metadata is returned."
+3. **AC5 — Content hash:** "Upload the same payload twice. Verify both returned records have the same `contentHash`."
+4. **AC8 — Viewer rendering:** "Render `<EvidenceViewer evidenceId='test-pdf'>` in Storybook. Verify the immutability badge is visible. Verify the download button is present. Verify no edit or delete buttons exist."
+5. **AC9 — Immutability error:** "Attempt (via a debug harness) to mutate a stored record. Verify `EvidenceImmutabilityError` is thrown and logged to the audit pipeline."
+6. **AC10 — Audit logging:** "Call `put()` as user Alice. Inspect the audit log. Verify an AUDIT# record exists with `action: 'evidence.put'`, `actor: 'alice'`, `evidenceId`, and `contentHash` fields."
+7. **AC11 — RBAC:** "As a user without `evidence.put` permission, attempt to call `put()`. Verify `AccessDeniedError` is thrown. Verify no audit record is created for the attempt except the denial event itself."
+8. **AC13 — Firmware reference wiring:** "With `FEATURE_COMPLIANCE_LIB=on`, upload a firmware artifact via the intake bundle UI. Verify the new `useEvidenceStore().put()` path is exercised. Turn the flag off; verify the legacy path is used."
+
+## Definition of Done
+
+- [ ] Code reviewed and approved
+- [ ] Unit tests passing with ≥ 85% coverage on new code
+- [ ] Adapter parity tests passing for mock + localstack S3
+- [ ] Storybook stories published for `EvidenceViewer`
+- [ ] `EVIDENCE_STORE_PROVIDER` env var documented in integration contract
+- [ ] ESLint `no-restricted-imports` rule in place and green
+- [ ] WCAG 2.1 AA — viewer keyboard-navigable, badge announced to screen readers
+- [ ] TypeScript strict — no `any` types
+- [ ] NIST mapping section of tech-spec verified (AU-2/3, AC-3, SC-12, SI-10, MP-6)
+- [ ] Audit-log integration test — put and getSignedReadUrl write AUDIT# records

--- a/Docs/epics/epic-28/story-28.2.md
+++ b/Docs/epics/epic-28/story-28.2.md
@@ -1,0 +1,112 @@
+# Story 28.2: Document Completeness Engine — Checklist Primitive
+
+**Epic:** Epic 28 — Enterprise Compliance Workflow Patterns
+**Phase:** PHASE 1: FOUNDATION
+**Persona:** Approval Reviewer (reference persona) / Template Consumer (audience)
+**Priority:** P0
+**Story Points:** 5
+**Status:** New
+
+## User Story
+
+As an approval reviewer, I want to see at a glance which required documents are present, missing, or waived for any submission under review, so that I can make an approval decision with full evidence of what is and is not accounted for — without having to audit N filesystems or tabs to figure out the state.
+
+## Preconditions
+
+- Story 28.1 shipped — evidence store interface is available (`IEvidenceStore`, `EvidenceMetadata`)
+- RBAC `canPerform("checklist.waive", resource)` is defined in `src/lib/rbac.ts` (waivers are reviewer-only; see business rules)
+- Story 28.4 (SLA tracker) design reviewed — this story introduces `waived-conditional` slot state that 28.4 then tracks deadlines for
+
+## Context / Business Rules
+
+- **Schema-driven.** A checklist is defined by a `ChecklistSchema<TKey>` — an array of `ChecklistSlot` entries with `key`, `label`, `required`, `description`. Consumers define their own schema; the primitive does not know what a "SBOM" or "FAT report" is.
+- **Four slot states:** `present` (evidenceId populated), `missing`, `waived-permanent`, `waived-conditional` (requires reason + due date).
+- **Waiver authority is reviewer-only.** The requester (submitter) can ATTACH evidence to slots but cannot WAIVE them. Waiving requires `canPerform("checklist.waive", subject)`. The primitive MUST enforce this server-side, not just in the UI.
+- **Completeness is a pure function.** `evaluateCompleteness(schema, state): Completeness` has no side effects, no I/O, and is fully unit-testable. Callers treat it as a derived value.
+- **Three completeness outcomes:**
+  - `complete` — every required slot is `present` or `waived-permanent`
+  - `conditionally-complete` — every required slot is `present`, `waived-permanent`, or `waived-conditional` AND at least one `waived-conditional` exists
+  - `incomplete` — at least one required slot is `missing`
+- **Domain-free.** `ChecklistSlot` takes a generic `TKey extends string` — consumers can constrain keys. No slot key is hardcoded in the primitive.
+- **Immutable transitions.** Every state change writes an AUDIT# record with prior state + new state + actor + reason.
+
+## Acceptance Criteria
+
+- [ ] AC1: `ChecklistSchema<TKey>`, `ChecklistSlot<TKey>`, `SlotState`, `ChecklistState<TKey>`, and `Completeness` types are defined in `src/lib/compliance/checklist/checklist-schema.ts` with all properties `readonly`.
+- [ ] AC2: `evaluateCompleteness<TKey>(schema, state): Completeness` is a pure function — no dependencies on I/O, clock, or globals.
+- [ ] AC3: `useChecklist(schemaId, subjectId)` hook returns `{ schema, state, completeness, attachSlot, waivePermanent, waiveConditional, unwaive }` — reads and writes via adapter interface `IChecklistStore`.
+- [ ] AC4: `IChecklistStore` interface is defined with: `loadSchema(schemaId)`, `loadState(schemaId, subjectId)`, `attachSlot(key, evidenceId, actor)`, `waivePermanent(key, reason, actor)`, `waiveConditional(key, reason, dueAt, actor)`, `unwaive(key, actor)`.
+- [ ] AC5: `createMockChecklistStore()` and a reference persistence adapter (`createDynamoDbChecklistStore(config)`) both exist and pass adapter parity tests.
+- [ ] AC6: `waivePermanent` and `waiveConditional` adapter calls verify `canPerform("checklist.waive", subject)` on the server path; unauthorized calls throw `AccessDeniedError` and write an AU-2 denial record.
+- [ ] AC7: `<ChecklistPanel schemaId={...} subjectId={...}>` component renders slots in schema order with per-slot state badge: `present` (green check), `missing` (red alert), `waived-permanent` (gray banner), `waived-conditional` (amber banner with countdown to `dueAt`).
+- [ ] AC8: For `missing` slots the viewer shows an **Attach Evidence** button (visible if `canPerform("checklist.attach", subject)`); clicking opens a file picker → uploads via `IEvidenceStore.put()` → calls `attachSlot(key, evidenceId)`.
+- [ ] AC9: For `missing` or `waived-conditional` slots the viewer shows a **Waive** button (visible ONLY if `canPerform("checklist.waive", subject)`); clicking opens `<WaiverDialog>` with mode selector (Permanent / Conditional), reason textarea (required), and due-date picker (required for Conditional).
+- [ ] AC10: For `waived-*` slots with waive authority, an **Unwaive** action is available and restores the slot to `missing`.
+- [ ] AC11: A compact `<ChecklistSummary>` component renders a one-line state: "8/10 complete · 1 conditional · 1 missing" with a link to the full panel.
+- [ ] AC12: `evaluateCompleteness` handles: all required present → `complete`; any required missing → `incomplete`; any conditional waiver on required slot → `conditionally-complete`; optional slots do not affect completeness.
+- [ ] AC13: Audit logging: every `attachSlot`, `waivePermanent`, `waiveConditional`, `unwaive` writes an AUDIT# record with subjectId, slotKey, prior state, new state, actor, reason.
+- [ ] AC14: Reference wiring: firmware intake form uses `<ChecklistPanel>` with a `firmwareIntakeChecklistSchema` defined in `src/lib/firmware/firmware-checklist-schema.ts` (the firmware-specific schema lives in the firmware feature folder; the primitive is firmware-agnostic).
+- [ ] AC15: Unit tests cover `evaluateCompleteness` with exhaustive state matrix (all slot-state combinations × required/optional) at 100% branch coverage; ≥ 85% coverage across the rest of the primitive.
+
+## UI Behavior
+
+- Checklist panel is a vertical list; each row is 56px tall; slot label on left, state badge + timestamp + actor on right, actions rightmost
+- State badges: green (present), red (missing), gray (waived-permanent), amber-with-countdown (waived-conditional)
+- Countdown format: "12d left" / "2d left" / "overdue 3d" — updates once per minute
+- Waiver dialog uses the existing `<Dialog>` primitive; fields: mode toggle, reason (textarea, 10-500 chars), due date (Conditional only, date picker, min today, max today+365d)
+- Unauthorized waive attempts in the UI: buttons are hidden (not disabled); server-side enforcement is the ground truth
+- Summary badge updates optimistically on attach/waive; rollback on error with toast
+
+## Out of Scope
+
+- Dynamic schema editing UI — schemas are code-defined
+- Per-slot validation rules (e.g., "only PDF mime types") — delegated to evidence adapter policies
+- Schema versioning and migration — `schemaId` is opaque; revising a schema is handled at the consumer level
+- Multi-actor sign-off per slot (only one attach/waive event per slot state) — a downstream extension
+- SLA breach handling — delivered in Story 28.4
+
+## Tech Spec Reference
+
+See [tech-spec.md](./tech-spec.md) §"File Layout → checklist/", §"Generic Types → Story 28.2".
+
+## Rulebook Compliance
+
+- **`security-nist-rulebook.md`** — AC-3 (waive gated by `canPerform`), AC-5 (waiver author ≠ requester enforced), AU-2/3 (every transition audited), SI-10 (reason length, due-date range validated)
+- **`architecture-rulebook.md`** — pure function for evaluator, UI composition via primitive components
+- **`api-data-layer-rulebook.md`** — hook uses `useQuery`+`useMutation`; mutation uses optimistic update with rollback
+- **`code-quality-rulebook.md`** — ≥ 85% coverage, 100% on evaluator, file-size limits enforced
+
+## Dev Checklist (NOT for QA)
+
+1. Add types in `checklist-schema.ts`
+2. Implement `evaluateCompleteness` as a pure function in `completeness-engine.ts` with exhaustive tests
+3. Define `IChecklistStore` interface
+4. Implement `createMockChecklistStore()` and `createDynamoDbChecklistStore()` with parity tests
+5. Server-side `canPerform("checklist.waive")` check in every waive adapter method
+6. Implement `useChecklist` hook
+7. Build `<ChecklistPanel>`, `<ChecklistSummary>`, `<WaiverDialog>` components
+8. Storybook stories covering every slot state + waiver dialog flows
+9. Reference wiring: define `firmwareIntakeChecklistSchema` and replace legacy checklist UI
+10. ESLint check: `src/lib/compliance/checklist/**` imports nothing from `src/lib/firmware/**`
+11. Audit-log integration test
+
+## AutoGent Test Prompts
+
+1. **AC2 — Pure evaluator:** "Given a schema with 3 required + 1 optional slot and a state where all required are present, verify `evaluateCompleteness` returns `complete`. Swap one required to `waived-conditional`; verify `conditionally-complete`. Swap one to `missing`; verify `incomplete`."
+2. **AC6 — Waive authority:** "As user with only `checklist.attach` permission, attempt to call `waivePermanent()`. Verify `AccessDeniedError`. Verify audit log has a denial record."
+3. **AC7-AC8 — Panel rendering:** "Render `<ChecklistPanel>` with a schema of 5 slots in mixed states. Verify 1 green, 1 red, 1 gray, 1 amber badge. Verify Attach button visible on missing. Verify Waive button visible only as reviewer."
+4. **AC9 — Waiver dialog:** "As reviewer, click Waive on a missing slot. Verify dialog opens. Select Conditional. Verify due-date picker appears. Leave reason blank; click Submit. Verify validation error. Fill reason + due date; submit. Verify slot moves to waived-conditional."
+5. **AC11 — Summary:** "With 8/10 present, 1 conditional, 1 missing, render `<ChecklistSummary>`. Verify text matches '8/10 complete · 1 conditional · 1 missing'."
+6. **AC13 — Audit:** "After attach, waivePermanent, unwaive operations, verify 3 AUDIT# records exist with correct prior/new state fields."
+
+## Definition of Done
+
+- [ ] Code reviewed and approved
+- [ ] Unit tests ≥ 85% overall; 100% branch coverage on `evaluateCompleteness`
+- [ ] Adapter parity tests green
+- [ ] Storybook stories published for all three UI primitives
+- [ ] Waiver dialog keyboard-navigable + announced by screen reader
+- [ ] TypeScript strict, no `any`
+- [ ] ESLint no-restricted-imports rule enforced
+- [ ] NIST audit-log integration test green
+- [ ] Reference firmware flow migrated behind `FEATURE_COMPLIANCE_LIB`

--- a/Docs/epics/epic-28/story-28.3.md
+++ b/Docs/epics/epic-28/story-28.3.md
@@ -1,0 +1,122 @@
+# Story 28.3: Gated Approval State Machine
+
+**Epic:** Epic 28 — Enterprise Compliance Workflow Patterns
+**Phase:** PHASE 1: FOUNDATION
+**Persona:** Approval Reviewer (reference persona) / Template Consumer (audience)
+**Priority:** P0
+**Story Points:** 8
+**Status:** New
+
+## User Story
+
+As an approval reviewer, I want a standardized four-state approval workflow — pending, approved, conditionally-approved, rejected — that enforces separation of duties, requires reasons for rejection and conditional approval, and writes a tamper-evident audit trail for every state transition, so that approval outcomes are consistent, defensible, and auditor-ready across every workflow in the platform.
+
+## Preconditions
+
+- Story 28.1 shipped — evidence store available
+- Story 28.2 shipped — checklist completeness function drives conditional approval eligibility
+- RBAC: `canPerform("approval.decide", resource)`, `canPerform("approval.submit", resource)` defined in `src/lib/rbac.ts`
+- AC-5 (separation of duties) enforced — reviewer and requester must not be the same principal
+
+## Context / Business Rules
+
+- **Four states:** `pending` (initial and post-resubmit), `approved`, `conditionally-approved`, `rejected`.
+- **State transitions:**
+  - `pending → approved` — requires checklist `complete`
+  - `pending → conditionally-approved` — requires checklist `conditionally-complete` (at least one waived-conditional)
+  - `pending → rejected` — requires a `reason` (10-500 chars)
+  - `conditionally-approved → approved` — requires all SLA conditions `satisfied` (delivered in Story 28.4)
+  - `conditionally-approved → rejected` — requires `reason`
+  - `rejected → pending` — on resubmission by requester (evidence changes detected via checklist state)
+- **Invalid transitions throw `ApprovalTransitionError`** — never silently absorbed. The transition table is the single source of truth (`approvalTransitionTable` in `approval-state-machine.ts`).
+- **Separation of duties (AC-5):** a principal who submitted the subject cannot approve, conditionally-approve, or reject it. `SelfApprovalError` is thrown. SoD check is enforced at the adapter, not the UI.
+- **Reasons are mandatory** for `rejected` and `conditionally-approved` transitions — never blank, never auto-generated.
+- **Audit everywhere:** every transition writes an AUDIT# record (AU-2/AU-3) with `subjectId`, `priorState`, `newState`, `actorId`, `reason`, `timestamp`, `checklistCompleteness` (snapshot at decision time).
+- **Engine is adapter-pluggable.** `IApprovalEngine` interface abstracts persistence; state machine logic is pure.
+- **Domain-free.** `Approval<TSubjectId>` has no firmware/device/ims references. `subjectId` is an opaque string chosen by the caller.
+
+## Acceptance Criteria
+
+- [ ] AC1: `ApprovalState` type, `Approval<TSubjectId>`, and `approvalTransitionTable` are defined in `src/lib/compliance/approval/approval-state-machine.ts`. State machine is a pure module with no I/O.
+- [ ] AC2: `transition(current, nextState, context): Approval` is a pure function that validates the transition against `approvalTransitionTable`, checks reason presence + length for `rejected` and `conditionally-approved`, and returns the updated approval object.
+- [ ] AC3: `transition` throws `ApprovalTransitionError` for any (current → next) not in the table; error message names the invalid pair.
+- [ ] AC4: `IApprovalEngine` interface is defined with: `create(subjectId, submittedBy)`, `loadBySubject(subjectId)`, `decide(id, nextState, reviewer, reason?, conditions?)`, `listPending(filter)`.
+- [ ] AC5: `createMockApprovalEngine()` and `createDynamoDbApprovalEngine(config)` factories both exist and pass parity tests.
+- [ ] AC6: Adapter `decide` method enforces SoD — throws `SelfApprovalError` when `reviewer.userId === approval.submittedBy`; SoD denial writes an AU-2 denial record.
+- [ ] AC7: Adapter `decide` method throws `ChecklistIncompleteError` when `nextState === "approved"` but checklist evaluates to `incomplete`; throws same when `nextState === "conditionally-approved"` but no conditional waivers exist.
+- [ ] AC8: `useApproval(subjectId)` hook returns `{ approval, decide, resubmit }` — uses TanStack Query `useQuery` for read, `useMutation` for write with optimistic state update and rollback on error.
+- [ ] AC9: `<ApprovalGateBadge approval={...}>` component renders a state pill: `pending` (gray clock), `approved` (green check), `conditionally-approved` (amber warning), `rejected` (red block). Hover shows reviewer + decidedAt + reason snippet.
+- [ ] AC10: `<ApprovalDecisionPanel subjectId={...}>` component renders (when viewer has `canPerform("approval.decide")`): current state, checklist summary, three action buttons (Approve, Conditional Approve, Reject), reason textarea. Buttons are enabled only for valid transitions per `approvalTransitionTable` and checklist state.
+- [ ] AC11: Approve button is disabled + tooltip "Checklist incomplete" when checklist not `complete`. Conditional Approve is disabled + tooltip "No conditional waivers" when no waived-conditional slots exist.
+- [ ] AC12: Reject confirmation modal requires reason (10-500 chars) before submit.
+- [ ] AC13: Every successful transition writes an AUDIT# record with the schema specified in §Business Rules.
+- [ ] AC14: Reference wiring: firmware review page uses `<ApprovalGateBadge>` + `<ApprovalDecisionPanel>` with `subjectId = firmwareVersionId`; legacy approval UI gated behind `FEATURE_COMPLIANCE_LIB=off`.
+- [ ] AC15: Exhaustive state machine test: every cell in `approvalTransitionTable` — allowed and rejected — has a test. Unit tests ≥ 85% overall; 100% branch coverage on `transition()`.
+- [ ] AC16: ESLint + TypeScript checks enforce: no domain imports in `src/lib/compliance/approval/`, no usage of `any`.
+
+## UI Behavior
+
+- Approval badge: 22px pill, icon + label, consistent across list views and detail pages
+- Decision panel: sticky footer on the review page when state is `pending` or `conditionally-approved` for eligible reviewers
+- Button layout: Approve (primary green) · Conditional Approve (amber) · Reject (destructive outline)
+- Reason textarea: 10-500 chars, character counter, placeholder varies per action ("Why are you rejecting?" / "Why conditional?")
+- Reject is double-confirmed via `<ConfirmDialog>` — irreversible transitions deserve a second confirm
+- Optimistic updates: badge updates immediately; rolls back on adapter error with a toast
+- Loading state: spinner in button; buttons disabled during mutation
+- Unauthorized user: decision panel is not rendered; badge still visible
+
+## Out of Scope
+
+- Multi-step / multi-reviewer approval chains (single reviewer for this story)
+- Delegated approval / proxy reviewers
+- SLA deadline tracking on conditional approvals — delivered in Story 28.4
+- Auto-approval by policy engine (rule-based) — deferred
+- Revocation of an approved approval — out of scope (rejection after approval requires a new subject version, not a state walk-back)
+
+## Tech Spec Reference
+
+See [tech-spec.md](./tech-spec.md) §"State Machine (Story 28.3)", §"Generic Types → Stories 28.3 + 28.4".
+
+## Rulebook Compliance
+
+- **`security-nist-rulebook.md`** — AC-3 (decide gated), AC-5 (SoD enforced at adapter), AU-2/3 (every transition + denial audited), SI-10 (reason length + state names validated)
+- **`architecture-rulebook.md`** — pure state machine module, engine adapter pattern, UI imports only hooks
+- **`api-data-layer-rulebook.md`** — optimistic mutation with rollback, stable cache key, typed errors
+- **`code-quality-rulebook.md`** — no `any`, 100% branch coverage on `transition()`, ≥ 85% elsewhere
+
+## Dev Checklist (NOT for QA)
+
+1. Create `approval-state-machine.ts` with type + table + `transition()` pure function
+2. Write exhaustive unit tests for every cell in the transition table (allowed + rejected)
+3. Define `IApprovalEngine` interface
+4. Implement `createMockApprovalEngine()` — in-memory Map with SoD and checklist checks
+5. Implement `createDynamoDbApprovalEngine()` reference adapter
+6. Enforce SoD check in `decide` — throws `SelfApprovalError`, writes AU-2 denial
+7. Integrate with Story 28.2 checklist to validate completeness at decide time
+8. Build `useApproval` hook with optimistic updates + rollback
+9. Build `<ApprovalGateBadge>` + `<ApprovalDecisionPanel>` + Storybook stories
+10. Reference wiring: firmware review page behind `FEATURE_COMPLIANCE_LIB`
+11. Add ESLint no-restricted-imports rule for `src/lib/compliance/approval/`
+12. Adapter parity test harness
+
+## AutoGent Test Prompts
+
+1. **AC2-AC3 — Transitions:** "Call `transition(pending, approved, { checklist: { kind: 'complete' } })`. Verify success. Call `transition(approved, pending, ...)`. Verify `ApprovalTransitionError` with message identifying the invalid pair."
+2. **AC6 — SoD:** "Alice submits. Alice attempts to approve. Verify `SelfApprovalError`. Verify AU-2 denial record exists."
+3. **AC7 — Checklist gate:** "With checklist `incomplete`, attempt `decide(id, 'approved', reviewer)`. Verify `ChecklistIncompleteError`."
+4. **AC9-AC10 — Panel:** "As reviewer, open a pending subject with complete checklist. Verify Approve button enabled, Conditional disabled (no conditional waivers), Reject enabled. Click Approve. Verify state pill updates to approved."
+5. **AC12 — Reject reason:** "Click Reject. Leave reason blank. Click submit. Verify validation error. Fill 15-char reason. Submit. Verify state becomes rejected; reason is recorded."
+6. **AC13 — Audit:** "After a pending→approved transition, verify AUDIT# record has priorState=pending, newState=approved, actor, timestamp, checklistCompleteness='complete'."
+
+## Definition of Done
+
+- [ ] Code reviewed + approved
+- [ ] Unit tests ≥ 85% overall, 100% branch coverage on `transition()`
+- [ ] All 16 transition-table cells have passing tests (allowed + rejected)
+- [ ] Adapter parity tests green
+- [ ] Storybook stories: pending, approved, conditionally-approved, rejected badges; decision panel with all button states
+- [ ] Decision panel keyboard-navigable, reason textarea announced
+- [ ] Reference firmware flow migrated behind flag
+- [ ] NIST audit integration test green (decision + SoD denial both logged)
+- [ ] TypeScript strict, no `any`
+- [ ] ESLint no-restricted-imports rule in place

--- a/Docs/epics/epic-28/story-28.4.md
+++ b/Docs/epics/epic-28/story-28.4.md
@@ -1,0 +1,115 @@
+# Story 28.4: Conditional Approval with SLA Tracking
+
+**Epic:** Epic 28 — Enterprise Compliance Workflow Patterns
+**Phase:** PHASE 2: EXCEPTION MANAGEMENT
+**Persona:** Approval Reviewer (reference persona) / Template Consumer (audience)
+**Priority:** P1
+**Story Points:** 5
+**Status:** New
+
+## User Story
+
+As an approval reviewer, I want to attach time-bound conditions to a conditional approval — each with a reason, a due date, and automated alerts as the deadline approaches or is missed — so that a "conditional approval" cannot quietly become a permanent deferral and the security-exception lifecycle is transparent to auditors.
+
+## Preconditions
+
+- Story 28.3 shipped — approval state machine supports `conditionally-approved` state
+- Story 28.2 shipped — checklist `waived-conditional` slot state exists
+- Story 22.3 shipped or compatible — global notification/toast pipeline is available
+
+## Context / Business Rules
+
+- **An approval in `conditionally-approved` state carries 1..N `SlaCondition` records.** Each condition: `id`, `description`, `dueAt`, `status` (`pending` | `satisfied` | `breached`).
+- **Condition sources:**
+  - Automatically created for each `waived-conditional` slot at the moment of conditional approval — one condition per waived slot, copying its `reason` and `dueAt`
+  - Optionally, reviewers can attach ad-hoc conditions at conditional-approval time (e.g., "resubmit scan within 30 days")
+- **Satisfaction:** a condition moves to `satisfied` when the related waived-conditional slot transitions to `present` (evidence attached) OR when the reviewer explicitly marks the condition satisfied with `markConditionSatisfied(conditionId, reason, actor)`.
+- **Breach:** any `pending` condition whose `dueAt < now` is `breached`. Breach computation runs on:
+  1. `useSlaWatch()` in-app interval (60s, visibility-aware backoff per Story 22.8)
+  2. Adapter-level query (server side) whenever a subject is read
+- **Alerts** fire at three milestones per condition: `T-7d` (warn), `T-1d` (urgent), `T+0` (breached). Each alert is emitted once; duplicate suppression uses `{conditionId, milestone}` as the key.
+- **Breach audit:** on transition to `breached`, an AUDIT# record is written immediately with `conditionId`, `subjectId`, `dueAt`, `observedAt`.
+- **Transition to `approved`:** requires ALL conditions to be `satisfied`. Enforced by Story 28.3 `decide` adapter.
+- **Domain-free.** `SlaCondition` has no firmware/device references. `description` is opaque caller-supplied text.
+
+## Acceptance Criteria
+
+- [ ] AC1: `SlaCondition` type is defined in `src/lib/compliance/approval/sla-tracker.ts` with fields: `id`, `subjectId`, `description`, `dueAt`, `status`, `createdBy`, `createdAt`, `satisfiedAt?`, `satisfiedBy?`.
+- [ ] AC2: `evaluateSlaStatus(condition, now): SlaCondition["status"]` is a pure function computing `pending` / `satisfied` / `breached` given current time.
+- [ ] AC3: `computeAlertMilestones(condition, now): AlertMilestone[]` returns which milestones (`T-7d`, `T-1d`, `T+0`) are active and not yet emitted. Pure function.
+- [ ] AC4: On conditional-approval decision (Story 28.3), `IApprovalEngine.decide(...)` auto-creates one `SlaCondition` per `waived-conditional` slot plus any reviewer-supplied ad-hoc conditions.
+- [ ] AC5: `markConditionSatisfied(conditionId, reason, actor)` on the approval engine adapter moves the condition to `satisfied`; throws `ApprovalTransitionError` if condition already `breached` and story policy requires explicit re-approval (configurable — see AC6).
+- [ ] AC6: Engine config `allowSatisfyAfterBreach` (default `true`) governs whether a breached condition can still be marked satisfied; when `false`, requires a rejection + resubmission cycle.
+- [ ] AC7: Attaching evidence to a slot that has a linked `SlaCondition` auto-calls `markConditionSatisfied` — the checklist flow closes the loop without reviewer re-intervention.
+- [ ] AC8: `useSlaWatch()` hook runs a 60-second interval (visibility-aware backoff), refetches conditions for subjects the user has open, emits alerts via the notification system (Story 22.3), and suppresses duplicates by `{conditionId, milestone}`.
+- [ ] AC9: `<SlaCountdown condition={...}>` component renders a pill with time-remaining: `> 7d` (gray), `≤ 7d` (amber), `≤ 24h` (red), `breached` (red-solid with warning icon). Text updates once per minute.
+- [ ] AC10: `<ConditionsPanel subjectId={...}>` component lists all conditions with description, due date, countdown pill, and (for reviewers) a Mark Satisfied button + an Unsatisfy action for undoing mistaken marks. Mark Satisfied opens a dialog requiring a reason (10-500 chars).
+- [ ] AC11: Breach transitions write an AUDIT# record synchronously at the moment breach is detected (by either the interval hook or an adapter read); duplicate breach-audit records are prevented by adapter-level idempotency.
+- [ ] AC12: `<ApprovalGateBadge>` (from Story 28.3) is extended: for `conditionally-approved` subjects, badge shows a secondary indicator — "1 breach" / "3 pending" / "2 satisfied" — to surface condition health at a glance.
+- [ ] AC13: Reference wiring: firmware review page shows `<ConditionsPanel>` beneath the approval panel for `conditionally-approved` firmware versions; extends Story 28.3 wiring.
+- [ ] AC14: Unit tests ≥ 85% across `sla-tracker.ts`; 100% branch coverage on `evaluateSlaStatus` and `computeAlertMilestones`.
+- [ ] AC15: Time-mocked tests cover: `T-8d` (no alert), `T-7d boundary`, `T-2d` (warn already emitted), `T-1d` (urgent), `T+0` (breach + audit), `T+1d` (already breached — no duplicate audit).
+
+## UI Behavior
+
+- Countdown pill updates once per minute — not per second (battery + accessibility)
+- Countdown uses relative format: "6d 4h", "23h", "12m", "overdue 2d"
+- Mark Satisfied action is a destructive-looking confirmation: "Mark condition as satisfied? This action is audit-logged."
+- Alerts appear as system notifications (top-right toast) with severity color matching the milestone
+- Breach alerts persist in the notification tray until acknowledged
+- A condition linked to a checklist slot shows "Linked to [slot label]" — clicking navigates to the slot in the checklist panel
+- `<ConditionsPanel>` empty state: "No conditions attached" (for `approved` subjects that never had conditions)
+
+## Out of Scope
+
+- External escalation (PagerDuty, Slack, email) — in-app notifications only; external hooks are an integration contract
+- Bulk-satisfy across subjects
+- Condition priority / weighting
+- Grace-period extension UI (renegotiating a due date) — if a date must change, reject + new conditional approval is the flow
+- Dashboard of all conditions across all subjects — deferred to a future analytics story
+
+## Tech Spec Reference
+
+See [tech-spec.md](./tech-spec.md) §"State Machine (Story 28.3)", §"SLA Tracker (Story 28.4)", §"Generic Types → Stories 28.3 + 28.4".
+
+## Rulebook Compliance
+
+- **`security-nist-rulebook.md`** — AC-3 (mark satisfied gated), AU-2/3 (every state change + breach audited), SI-10 (reason + due-date range validated, max 365d in future)
+- **`architecture-rulebook.md`** — pure evaluators separated from I/O; adapter handles persistence + idempotency
+- **`api-data-layer-rulebook.md`** — visibility-aware backoff (Story 22.8 pattern), stable query keys
+- **`performance-rulebook.md`** — 60-second interval with backoff; countdown re-render once per minute; no unnecessary re-renders of unrelated subjects
+- **`code-quality-rulebook.md`** — 100% branch coverage on pure evaluators, ≥ 85% elsewhere
+
+## Dev Checklist (NOT for QA)
+
+1. Add `SlaCondition` type + `evaluateSlaStatus` + `computeAlertMilestones` as pure functions in `sla-tracker.ts`
+2. Time-mocked tests for status + milestone computation
+3. Extend `IApprovalEngine` adapters with `createCondition`, `markConditionSatisfied`, breach-idempotency handling
+4. Integrate auto-creation of conditions on conditional-approval decision (edit Story 28.3 engine impl)
+5. Integrate auto-satisfy on checklist `attachSlot` when linked condition exists (edit Story 28.2 engine impl)
+6. Implement `useSlaWatch` with 60s interval + visibility backoff + duplicate suppression
+7. Build `<SlaCountdown>` + `<ConditionsPanel>` + extend `<ApprovalGateBadge>` with secondary indicator
+8. Storybook stories for countdown pill at all four severity levels + conditions panel
+9. Reference wiring on firmware review page behind `FEATURE_COMPLIANCE_LIB`
+10. Breach-audit idempotency test — simulating double-fire
+
+## AutoGent Test Prompts
+
+1. **AC2-AC3 — Evaluators:** "Create a condition with `dueAt = now + 6 days`. Call `evaluateSlaStatus` — verify `pending`. Call `computeAlertMilestones` — verify `['T-7d']`. Advance clock by 5.5 days; verify `['T-1d']`."
+2. **AC4 — Auto-create:** "Checklist has 2 waived-conditional slots. Reviewer marks subject conditionally-approved. Verify 2 `SlaCondition` records exist with matching descriptions and due dates."
+3. **AC7 — Auto-satisfy:** "A condition is linked to slot 'sbom'. Requester uploads evidence to 'sbom'. Verify condition status becomes `satisfied` without reviewer action."
+4. **AC9 — Countdown colors:** "Render `<SlaCountdown>` with dueAt = +10d. Verify gray. With +3d — amber. With +12h — red. With -1d — red-solid with warning."
+5. **AC11 — Breach audit:** "Set dueAt to -1d. Read subject. Verify a single breach AUDIT# record exists. Read subject again. Verify no duplicate."
+6. **AC12 — Badge indicator:** "Subject with 3 pending, 1 breach. Render `<ApprovalGateBadge>`. Verify secondary indicator shows 'breach: 1'."
+
+## Definition of Done
+
+- [ ] Code reviewed + approved
+- [ ] Unit tests ≥ 85% overall, 100% on pure evaluators
+- [ ] Time-mocked tests cover all four milestones + breach idempotency
+- [ ] Storybook stories for countdown + panel + extended badge
+- [ ] Reference firmware flow shows conditions panel behind flag
+- [ ] Visibility-aware backoff verified (hook pauses when tab is hidden)
+- [ ] TypeScript strict, no `any`
+- [ ] NIST audit integration test — breach + mark-satisfied both logged
+- [ ] Performance: < 1% CPU usage with 50 open subjects (measured locally)

--- a/Docs/epics/epic-28/story-28.5.md
+++ b/Docs/epics/epic-28/story-28.5.md
@@ -1,0 +1,111 @@
+# Story 28.5: Scoped One-Time Secure Distribution
+
+**Epic:** Epic 28 — Enterprise Compliance Workflow Patterns
+**Phase:** PHASE 2: DELIVERY
+**Persona:** Distribution Recipient (reference persona: Service Technician) / Template Consumer (audience)
+**Priority:** P1
+**Story Points:** 5
+**Status:** New
+
+## User Story
+
+As a recipient of a regulated digital asset, I want to receive a scoped, one-time-use, MFA-gated download link that expires after a short window and after first use, and is tied to my identity — so that sensitive content is not leaked through stale URLs, bookmarks, or shared links, and every delivery is individually audited.
+
+## Preconditions
+
+- Story 28.1 shipped — evidence store exists with `getSignedReadUrl`
+- Step-up MFA primitive available via auth adapter (Story 19.5 / 19.6 provide the session primitives this story builds on)
+- Global notification pipeline (Story 22.3) available
+- `canPerform("distribution.request", resource)` and `canPerform("distribution.approve", resource)` defined in RBAC
+
+## Context / Business Rules
+
+- **Each link is bound to a specific recipient** (`recipientUserId`) — tokens verify the redeeming session matches the recipient.
+- **Each link is single-use.** Redemption atomically marks the link consumed; second redemption returns `SecureLinkConsumedError`.
+- **Each link has a short expiry** (default 15 minutes; adapter config). Expired redemption returns `SecureLinkExpiredError`.
+- **Step-up MFA is required** for redemption when `requireStepUpMfa === true` — the user is prompted for fresh MFA even if their session is already authenticated. Last-step-up timestamp is enforced at ≤ 5 minutes for redemption.
+- **Link minting is an authorized action.** Callers must pass RBAC `distribution.approve` (ownership approves the distribution) AND have the recipient's `distribution.request` on the resource.
+- **Minting and redemption both audit.** Minting writes `action: "distribution.minted"`; redemption writes `action: "distribution.redeemed"`; failed redemptions write denial records with the failure kind.
+- **Tokens opaque and signed.** Adapters generate tokens that encode `{evidenceId, recipientUserId, expiresAt, jti}`; server validates signature + jti uniqueness in a consumed-jti store (DynamoDB TTL-backed).
+- **Domain-free.** `SecureLinkRequest` references `evidenceId`, not firmware versions or device serials.
+
+## Acceptance Criteria
+
+- [ ] AC1: `ISecureDistribution` interface is defined with: `mintLink(request)`, `redeem(token, session)`, `listMyActive(userId)`. Redeem returns a short-lived (< 60s) signed storage URL for the underlying evidence.
+- [ ] AC2: `SecureLinkRequest`, `SecureLink`, `SecureLinkRedemption` types defined in `src/lib/compliance/distribution/secure-distribution.interface.ts`.
+- [ ] AC3: `createMockSecureDistribution()` + `createS3SignedUrlDistribution(config)` factories both exist and pass parity tests.
+- [ ] AC4: `mintLink` enforces RBAC: caller has `distribution.approve` AND recipient has `distribution.request` on the evidence's owning resource. Failures throw `AccessDeniedError` + write audit denial.
+- [ ] AC5: `redeem` enforces: token signature valid, `expiresAt > now`, `jti` not already consumed, session's `userId === recipientUserId`, step-up MFA freshness ≤ 5 minutes when required. Each failure throws a typed error (`SecureLinkExpiredError`, `SecureLinkConsumedError`, `MfaStepUpRequiredError`, `TokenMismatchError`) and writes audit denial.
+- [ ] AC6: Successful `redeem` atomically writes `jti` to the consumed-jti store before returning the short-lived storage URL — race-safe against concurrent redemption attempts.
+- [ ] AC7: Adapter config exposes: `defaultExpiryMs` (default 900_000 = 15 min), `maxExpiryMs` (default 86_400_000 = 24h), `mfaFreshnessMs` (default 300_000 = 5 min), `storageUrlTtlMs` (default 30_000 = 30s).
+- [ ] AC8: `useSecureDistribution()` hook returns `{ mintLink, redeem, listMyActive }`; uses TanStack Query `useMutation` for mint/redeem and `useQuery` for the active-list.
+- [ ] AC9: `<SecureDownloadButton evidenceId requireStepUpMfa>` component — visible to users with `distribution.request`; clicking requests a fresh link via `mintLink` (if not already minted for this user+evidence), prompts for MFA step-up if needed, redeems the link, and triggers the browser download. All within a single click flow.
+- [ ] AC10: `<DistributionHistoryPanel subjectId>` component — lists past distribution events (mint + redeem + denials) with recipient, actor, timestamp, outcome. Available to reviewers.
+- [ ] AC11: Every mint, every redemption (success + denial) writes an AUDIT# record with the full event context (tokenJti, evidenceId, actor, recipient, outcome, timestamp).
+- [ ] AC12: Reference wiring: firmware download flow for service technicians is refactored to use `<SecureDownloadButton>` + `useSecureDistribution`; legacy download path gated behind `FEATURE_COMPLIANCE_LIB=off`.
+- [ ] AC13: Adapter parity tests cover: successful mint → redeem round-trip, double-redeem rejection, expired redemption, wrong-user redemption, MFA-required without step-up, race condition (two concurrent redemptions — only one succeeds).
+- [ ] AC14: Unit tests ≥ 85% coverage with error paths exercised.
+
+## UI Behavior
+
+- Button label: "Download" with a lock icon; subtitle: "One-time secure link · expires in 15 min"
+- On click: brief spinner while link mints; MFA step-up modal if required; then browser download triggers automatically
+- MFA step-up modal reuses existing auth primitives (Story 19.6); on success, download proceeds; on cancel, flow aborts with a toast
+- If link already minted + unconsumed for this recipient + evidence, re-clicking uses the existing link (no duplicate mint)
+- Failure states: specific toast per error — "Link expired — try again", "Link already used", "Additional verification required"
+- Distribution history panel: table with outcome color — success (green), expired (amber), denied (red), in-flight (blue)
+
+## Out of Scope
+
+- QR-code / deep-link sharing UX (single-session in-browser only)
+- Email-delivered links (adapter could support; not in this story's UI)
+- Watermarking or DRM of downloaded content
+- Per-download analytics dashboard (aggregate; future story)
+- Revocation UI for unconsumed links (a separate story — admin revoke list)
+
+## Tech Spec Reference
+
+See [tech-spec.md](./tech-spec.md) §"File Layout → distribution/", §"Generic Types → Story 28.5", §"Error Taxonomy".
+
+## Rulebook Compliance
+
+- **`security-nist-rulebook.md`** — AC-3 (mint + redeem gated), AU-2/3 (success + denial audited with JTI), IA-2 (step-up MFA), SC-8 (TLS in transit for signed URLs), SC-12 (KMS-encrypted evidence bucket), SI-10 (token validation at every boundary)
+- **`architecture-rulebook.md`** — adapter pattern, consumed-jti store as adapter concern
+- **`api-data-layer-rulebook.md`** — typed errors, retry-safe mutations; no optimistic updates for redemption (must be server-authoritative)
+- **`code-quality-rulebook.md`** — no `any`, ≥ 85% coverage, race-safe tests included
+
+## Dev Checklist (NOT for QA)
+
+1. Define interface + types + errors in `secure-distribution.interface.ts`
+2. Implement `createMockSecureDistribution()` with in-memory jti store + Map + time-mocked expiry
+3. Implement `createS3SignedUrlDistribution()` — token minter with signed JWT, DynamoDB consumed-jti store with TTL, calls `IEvidenceStore.getSignedReadUrl` on successful redeem
+4. RBAC check in mint; full validation chain in redeem
+5. Audit-log every branch (mint, redeem success, each denial kind)
+6. Build `useSecureDistribution` hook + `<SecureDownloadButton>` + `<DistributionHistoryPanel>`
+7. Storybook stories: idle, minting, MFA prompt, error toasts, history with mixed outcomes
+8. Wire firmware download flow behind `FEATURE_COMPLIANCE_LIB`
+9. Parity tests + race condition test (Promise.all of two redemptions; assert exactly one resolves)
+10. ESLint no-restricted-imports rule
+
+## AutoGent Test Prompts
+
+1. **AC5 — Single use:** "Mint a link for user alice. Redeem as alice — verify success + download URL returned. Redeem the same token again — verify `SecureLinkConsumedError`."
+2. **AC5 — Wrong user:** "Mint for alice. Attempt redeem as bob. Verify `TokenMismatchError` and denial audit record."
+3. **AC5 — Expired:** "Mint with expiresInSeconds=1. Wait 2 seconds. Redeem. Verify `SecureLinkExpiredError`."
+4. **AC5 — MFA required:** "Mint with requireStepUpMfa=true. Session's last step-up was 10 minutes ago. Redeem. Verify `MfaStepUpRequiredError`."
+5. **AC6 — Race safety:** "Mint one link. `Promise.all` two simultaneous redeems. Verify exactly one resolves and one rejects with `SecureLinkConsumedError`."
+6. **AC9 — Button flow:** "Click `<SecureDownloadButton>` in Storybook. Verify spinner appears, MFA modal shows (for step-up variant), then download triggers."
+7. **AC11 — Audit:** "After mint + successful redeem + one expired attempt, verify 3 AUDIT# records exist: mint, redeemed, redeem-denied-expired."
+
+## Definition of Done
+
+- [ ] Code reviewed + approved
+- [ ] Unit tests ≥ 85% coverage; race-condition test green
+- [ ] Adapter parity tests green for mock + localstack
+- [ ] Storybook stories published
+- [ ] Reference firmware download migrated behind flag
+- [ ] NIST audit integration test covers mint + redeem success + all denial kinds
+- [ ] Step-up MFA flow tested end-to-end manually
+- [ ] TypeScript strict, no `any`
+- [ ] Security review: tokens are unguessable (≥ 128 bits entropy), signed, jti-tracked, expiring
+- [ ] ESLint no-restricted-imports rule in place

--- a/Docs/epics/epic-28/story-28.6.md
+++ b/Docs/epics/epic-28/story-28.6.md
@@ -1,0 +1,108 @@
+# Story 28.6: Two-Phase Action Confirmation (Chain of Custody)
+
+**Epic:** Epic 28 — Enterprise Compliance Workflow Patterns
+**Phase:** PHASE 3: PROVENANCE
+**Persona:** Field Operator (reference persona: Service Technician) / Compliance Officer (audience)
+**Priority:** P2
+**Story Points:** 5
+**Status:** New
+
+## User Story
+
+As a compliance officer, I want every action that involves an external, real-world step — shipping an asset, deploying a configuration, installing a device, delivering a document — to be modeled as a two-phase workflow (initiate → confirm-with-proof) so that the audit trail records not just that an action was authorized and distributed, but that the action was actually completed and evidenced, closing the chain of custody.
+
+## Preconditions
+
+- Story 28.1 shipped — evidence store is available for storing proof artifacts
+- Story 28.5 shipped — distribution primitive is the most common "initiate" caller
+- RBAC: `canPerform("confirmation.initiate", resource)`, `canPerform("confirmation.complete", resource)`, `canPerform("confirmation.abandon", resource)`
+
+## Context / Business Rules
+
+- **Two-phase lifecycle states:** `initiated` → (`confirmed` | `abandoned`). No state walk-backs.
+- **Initiation is always audit-logged and timestamped with actor + kind + payload.**
+- **Confirmation requires proof.** The caller supplies a `proof` object validated by a caller-provided `validator(proof): ValidationResult`. Proof commonly includes: confirmation timestamp, location coordinates (optional), notes, and 1..N `evidenceId` references to uploaded photos/docs (via Story 28.1).
+- **Abandonment is a first-class outcome.** An `initiated` action that is never completed is abandoned explicitly (user action) or after a timeout (`abandonAfterMs` per adapter config). Abandonment writes its own audit record with reason.
+- **SoD (optional, caller-chosen):** adapter config `requireDistinctConfirmer` (default `false`) throws `SelfConfirmationError` when `initiatedBy === confirmedBy`. Callers that need this invariant enable it.
+- **Open-ended timeline.** Initiations do not auto-expire by default; each adapter sets its own timeout via config. Configuration is documented.
+- **Domain-free.** `ActionInitiation<TPayload>` is generic; `kind` is a caller-supplied string. The primitive knows nothing about devices, deployments, or installations.
+
+## Acceptance Criteria
+
+- [ ] AC1: `ActionInitiation<TPayload>`, `ActionConfirmation<TProof>`, `ConfirmationOutcome` types defined in `src/lib/compliance/distribution/confirmation-primitive.ts`.
+- [ ] AC2: `IConfirmationEngine` interface defined: `initiate(kind, payload, actor)`, `complete(initiationId, proof, actor)`, `abandon(initiationId, reason, actor)`, `loadByKind(kind, filter)`, `loadById(initiationId)`.
+- [ ] AC3: `createMockConfirmationEngine()` + `createDynamoDbConfirmationEngine(config)` factories exist with parity tests.
+- [ ] AC4: `initiate` enforces `canPerform("confirmation.initiate", subject)`; `complete` enforces `canPerform("confirmation.complete", subject)`; `abandon` enforces `canPerform("confirmation.abandon", subject)`. Failures throw `AccessDeniedError` + audit denial.
+- [ ] AC5: `complete` validates the proof against a caller-registered validator (`registerValidator(kind, validator)`) — failure throws `ActionConfirmationMismatchError` with the validator's messages.
+- [ ] AC6: `complete` verifies initiation exists, is in `initiated` state, and has not been abandoned; otherwise throws `InvalidTransitionError`.
+- [ ] AC7: `complete` respects `requireDistinctConfirmer` config — when `true` and `initiatedBy === confirmedBy`, throws `SelfConfirmationError`.
+- [ ] AC8: Background `abandonStaleInitiations(kind)` job or hook transitions `initiated` records older than `abandonAfterMs` to `abandoned` with reason `"auto-abandoned: exceeded timeout"`. In-app, this is exposed via `useAbandonStaleInitiations()` hook — caller decides when to run.
+- [ ] AC9: `useConfirmation(initiationId)` hook returns `{ initiation, complete, abandon }` — TanStack Query read + mutations.
+- [ ] AC10: `<ConfirmationDialog kind payload validator onConfirmed>` component renders a form driven by a caller-provided schema; uploads any attached evidence via `IEvidenceStore.put()`; calls `complete` with the proof payload; shows success/error states.
+- [ ] AC11: `<ProvenanceTimeline subjectId>` component renders the complete chain — approval decision → distribution mint → redemption → confirmation (or abandonment) — pulling from existing audit records. Each entry includes actor, timestamp, outcome.
+- [ ] AC12: Every state change (initiate, complete, abandon, auto-abandon, denials, validator failure) writes an AUDIT# record with full context.
+- [ ] AC13: Reference wiring: firmware **deployment confirmation** — when a service technician redeems a distribution link, a confirmation is initiated automatically; after on-site install, the tech completes it with proof (photos, timestamp, notes) via `<ConfirmationDialog>`. The firmware domain registers its proof validator externally; the compliance library knows nothing about firmware.
+- [ ] AC14: Reference proof validator (in firmware feature folder, NOT in `src/lib/compliance/**`) validates: at least 1 photo evidence, notes 10-2000 chars, timestamp within 30 days.
+- [ ] AC15: Unit tests ≥ 85% coverage; specifically cover: all valid transitions, all blocked transitions, validator success/failure, SoD config on/off, auto-abandon timer.
+
+## UI Behavior
+
+- Confirmation dialog: title "Confirm [kind]", payload summary (read-only), proof form driven by validator schema, evidence upload button (multi-select, preview thumbnails)
+- Submit button disabled until validator passes locally (client-side); server re-validates
+- Abandon flow: smaller text link "Unable to complete — abandon action" → confirmation dialog with reason textarea
+- Provenance timeline: vertical stepper with color-coded nodes (green=confirmed, amber=in-flight, gray=abandoned, red=denied)
+- Empty state: "No actions initiated"
+- Error states: validator failure lists per-field messages; transition failures show a red banner with the typed error
+
+## Out of Scope
+
+- Offline / intermittent-connectivity proof capture (service techs in bad-signal areas) — deferred to a domain-specific mobile story
+- Proof cryptographic signing (non-repudiation) — deferred; proof is trusted on the platform
+- Multi-step confirmation ("installation began" → "installation complete") — this primitive is single-step; callers compose multi-phase flows
+- Rewriting past confirmations / corrections — confirmations are immutable; corrections require a new initiation
+
+## Tech Spec Reference
+
+See [tech-spec.md](./tech-spec.md) §"File Layout → distribution/", §"Generic Types → Story 28.6", §"Error Taxonomy".
+
+## Rulebook Compliance
+
+- **`security-nist-rulebook.md`** — AC-3 (all three ops gated), AU-2/3 (every transition + denial audited), SI-10 (proof validator enforces schema), optional AC-5 (SoD when enabled)
+- **`architecture-rulebook.md`** — validator registry pattern keeps proof schema outside the library; domain concerns stay in feature folders
+- **`api-data-layer-rulebook.md`** — server-authoritative; no optimistic updates; typed errors
+- **`code-quality-rulebook.md`** — ≥ 85% coverage, no `any`, file-size limits
+
+## Dev Checklist (NOT for QA)
+
+1. Define types + errors in `confirmation-primitive.ts`
+2. `IConfirmationEngine` interface with clear JSDoc
+3. Implement `createMockConfirmationEngine()` with in-memory state + validator registry
+4. Implement `createDynamoDbConfirmationEngine()` reference adapter with TTL-based auto-abandon
+5. RBAC + SoD config + audit on every branch
+6. `useConfirmation` hook + `<ConfirmationDialog>` + `<ProvenanceTimeline>`
+7. Storybook stories for dialog (happy/validator-fail/evidence-upload) + timeline (complete chain)
+8. Reference wiring — firmware deployment confirmation; register firmware-specific validator in `src/lib/firmware/firmware-deployment-validator.ts`
+9. `useAbandonStaleInitiations` hook — documented as caller-driven; reference wiring runs it on admin page load
+10. Parity tests; validator-registry test; timeout test
+
+## AutoGent Test Prompts
+
+1. **AC5 — Validator:** "Initiate a firmware deploy confirmation. Complete with no photos. Verify `ActionConfirmationMismatchError` with message 'at least 1 photo required'. Complete with 1 photo + notes. Verify success."
+2. **AC6 — Invalid transition:** "Complete an already-completed initiation. Verify `InvalidTransitionError`. Complete an abandoned initiation. Verify same."
+3. **AC7 — SoD:** "With `requireDistinctConfirmer=true`, alice initiates and alice attempts complete. Verify `SelfConfirmationError`."
+4. **AC8 — Auto-abandon:** "Initiate. Mock clock forward past `abandonAfterMs`. Call `abandonStaleInitiations(kind)`. Verify the initiation is `abandoned` with reason 'auto-abandoned: exceeded timeout'."
+5. **AC10 — Dialog:** "Open `<ConfirmationDialog>`. Upload 2 photos. Fill notes 50 chars. Submit. Verify `complete` called with proof containing both evidenceIds."
+6. **AC11 — Timeline:** "For a subject that went approval → mint → redeem → complete, render `<ProvenanceTimeline>`. Verify 4 chronological nodes with matching colors."
+7. **AC12 — Audit:** "After initiate + complete, verify 2 AUDIT# records; after abandon, 2 records (initiate + abandon)."
+
+## Definition of Done
+
+- [ ] Code reviewed + approved
+- [ ] Unit tests ≥ 85% coverage; all transitions + validator paths covered
+- [ ] Adapter parity tests green
+- [ ] Storybook stories published
+- [ ] Reference firmware deployment confirmation wired end-to-end behind flag
+- [ ] Validator registry pattern verified — no firmware types leaked into `src/lib/compliance/**`
+- [ ] NIST audit integration: initiate, complete, abandon, all denials logged
+- [ ] Provenance timeline demonstrable end-to-end (approval → mint → redeem → confirm)
+- [ ] TypeScript strict, no `any`

--- a/Docs/epics/epic-28/story-28.7.md
+++ b/Docs/epics/epic-28/story-28.7.md
@@ -1,0 +1,111 @@
+# Story 28.7: Inverse Dependency Query — Version → Consumers
+
+**Epic:** Epic 28 — Enterprise Compliance Workflow Patterns
+**Phase:** PHASE 3: IMPACT ANALYSIS
+**Persona:** Compliance Officer / Incident Responder (reference personas) / Template Consumer (audience)
+**Priority:** P2
+**Story Points:** 5
+**Status:** New
+
+## User Story
+
+As an incident responder, I want to select any versioned resource and immediately see every consumer currently depending on a specific version — with their scope, state, and identifying metadata — so that when a vulnerability or defect is discovered in a version, I can scope the blast radius in seconds rather than minutes, without grepping logs or hand-joining tables.
+
+## Preconditions
+
+- Story 28.3 shipped — approval state is queryable per consumer
+- Existing entity model has at least one versioned resource with 1-to-many consumers (firmware → devices in IMS; the primitive is domain-agnostic)
+- DynamoDB secondary indexes or equivalent query primitive available in persistence layer
+
+## Context / Business Rules
+
+- **Query is version-first.** Given `(resourceId, version)`, return all `Consumer<TMeta>` records currently bound to that version.
+- **Consumers carry scope.** `scope: string[]` lets callers tag consumers (e.g., `["tenant:xyz", "site:abc", "env:prod"]`). Queries support `scope` filters (all-of or any-of).
+- **Consumers carry state.** A `consumerState` field (open taxonomy, caller-supplied) surfaces consumer health (e.g., `active`, `quarantined`, `decommissioned`). Queries support state filters.
+- **Results are cursor-paginated.** Large result sets (10k+ consumers) use cursor-based pagination per the api-data-layer rulebook.
+- **Secondary view: version inventory.** `listVersionsInUse(resourceId)` returns all versions in active use with consumer counts — the dual query direction.
+- **Export supported.** Results export to CSV for offline analysis.
+- **Domain-free.** `Consumer<TMeta>` parameterizes on caller-supplied metadata; the primitive doesn't know whether a consumer is a device, a tenant, or a service.
+
+## Acceptance Criteria
+
+- [ ] AC1: `IDependencyGraph` interface defined in `src/lib/compliance/impact/dependency-graph.interface.ts` with methods: `listConsumers<TMeta>(resourceId, version, options)`, `listVersionsInUse(resourceId, options)`, `upsertBinding(consumerId, resourceId, version, scope, state, meta)`, `removeBinding(consumerId, resourceId)`.
+- [ ] AC2: `Consumer<TMeta>` and `BindingRecord` types defined with `readonly` properties and generic metadata parameter.
+- [ ] AC3: `createMockDependencyGraph()` + `createDynamoDbDependencyGraph(config)` factories exist with parity tests.
+- [ ] AC4: `listConsumers` supports options: `scope` (array, ANY_OF), `state` (array, ANY_OF), `cursor`, `limit` (1-500, default 50). Returns `{ items, nextCursor }`.
+- [ ] AC5: `listVersionsInUse` returns `[{ version, consumerCount }]` sorted descending by `consumerCount`; filter options mirror `listConsumers`.
+- [ ] AC6: Binding writes (`upsertBinding`) are idempotent keyed on `(consumerId, resourceId)`; transitioning a consumer from version A → B is a single upsert call, not a remove+add.
+- [ ] AC7: Reference firmware wiring registers a binding when a deployment confirmation completes (Story 28.6); `consumerId = deviceId`, `resourceId = firmwareFamilyId`, `version = firmwareVersion`, `scope = ["site:$siteId", "customer:$customerId"]`, `state = "active"`.
+- [ ] AC8: `useInverseDependency(resourceId, version, options)` hook returns paginated consumers with stable cache keys and visibility-aware polling disabled (on-demand reads only).
+- [ ] AC9: `useVersionsInUse(resourceId, options)` hook returns versions in use.
+- [ ] AC10: `<ImpactQueryTable resourceId version>` component renders a paginated table: columns = `consumerId`, `scope` (tag chips), `consumerState` (badge), `meta` (custom renderer), `lastUpdated`. Filters for scope + state above the table.
+- [ ] AC11: `<ImpactQueryTable>` supports CSV export of all matching records (not just current page) via a background fetch that iterates cursors.
+- [ ] AC12: `<VersionsInUseBadge resourceId>` — compact inline badge showing "3 versions in use" with a click-through to a version list.
+- [ ] AC13: Audit: every query execution writes an audit record with actor + filter params + result count (AU-12 for information flow monitoring).
+- [ ] AC14: Reference firmware wiring: firmware version detail page gains an **"Impact"** tab using `<ImpactQueryTable firmwareFamilyId firmwareVersion>`.
+- [ ] AC15: Unit tests ≥ 85% coverage. Adapter parity tests include large-result pagination (1000+ synthetic consumers).
+- [ ] AC16: Performance: 500-row query returns < 500ms on localhost against the DynamoDB adapter (localstack).
+
+## UI Behavior
+
+- Impact table: 5 columns; scope chips are compact 4-char-ish tags with tooltip full label; state badge uses the same design language as approval state pills (Story 28.3) for consistency
+- Filters: multi-select dropdowns for scope and state; clear button; URL-persisted filter state (searchable/shareable)
+- Empty states: "No consumers on this version" (with suggestion to check if version is stale), "No versions in use" (rare — for decommissioned resources)
+- Export button: primary action; shows progress toast while iterating pages; delivers CSV via browser download
+- Performance: table virtualizes rows beyond 100 (per performance rulebook); filter changes debounced 200ms
+
+## Out of Scope
+
+- Graph visualization (network diagram rendering) — tabular only in this story; deferred as a polish story
+- Temporal queries ("who was on version X as of date Y") — this story returns _current_ state only
+- Cross-resource dependency chains (X→Y→Z) — single-hop inverse only
+- Write-through automation that pushes version updates to consumers — this is a read-query primitive only
+- Alerting on blast-radius thresholds (e.g., "any version with > 1000 consumers") — deferred
+
+## Tech Spec Reference
+
+See [tech-spec.md](./tech-spec.md) §"File Layout → impact/", §"Generic Types → Story 28.7".
+
+## Rulebook Compliance
+
+- **`security-nist-rulebook.md`** — AU-12 (query audit), AC-3 (read gated by canPerform), SI-10 (filter validation)
+- **`architecture-rulebook.md`** — dependency-graph interface pattern, domain-free types
+- **`api-data-layer-rulebook.md`** — cursor pagination, stable cache keys, classified errors
+- **`performance-rulebook.md`** — table virtualization at 100+ rows, debounced filters, bulk export via iterator not single fetch
+- **`code-quality-rulebook.md`** — ≥ 85% coverage, no `any`, export generator tested at scale
+
+## Dev Checklist (NOT for QA)
+
+1. Define interface + types in `dependency-graph.interface.ts`
+2. Implement `createMockDependencyGraph()` with in-memory indexed Map (keyed on resourceId+version and consumerId+resourceId)
+3. Implement `createDynamoDbDependencyGraph()` with two GSIs: `(resourceId, version) → consumers`, `(resourceId) → versions`
+4. Idempotent `upsertBinding` semantics — single-item PutItem
+5. `listConsumers` + `listVersionsInUse` with scope/state filters and cursor pagination
+6. Hooks: `useInverseDependency`, `useVersionsInUse`
+7. `<ImpactQueryTable>` with virtualization + URL-persisted filter state + CSV export (iterator pattern)
+8. `<VersionsInUseBadge>` compact display
+9. Reference wiring: Story 28.6 deployment confirmation triggers `upsertBinding`; firmware version detail page gets Impact tab
+10. Adapter parity tests incl. 1000-consumer pagination
+11. Performance test: measure p95 query latency on 1000 + 10_000 consumer fixtures
+
+## AutoGent Test Prompts
+
+1. **AC4 — Pagination:** "Seed 500 synthetic consumers for `(fw-X, 1.2)`. Call `listConsumers('fw-X', '1.2', { limit: 50 })`. Verify 50 returned with `nextCursor`. Iterate using cursors — verify all 500 retrieved without duplicates."
+2. **AC4 — Filters:** "With 500 consumers across 3 scopes and 2 states, query scope=['site:abc'] state=['active']. Verify result count matches fixture expectation."
+3. **AC5 — Versions in use:** "Seed consumers across versions 1.0 (200), 1.1 (150), 1.2 (50). Call `listVersionsInUse('fw-X')`. Verify returned array: [{1.0, 200}, {1.1, 150}, {1.2, 50}]."
+4. **AC6 — Idempotent upsert:** "Call `upsertBinding` twice with identical (consumerId, resourceId). Verify single record, latest version wins. Call again with different version. Verify the consumer moved (no duplicate binding)."
+5. **AC10-AC11 — Table + export:** "Render `<ImpactQueryTable>` with 200 rows. Verify table virtualizes. Apply filter scope=['site:abc']. Verify only matching rows visible. Click Export CSV. Verify CSV contains all filtered rows across pages."
+6. **AC13 — Query audit:** "Execute a query with filters. Verify an AUDIT# record exists with `action: 'impact.query'`, actor, filters, and `resultCount`."
+
+## Definition of Done
+
+- [ ] Code reviewed + approved
+- [ ] Unit tests ≥ 85%; pagination at 1000+ consumers green
+- [ ] Adapter parity tests green for mock + localstack
+- [ ] Performance: p95 < 500ms on 500-row query; < 2s on 10k-row query (localstack)
+- [ ] Storybook stories published
+- [ ] Reference firmware Impact tab wired behind `FEATURE_COMPLIANCE_LIB`
+- [ ] CSV export iterator handles 1000+ rows without memory spike (measured)
+- [ ] Filter state URL-persisted and shareable
+- [ ] TypeScript strict, no `any`
+- [ ] NIST audit integration — each query writes AU-12 record

--- a/Docs/epics/epic-28/tech-spec.md
+++ b/Docs/epics/epic-28/tech-spec.md
@@ -1,0 +1,266 @@
+# Epic 28 — Tech Spec: Enterprise Compliance Workflow Patterns
+
+## Architectural Premise
+
+This epic ships a **compliance primitives library** under `src/lib/compliance/`. Every primitive is a **provider interface + at least two adapter implementations + a set of React hooks + reference UI components**. The library is domain-agnostic: types use generic parameters; no file imports IMS domain entities.
+
+The reference implementation wires these primitives into the existing firmware flow so the patterns are exercised end-to-end. That wiring lives in the firmware feature folder, NOT inside `src/lib/compliance/` — the library must remain domain-free.
+
+## File Layout
+
+```
+src/lib/compliance/
+├── evidence/                          ← Story 28.1
+│   ├── evidence-store.interface.ts
+│   ├── mock-evidence-store.ts
+│   ├── s3-evidence-store.ts           (reference adapter — s3 object lock)
+│   ├── evidence-errors.ts             (EvidenceImmutabilityError, etc.)
+│   └── evidence-store.test.ts
+├── checklist/                         ← Story 28.2
+│   ├── checklist-schema.ts            (generic N-of-M checklist type)
+│   ├── completeness-engine.ts         (pure evaluator — no I/O)
+│   ├── use-checklist.ts               (hook)
+│   └── completeness-engine.test.ts
+├── approval/                          ← Stories 28.3, 28.4
+│   ├── approval-state-machine.ts      (4-state transition table)
+│   ├── approval-engine.interface.ts
+│   ├── mock-approval-engine.ts
+│   ├── dynamodb-approval-engine.ts    (reference adapter)
+│   ├── sla-tracker.ts                 (Story 28.4 — deadline alerts)
+│   ├── approval-errors.ts
+│   ├── use-approval.ts
+│   └── approval-state-machine.test.ts
+├── distribution/                      ← Stories 28.5, 28.6
+│   ├── secure-distribution.interface.ts
+│   ├── mock-secure-distribution.ts
+│   ├── s3-signed-url-distribution.ts  (one-time MFA-gated signed URL)
+│   ├── confirmation-primitive.ts      (Story 28.6 — two-phase init→complete)
+│   ├── distribution-errors.ts
+│   ├── use-secure-distribution.ts
+│   └── secure-distribution.test.ts
+├── impact/                            ← Story 28.7
+│   ├── dependency-graph.interface.ts
+│   ├── mock-dependency-graph.ts
+│   ├── dynamodb-dependency-graph.ts   (reference adapter using GSI)
+│   ├── use-inverse-dependency.ts
+│   └── dependency-graph.test.ts
+└── index.ts                           (public re-exports only)
+
+src/app/components/compliance/         ← UI primitives (generic)
+├── evidence-viewer.tsx                ← Story 28.1 — read-only viewer with immutability badge
+├── checklist-panel.tsx                ← Story 28.2
+├── approval-gate-badge.tsx            ← Story 28.3
+├── waiver-dialog.tsx                  ← Story 28.4
+├── sla-countdown.tsx                  ← Story 28.4
+├── secure-download-button.tsx         ← Story 28.5
+├── confirmation-dialog.tsx            ← Story 28.6
+└── impact-query-table.tsx             ← Story 28.7
+```
+
+The reference wiring (firmware-flow integration) lives in existing firmware feature folders:
+
+```
+src/app/components/firmware/
+├── firmware-intake-bundle.tsx         (uses checklist-panel + evidence-viewer)
+├── firmware-review-gate.tsx           (uses approval-gate-badge + waiver-dialog)
+├── firmware-distribution-request.tsx  (uses secure-download-button)
+└── firmware-impact-query.tsx          (uses impact-query-table)
+```
+
+## Generic Types (Domain-Free)
+
+```typescript
+// Story 28.1 — Evidence
+export interface EvidenceMetadata {
+  readonly id: string;
+  readonly contentHash: string; // sha-256
+  readonly mimeType: string;
+  readonly sizeBytes: number;
+  readonly uploadedAt: string; // ISO-8601
+  readonly uploadedBy: { userId: string; displayName: string };
+  readonly retention: { mode: "compliance" | "governance"; retainUntil: string };
+  readonly immutable: true; // type-level guarantee
+}
+
+export interface IEvidenceStore {
+  put(input: EvidencePutInput): Promise<EvidenceMetadata>;
+  get(id: string): Promise<EvidenceMetadata>;
+  getSignedReadUrl(id: string, expiresInSeconds: number): Promise<string>;
+  list(filter: EvidenceListFilter): Promise<EvidenceMetadata[]>;
+  // NO delete, NO update, NO patch — enforced at interface level
+}
+
+// Story 28.2 — Checklist
+export interface ChecklistSlot<TKey extends string = string> {
+  readonly key: TKey;
+  readonly label: string;
+  readonly required: boolean;
+  readonly description?: string;
+}
+
+export type SlotState =
+  | { kind: "present"; evidenceId: string; filledAt: string; filledBy: string }
+  | { kind: "missing" }
+  | { kind: "waived-permanent"; reason: string; waivedAt: string; waivedBy: string }
+  | { kind: "waived-conditional"; reason: string; dueAt: string; waivedBy: string };
+
+export interface ChecklistState<TKey extends string = string> {
+  readonly schemaId: string;
+  readonly slots: Record<TKey, SlotState>;
+}
+
+export type Completeness =
+  | { kind: "complete" }
+  | { kind: "conditionally-complete"; pendingWaivers: string[] }
+  | { kind: "incomplete"; missing: string[] };
+
+// Story 28.3 + 28.4 — Approval
+export type ApprovalState = "pending" | "approved" | "conditionally-approved" | "rejected";
+
+export interface Approval<TSubjectId extends string = string> {
+  readonly id: string;
+  readonly subjectId: TSubjectId;
+  readonly state: ApprovalState;
+  readonly reviewer: { userId: string; displayName: string } | null;
+  readonly reason: string | null;
+  readonly decidedAt: string | null;
+  readonly conditions: SlaCondition[]; // Story 28.4
+}
+
+export interface SlaCondition {
+  readonly id: string;
+  readonly description: string;
+  readonly dueAt: string;
+  readonly status: "pending" | "satisfied" | "breached";
+}
+
+// Story 28.5 + 28.6 — Distribution
+export interface SecureLinkRequest {
+  readonly evidenceId: string;
+  readonly recipientUserId: string;
+  readonly expiresInSeconds: number;
+  readonly requireStepUpMfa: boolean;
+}
+
+export interface SecureLink {
+  readonly url: string;
+  readonly expiresAt: string;
+  readonly singleUse: true;
+}
+
+// Story 28.6 — Two-phase confirmation
+export interface ActionInitiation<TPayload = unknown> {
+  readonly id: string;
+  readonly kind: string; // caller-defined action type
+  readonly initiatedAt: string;
+  readonly initiatedBy: string;
+  readonly payload: TPayload;
+  readonly state: "initiated" | "confirmed" | "abandoned";
+}
+
+export interface ActionConfirmation<TProof = unknown> {
+  readonly initiationId: string;
+  readonly confirmedAt: string;
+  readonly confirmedBy: string;
+  readonly proof: TProof;
+}
+
+// Story 28.7 — Inverse dependency query
+export interface Consumer<TMeta = unknown> {
+  readonly consumerId: string;
+  readonly consumerType: string;
+  readonly version: string;
+  readonly scope: string[]; // e.g., ["site:abc", "tenant:xyz"]
+  readonly meta: TMeta;
+}
+
+export interface IDependencyGraph {
+  listConsumers<T>(resourceId: string, version: string): Promise<Consumer<T>[]>;
+  listVersionsInUse(resourceId: string): Promise<string[]>;
+}
+```
+
+## State Machine (Story 28.3)
+
+```
+           ┌──────────────────────────────────────┐
+           │                                       │
+  pending ─┼──> approved                           │
+           │                                       │
+           ├──> conditionally-approved ─> approved │
+           │            │                          │
+           │            └──> rejected              │
+           │                                       │
+           └──> rejected ──> pending  (resubmit)   │
+```
+
+- `conditionally-approved` is reachable only when at least one `waived-conditional` slot exists on the checklist (Story 28.2)
+- Transition to `approved` from `conditionally-approved` requires ALL `SlaCondition.status === "satisfied"`
+- Transition audit-logs actor, reason, and prior state (AU-2/AU-3)
+
+## SLA Tracker (Story 28.4)
+
+- A background hook (`useSlaWatch`) runs in-app, recomputing breach states on 60-second intervals and on window focus
+- Breach alerts are emitted as in-app notifications; breach audit-logs are written immediately
+- A cron-equivalent server task (out of scope for this story — documented in `Docs/integration-contract.md`) ensures alerts fire even when no user is logged in
+- The watch hook MUST use visibility-aware backoff (Story 22.8 pattern)
+
+## Provider Selection (Integration Contract)
+
+Each adapter is selected via env var following the Epic 19 pattern:
+
+```
+EVIDENCE_STORE_PROVIDER=mock | s3
+APPROVAL_ENGINE_PROVIDER=mock | dynamodb
+SECURE_DISTRIBUTION_PROVIDER=mock | s3-signed-url
+DEPENDENCY_GRAPH_PROVIDER=mock | dynamodb
+```
+
+Selection happens in `src/lib/compliance/index.ts` factory resolver; call sites import from the barrel.
+
+## NIST 800-53 Mapping
+
+| Control              | Where Enforced                                                                                                 |
+| -------------------- | -------------------------------------------------------------------------------------------------------------- |
+| AU-2 / AU-3 (Audit)  | Every state transition in 28.3/28.4, every put/getSignedReadUrl in 28.1, every distribution event in 28.5/28.6 |
+| AC-3 (Access)        | Approval/waiver/distribution gated through `canPerform()` in rbac.ts                                           |
+| AC-5 (SoD)           | Approval engine rejects `reviewerId === requesterId`                                                           |
+| SC-12 (Key Mgmt)     | S3 evidence store uses KMS-encrypted buckets; adapter documents required policy                                |
+| SI-10 (Input Valid.) | Zod schemas at every adapter boundary (per api-data-layer-rulebook §3)                                         |
+| MP-6 (Media Sanit.)  | WORM storage disallows delete — compliance mode documented                                                     |
+
+## Error Taxonomy
+
+All primitives throw typed errors that extend a base `ComplianceError`:
+
+- `EvidenceImmutabilityError` — attempt to delete/modify immutable evidence
+- `ChecklistIncompleteError` — approval requested while checklist incomplete without waiver
+- `ApprovalTransitionError` — invalid state machine transition
+- `SelfApprovalError` — SoD violation
+- `SlaBreachError` — condition due date has passed
+- `SecureLinkExpiredError`, `SecureLinkConsumedError` — one-time-link failures
+- `MfaStepUpRequiredError` — distribution requires step-up MFA
+- `ActionConfirmationMismatchError` — proof fails validator
+
+Errors are surfaced through the existing global error boundary + toast pipeline (Story 22.3).
+
+## Testing Strategy
+
+- Every primitive: ≥ 85% line coverage with both mock and reference adapter exercised
+- State machine: exhaustive transition table test — every (from, to) pair in the table is covered (allowed or explicitly rejected)
+- SLA tracker: time-mocked tests for `T-3d`, `T-1d`, `T-0`, `T+1d` breach scenarios
+- Distribution: test single-use enforcement (second redemption fails), expiry, MFA step-up denial
+- Adapter parity tests: a shared test harness runs identical scenarios against every adapter implementation; any deviation fails CI
+
+## Migration / Backward Compatibility
+
+- No existing IMS data is migrated. The reference firmware flow is _additively_ wired to the new primitives; legacy firmware tables remain untouched until a Phase 4 migration story (out of scope for Epic 28).
+- Feature flag `FEATURE_COMPLIANCE_LIB=on` gates the reference wiring so the legacy flow remains available during rollout.
+
+## Definition of Done (Epic-Level)
+
+- All 7 stories shipped behind `FEATURE_COMPLIANCE_LIB` flag
+- Zero IMS domain imports in `src/lib/compliance/**` — enforced by ESLint `no-restricted-imports`
+- Adapter parity test suite passes for every primitive
+- Integration contract documented in `Docs/integration-contract.md`
+- Auditor walkthrough script added to `Docs/audit/compliance-walkthrough.md`

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -51,5 +51,36 @@ export default tseslint.config(
       "@typescript-eslint/no-explicit-any": "error",
       "no-console": ["error", { allow: ["warn", "error"] }],
     },
-  }
+  },
+  // Epic 28 — compliance library must remain domain-agnostic.
+  // The primitives under src/lib/compliance/** must not import from any
+  // feature folder; keeping this enforced is what lets the library be
+  // re-used by template consumers in other domains.
+  {
+    files: ["src/lib/compliance/**/*.{ts,tsx}"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: [
+                "**/lib/firmware/**",
+                "**/lib/device*",
+                "**/lib/sbom*",
+                "**/lib/customer*",
+                "**/app/components/firmware/**",
+                "**/app/components/inventory/**",
+                "**/app/components/deployment/**",
+                "**/app/components/sbom/**",
+                "**/app/components/analytics/**",
+              ],
+              message:
+                "Compliance primitives must remain domain-agnostic (Epic 28). Import only generic utilities and @tanstack/react-query / lucide-react / @/lib/rbac / @/lib/audit / @/lib/query-keys / @/lib/feature-flags.",
+            },
+          ],
+        },
+      ],
+    },
+  },
 );

--- a/src/__tests__/lib/compliance/approval/approval-state-machine.test.ts
+++ b/src/__tests__/lib/compliance/approval/approval-state-machine.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import {
+  approvalTransitionTable,
+  isTransitionAllowed,
+  newPendingApproval,
+  transition,
+  ApprovalTransitionError,
+  ApprovalReasonError,
+  type Approval,
+  type ApprovalState,
+  type SlaCondition,
+} from "@/lib/compliance/approval/approval-state-machine";
+
+const ALICE = { userId: "alice", displayName: "Alice" };
+const BOB = { userId: "bob", displayName: "Bob" };
+const NOW = "2026-04-21T12:00:00Z";
+
+const REASON_OK = "Valid ten-char reason explaining the decision.";
+
+function seed(state: ApprovalState, conditions: readonly SlaCondition[] = []): Approval {
+  const base = newPendingApproval({
+    id: "a-1",
+    subjectId: "subj-1",
+    submittedBy: ALICE,
+    at: NOW,
+  });
+  return { ...base, state, conditions };
+}
+
+const ALL_STATES: ApprovalState[] = ["pending", "approved", "conditionally-approved", "rejected"];
+
+describe("approval state machine — exhaustive transition table", () => {
+  // Every pair (from → to) over all four states — allowed pairs in the
+  // table must succeed; all other pairs must throw ApprovalTransitionError.
+  for (const from of ALL_STATES) {
+    for (const to of ALL_STATES) {
+      const allowed = approvalTransitionTable.some((t) => t.from === from && t.to === to);
+      const title = `${from} → ${to} ${allowed ? "allowed" : "rejected"}`;
+
+      // Need to avoid special constraint: conditionally-approved → approved
+      // only succeeds when ALL conditions are satisfied. Use a variant for
+      // that pair.
+      if (from === "conditionally-approved" && to === "approved") {
+        it(`${title} (with satisfied conditions)`, () => {
+          const satisfied: SlaCondition = {
+            id: "c-1",
+            description: "ok",
+            dueAt: "2099-01-01T00:00:00Z",
+            status: "satisfied",
+          };
+          const out = transition(seed(from, [satisfied]), to, {
+            actor: BOB,
+            at: NOW,
+          });
+          expect(out.state).toBe(to);
+        });
+        it(`${from} → approved BLOCKED when any condition unsatisfied`, () => {
+          const pending: SlaCondition = {
+            id: "c-1",
+            description: "nope",
+            dueAt: "2099-01-01T00:00:00Z",
+            status: "pending",
+          };
+          expect(() => transition(seed(from, [pending]), to, { actor: BOB, at: NOW })).toThrow(
+            ApprovalTransitionError,
+          );
+        });
+        continue;
+      }
+
+      if (allowed) {
+        it(`${title}`, () => {
+          const ctx =
+            to === "rejected" || to === "conditionally-approved"
+              ? { actor: BOB, at: NOW, reason: REASON_OK }
+              : { actor: BOB, at: NOW };
+          const out = transition(seed(from), to, ctx);
+          expect(out.state).toBe(to);
+          expect(isTransitionAllowed(from, to)).toBe(true);
+        });
+      } else {
+        it(`${title}`, () => {
+          expect(() =>
+            transition(seed(from), to, { actor: BOB, at: NOW, reason: REASON_OK }),
+          ).toThrow(ApprovalTransitionError);
+          expect(isTransitionAllowed(from, to)).toBe(false);
+        });
+      }
+    }
+  }
+});
+
+describe("approval state machine — reason validation", () => {
+  it("rejected requires 10-500 char reason", () => {
+    expect(() => transition(seed("pending"), "rejected", { actor: BOB, at: NOW })).toThrow(
+      ApprovalReasonError,
+    );
+    expect(() =>
+      transition(seed("pending"), "rejected", { actor: BOB, at: NOW, reason: "short" }),
+    ).toThrow(ApprovalReasonError);
+    expect(() =>
+      transition(seed("pending"), "rejected", {
+        actor: BOB,
+        at: NOW,
+        reason: "x".repeat(501),
+      }),
+    ).toThrow(ApprovalReasonError);
+    const ok = transition(seed("pending"), "rejected", {
+      actor: BOB,
+      at: NOW,
+      reason: REASON_OK,
+    });
+    expect(ok.state).toBe("rejected");
+    expect(ok.reason).toBe(REASON_OK);
+  });
+
+  it("conditionally-approved requires reason", () => {
+    expect(() =>
+      transition(seed("pending"), "conditionally-approved", { actor: BOB, at: NOW }),
+    ).toThrow(ApprovalReasonError);
+    const ok = transition(seed("pending"), "conditionally-approved", {
+      actor: BOB,
+      at: NOW,
+      reason: REASON_OK,
+    });
+    expect(ok.state).toBe("conditionally-approved");
+  });
+
+  it("approved does not require reason", () => {
+    const ok = transition(seed("pending"), "approved", { actor: BOB, at: NOW });
+    expect(ok.state).toBe("approved");
+  });
+});
+
+describe("approval history", () => {
+  it("appends history entry on every transition", () => {
+    const p = seed("pending");
+    const a = transition(p, "approved", { actor: BOB, at: NOW });
+    expect(a.history.length).toBe(p.history.length + 1);
+    const last = a.history[a.history.length - 1];
+    if (!last) throw new Error("history empty");
+    expect(last.from).toBe("pending");
+    expect(last.to).toBe("approved");
+    expect(last.actor.userId).toBe("bob");
+  });
+
+  it("resubmit clears reviewer + decidedAt", () => {
+    const rejected: Approval = {
+      ...seed("rejected"),
+      reviewer: BOB,
+      reason: REASON_OK,
+      decidedAt: NOW,
+    };
+    const resubmitted = transition(rejected, "pending", { actor: ALICE, at: NOW });
+    expect(resubmitted.state).toBe("pending");
+    expect(resubmitted.reviewer).toBeNull();
+    expect(resubmitted.decidedAt).toBeNull();
+    expect(resubmitted.reason).toBeNull();
+  });
+});

--- a/src/__tests__/lib/compliance/approval/mock-approval-engine.test.ts
+++ b/src/__tests__/lib/compliance/approval/mock-approval-engine.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import { createMockApprovalEngine } from "@/lib/compliance/approval/mock-approval-engine";
+import {
+  ChecklistIncompleteForApprovalError,
+  NoConditionalWaiverError,
+  SelfApprovalError,
+} from "@/lib/compliance/approval/approval-errors";
+import { AccessDeniedError } from "@/lib/compliance/types";
+import type { Role } from "@/lib/rbac";
+
+const ALICE = { userId: "alice", displayName: "Alice" };
+const BOB = { userId: "bob", displayName: "Bob" };
+
+const complete = { kind: "complete" } as const;
+const incomplete = { kind: "incomplete", missing: ["sbom"] } as const;
+const conditional = {
+  kind: "conditionally-complete",
+  pendingWaivers: ["fat"],
+} as const;
+
+describe("createMockApprovalEngine — SoD + gating + audit behavior", () => {
+  it("create returns pending and idempotently reuses by subject", async () => {
+    const engine = createMockApprovalEngine({ resolveRole: () => "Admin" as Role });
+    const a = await engine.create("subj-1", ALICE);
+    expect(a.state).toBe("pending");
+    const again = await engine.create("subj-1", ALICE);
+    expect(again.id).toBe(a.id);
+  });
+
+  it("AC-5: reviewer cannot equal submitter", async () => {
+    const engine = createMockApprovalEngine({ resolveRole: () => "Admin" as Role });
+    const appr = await engine.create("subj-1", ALICE);
+    await expect(
+      engine.decide(
+        appr.id,
+        { nextState: "approved", reviewer: ALICE },
+        { completeness: complete },
+      ),
+    ).rejects.toBeInstanceOf(SelfApprovalError);
+  });
+
+  it("approve blocked when checklist incomplete", async () => {
+    const engine = createMockApprovalEngine({ resolveRole: () => "Admin" as Role });
+    const appr = await engine.create("subj-1", ALICE);
+    await expect(
+      engine.decide(
+        appr.id,
+        { nextState: "approved", reviewer: BOB },
+        { completeness: incomplete },
+      ),
+    ).rejects.toBeInstanceOf(ChecklistIncompleteForApprovalError);
+  });
+
+  it("conditionally-approved blocked when no conditional waivers exist", async () => {
+    const engine = createMockApprovalEngine({ resolveRole: () => "Admin" as Role });
+    const appr = await engine.create("subj-1", ALICE);
+    await expect(
+      engine.decide(
+        appr.id,
+        {
+          nextState: "conditionally-approved",
+          reviewer: BOB,
+          reason: "Valid ten-char reason.",
+        },
+        { completeness: complete },
+      ),
+    ).rejects.toBeInstanceOf(NoConditionalWaiverError);
+  });
+
+  it("happy path: pending → conditionally-approved → approved when satisfied", async () => {
+    const engine = createMockApprovalEngine({ resolveRole: () => "Admin" as Role });
+    const appr = await engine.create("subj-1", ALICE);
+    const ca = await engine.decide(
+      appr.id,
+      {
+        nextState: "conditionally-approved",
+        reviewer: BOB,
+        reason: "Scheduled remediation by next sprint.",
+        conditions: [
+          {
+            id: "c1",
+            description: "attach fat",
+            dueAt: "2099-01-01T00:00:00Z",
+            status: "satisfied",
+          },
+        ],
+      },
+      { completeness: conditional },
+    );
+    expect(ca.state).toBe("conditionally-approved");
+    const approved = await engine.decide(
+      appr.id,
+      { nextState: "approved", reviewer: BOB },
+      { completeness: complete },
+    );
+    expect(approved.state).toBe("approved");
+  });
+
+  it("resubmit returns state to pending", async () => {
+    const engine = createMockApprovalEngine({ resolveRole: () => "Admin" as Role });
+    const appr = await engine.create("subj-1", ALICE);
+    const rejected = await engine.decide(
+      appr.id,
+      {
+        nextState: "rejected",
+        reviewer: BOB,
+        reason: "Needs further review, please retry.",
+      },
+      { completeness: complete },
+    );
+    expect(rejected.state).toBe("rejected");
+    const resubmitted = await engine.resubmit(appr.id, ALICE);
+    expect(resubmitted.state).toBe("pending");
+  });
+
+  it("RBAC: non-submit role cannot create", async () => {
+    const engine = createMockApprovalEngine({ resolveRole: () => "Viewer" as Role });
+    await expect(engine.create("subj-1", ALICE)).rejects.toBeInstanceOf(AccessDeniedError);
+  });
+
+  it("RBAC: Technician can submit but not decide", async () => {
+    const engine = createMockApprovalEngine({ resolveRole: () => "Technician" as Role });
+    const appr = await engine.create("subj-1", ALICE);
+    expect(appr.state).toBe("pending");
+    await expect(
+      engine.decide(appr.id, { nextState: "approved", reviewer: BOB }, { completeness: complete }),
+    ).rejects.toBeInstanceOf(AccessDeniedError);
+  });
+
+  it("listPending excludes decided approvals", async () => {
+    const engine = createMockApprovalEngine({ resolveRole: () => "Admin" as Role });
+    const a = await engine.create("subj-1", ALICE);
+    await engine.create("subj-2", ALICE);
+    await engine.decide(a.id, { nextState: "approved", reviewer: BOB }, { completeness: complete });
+    const pending = await engine.listPending({});
+    expect(pending.length).toBe(1);
+    expect(pending[0]?.subjectId).toBe("subj-2");
+  });
+});

--- a/src/__tests__/lib/compliance/checklist/completeness-engine.test.ts
+++ b/src/__tests__/lib/compliance/checklist/completeness-engine.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import { evaluateCompleteness } from "@/lib/compliance/checklist/completeness-engine";
+import type {
+  ChecklistSchema,
+  ChecklistState,
+  SlotState,
+} from "@/lib/compliance/checklist/checklist-schema";
+
+const ACTOR = { userId: "u", displayName: "u" };
+const ISO = "2026-04-21T00:00:00Z";
+
+type Key = "a" | "b" | "c" | "d";
+
+const SCHEMA: ChecklistSchema<Key> = {
+  schemaId: "demo",
+  label: "Demo",
+  slots: [
+    { key: "a", label: "A", required: true },
+    { key: "b", label: "B", required: true },
+    { key: "c", label: "C", required: true },
+    { key: "d", label: "D", required: false }, // optional
+  ],
+};
+
+function state(overrides: Partial<Record<Key, SlotState>>): ChecklistState<Key> {
+  return {
+    schemaId: "demo",
+    subjectId: "s1",
+    slots: {
+      a: overrides.a ?? { kind: "missing" },
+      b: overrides.b ?? { kind: "missing" },
+      c: overrides.c ?? { kind: "missing" },
+      d: overrides.d ?? { kind: "missing" },
+    },
+  };
+}
+
+const present: SlotState = {
+  kind: "present",
+  evidenceId: "ev-1",
+  filledAt: ISO,
+  filledBy: ACTOR,
+};
+const waivedPerm: SlotState = {
+  kind: "waived-permanent",
+  reason: "not applicable to this product line",
+  waivedAt: ISO,
+  waivedBy: ACTOR,
+};
+const waivedCond: SlotState = {
+  kind: "waived-conditional",
+  reason: "remediation scheduled",
+  dueAt: "2026-09-01T00:00:00Z",
+  waivedAt: ISO,
+  waivedBy: ACTOR,
+};
+
+describe("evaluateCompleteness", () => {
+  it("all required present → complete", () => {
+    const c = evaluateCompleteness(SCHEMA, state({ a: present, b: present, c: present }));
+    expect(c.kind).toBe("complete");
+  });
+
+  it("all required waived-permanent → complete", () => {
+    const c = evaluateCompleteness(SCHEMA, state({ a: waivedPerm, b: waivedPerm, c: waivedPerm }));
+    expect(c.kind).toBe("complete");
+  });
+
+  it("one required waived-conditional → conditionally-complete", () => {
+    const c = evaluateCompleteness(SCHEMA, state({ a: present, b: waivedCond, c: present }));
+    expect(c.kind).toBe("conditionally-complete");
+    if (c.kind === "conditionally-complete") {
+      expect(c.pendingWaivers).toEqual(["b"]);
+    }
+  });
+
+  it("any required missing → incomplete (missing takes priority over conditional)", () => {
+    const c = evaluateCompleteness(SCHEMA, state({ a: present, b: waivedCond }));
+    expect(c.kind).toBe("incomplete");
+    if (c.kind === "incomplete") {
+      expect(c.missing).toEqual(["c"]);
+    }
+  });
+
+  it("optional slot missing does not affect completeness", () => {
+    const c = evaluateCompleteness(
+      SCHEMA,
+      state({ a: present, b: present, c: present, d: { kind: "missing" } }),
+    );
+    expect(c.kind).toBe("complete");
+  });
+
+  it("schema/state mismatch → incomplete with all required keys", () => {
+    const mismatch: ChecklistState<Key> = {
+      ...state({ a: present, b: present, c: present }),
+      schemaId: "other",
+    };
+    const c = evaluateCompleteness(SCHEMA, mismatch);
+    expect(c.kind).toBe("incomplete");
+    if (c.kind === "incomplete") {
+      expect(c.missing).toEqual(["a", "b", "c"]);
+    }
+  });
+
+  it("slots entry missing from state treated as missing", () => {
+    const partial: ChecklistState<Key> = {
+      schemaId: "demo",
+      subjectId: "s1",
+      // @ts-expect-error — partial state for defensive-branch test
+      slots: { a: present },
+    };
+    const c = evaluateCompleteness(SCHEMA, partial);
+    expect(c.kind).toBe("incomplete");
+  });
+
+  it("mixed permanent + conditional waivers → conditionally-complete", () => {
+    const c = evaluateCompleteness(SCHEMA, state({ a: waivedPerm, b: waivedCond, c: present }));
+    expect(c.kind).toBe("conditionally-complete");
+    if (c.kind === "conditionally-complete") {
+      expect(c.pendingWaivers).toEqual(["b"]);
+    }
+  });
+});

--- a/src/__tests__/lib/compliance/checklist/mock-checklist-store.test.ts
+++ b/src/__tests__/lib/compliance/checklist/mock-checklist-store.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import { createMockChecklistStore } from "@/lib/compliance/checklist/mock-checklist-store";
+import { ChecklistValidationError } from "@/lib/compliance/checklist/checklist-errors";
+import { AccessDeniedError } from "@/lib/compliance/types";
+import type { ChecklistSchema } from "@/lib/compliance/checklist/checklist-schema";
+import type { Role } from "@/lib/rbac";
+
+const ACTOR = { userId: "alice", displayName: "Alice" };
+const SCHEMA: ChecklistSchema = {
+  schemaId: "demo",
+  label: "Demo",
+  slots: [
+    { key: "sbom", label: "SBOM", required: true },
+    { key: "release-notes", label: "Release Notes", required: true },
+  ],
+};
+
+function adminStore() {
+  return createMockChecklistStore({
+    resolveRole: () => "Admin" as Role,
+    seedSchemas: [SCHEMA],
+    now: () => new Date("2026-04-21T00:00:00Z"),
+  });
+}
+
+describe("createMockChecklistStore", () => {
+  it("loadState initializes missing slots from schema", async () => {
+    const store = adminStore();
+    const state = await store.loadState("demo", "fw-1");
+    expect(state.slots["sbom"]?.kind).toBe("missing");
+    expect(state.slots["release-notes"]?.kind).toBe("missing");
+  });
+
+  it("attachSlot moves slot to present with evidenceId", async () => {
+    const store = adminStore();
+    const next = await store.attachSlot("demo", "fw-1", "sbom", "ev-123", ACTOR);
+    expect(next.kind).toBe("present");
+    if (next.kind === "present") expect(next.evidenceId).toBe("ev-123");
+  });
+
+  it("waivePermanent records reason and actor", async () => {
+    const store = adminStore();
+    const next = await store.waivePermanent(
+      "demo",
+      "fw-1",
+      "sbom",
+      "Not required for this product line",
+      ACTOR,
+    );
+    expect(next.kind).toBe("waived-permanent");
+    if (next.kind === "waived-permanent") {
+      expect(next.reason).toContain("Not required");
+      expect(next.waivedBy.userId).toBe("alice");
+    }
+  });
+
+  it("waiveConditional rejects due date in the past", async () => {
+    const store = adminStore();
+    await expect(
+      store.waiveConditional(
+        "demo",
+        "fw-1",
+        "sbom",
+        "Scheduled remediation",
+        "2020-01-01T00:00:00Z",
+        ACTOR,
+      ),
+    ).rejects.toBeInstanceOf(ChecklistValidationError);
+  });
+
+  it("waiveConditional rejects due date > 365d in future", async () => {
+    const store = adminStore();
+    await expect(
+      store.waiveConditional(
+        "demo",
+        "fw-1",
+        "sbom",
+        "Scheduled remediation",
+        "2030-04-21T00:00:00Z",
+        ACTOR,
+      ),
+    ).rejects.toBeInstanceOf(ChecklistValidationError);
+  });
+
+  it("waivePermanent rejects short reason", async () => {
+    const store = adminStore();
+    await expect(
+      store.waivePermanent("demo", "fw-1", "sbom", "short", ACTOR),
+    ).rejects.toBeInstanceOf(ChecklistValidationError);
+  });
+
+  it("unwaive restores slot to missing", async () => {
+    const store = adminStore();
+    await store.waivePermanent("demo", "fw-1", "sbom", "Not required for this product line", ACTOR);
+    const next = await store.unwaive("demo", "fw-1", "sbom", ACTOR);
+    expect(next.kind).toBe("missing");
+  });
+
+  it("attach/waive denied for role without permission", async () => {
+    const denyStore = createMockChecklistStore({
+      resolveRole: () => "Viewer" as Role,
+      seedSchemas: [SCHEMA],
+    });
+    await expect(
+      denyStore.attachSlot("demo", "fw-1", "sbom", "ev-1", ACTOR),
+    ).rejects.toBeInstanceOf(AccessDeniedError);
+    await expect(
+      denyStore.waivePermanent("demo", "fw-1", "sbom", "Not required for this product line", ACTOR),
+    ).rejects.toBeInstanceOf(AccessDeniedError);
+  });
+
+  it("Technician can attach but not waive", async () => {
+    const store = createMockChecklistStore({
+      resolveRole: () => "Technician" as Role,
+      seedSchemas: [SCHEMA],
+    });
+    const ok = await store.attachSlot("demo", "fw-1", "sbom", "ev-99", ACTOR);
+    expect(ok.kind).toBe("present");
+    await expect(
+      store.waivePermanent("demo", "fw-1", "sbom", "tech shouldn't be able to waive", ACTOR),
+    ).rejects.toBeInstanceOf(AccessDeniedError);
+  });
+});

--- a/src/__tests__/lib/compliance/evidence/mock-evidence-store.test.ts
+++ b/src/__tests__/lib/compliance/evidence/mock-evidence-store.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createMockEvidenceStore } from "@/lib/compliance/evidence/mock-evidence-store";
+import {
+  EvidenceImmutabilityError,
+  EvidenceNotFoundError,
+} from "@/lib/compliance/evidence/evidence-errors";
+import { AccessDeniedError, type ComplianceActor } from "@/lib/compliance/types";
+import type { IEvidenceStore } from "@/lib/compliance/evidence/evidence-store.interface";
+import type { Role } from "@/lib/rbac";
+
+const ALICE: ComplianceActor = { userId: "alice", displayName: "Alice" };
+const BOB: ComplianceActor = { userId: "bob", displayName: "Bob" };
+
+const adminRole: (a: ComplianceActor) => Role = () => "Admin";
+const viewerRole: (a: ComplianceActor) => Role = () => "Viewer";
+
+function bytesOf(s: string): Uint8Array {
+  return new TextEncoder().encode(s);
+}
+
+describe("createMockEvidenceStore", () => {
+  let store: IEvidenceStore;
+  const fixedNow = () => new Date("2026-04-21T10:00:00Z");
+
+  beforeEach(() => {
+    store = createMockEvidenceStore({ resolveRole: adminRole, now: fixedNow });
+  });
+
+  it("interface exposes no mutation methods", () => {
+    // Compile-time guarantee verified via ts-check; this runtime test is
+    // a belt-and-braces assertion that the returned object shape matches.
+    expect("put" in store).toBe(true);
+    expect("get" in store).toBe(true);
+    expect("getSignedReadUrl" in store).toBe(true);
+    expect("list" in store).toBe(true);
+    expect("delete" in store).toBe(false);
+    expect("update" in store).toBe(false);
+  });
+
+  it("put stores metadata with immutable=true and SHA-256 hash", async () => {
+    const meta = await store.put({
+      bytes: bytesOf("hello"),
+      mimeType: "text/plain",
+      retentionMode: "compliance",
+      retainUntil: "2030-01-01T00:00:00Z",
+      actor: ALICE,
+    });
+    expect(meta.immutable).toBe(true);
+    expect(meta.contentHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(meta.uploadedBy.userId).toBe("alice");
+    expect(meta.retention.mode).toBe("compliance");
+    expect(meta.uploadedAt).toBe("2026-04-21T10:00:00.000Z");
+  });
+
+  it("identical payloads produce the same content hash (dedup-safe)", async () => {
+    const a = await store.put({
+      bytes: bytesOf("same"),
+      mimeType: "text/plain",
+      retentionMode: "compliance",
+      retainUntil: "2030-01-01T00:00:00Z",
+      actor: ALICE,
+    });
+    const b = await store.put({
+      bytes: bytesOf("same"),
+      mimeType: "text/plain",
+      retentionMode: "compliance",
+      retainUntil: "2030-01-01T00:00:00Z",
+      actor: BOB,
+    });
+    expect(a.contentHash).toBe(b.contentHash);
+    expect(a.id).toBe(b.id);
+  });
+
+  it("returned metadata is frozen — direct mutation throws", async () => {
+    const meta = await store.put({
+      bytes: bytesOf("frozen"),
+      mimeType: "text/plain",
+      retentionMode: "compliance",
+      retainUntil: "2030-01-01T00:00:00Z",
+      actor: ALICE,
+    });
+    expect(() => {
+      // @ts-expect-error — immutability invariant check
+      meta.id = "tampered";
+    }).toThrow();
+  });
+
+  it("get returns stored metadata and rejects unknown ids", async () => {
+    const meta = await store.put({
+      bytes: bytesOf("fetch-me"),
+      mimeType: "text/plain",
+      retentionMode: "compliance",
+      retainUntil: "2030-01-01T00:00:00Z",
+      actor: ALICE,
+    });
+    const got = await store.get(meta.id, { actor: ALICE });
+    expect(got.id).toBe(meta.id);
+    await expect(store.get("ev-nonexistent", { actor: ALICE })).rejects.toBeInstanceOf(
+      EvidenceNotFoundError,
+    );
+  });
+
+  it("getSignedReadUrl returns a non-empty url and rejects unknown ids", async () => {
+    const meta = await store.put({
+      bytes: bytesOf("signme"),
+      mimeType: "text/plain",
+      retentionMode: "compliance",
+      retainUntil: "2030-01-01T00:00:00Z",
+      actor: ALICE,
+    });
+    const url = await store.getSignedReadUrl(meta.id, 60, { actor: ALICE });
+    expect(url).toMatch(/^data:text\/plain/);
+    await expect(store.getSignedReadUrl("ev-nope", 60, { actor: ALICE })).rejects.toBeInstanceOf(
+      EvidenceNotFoundError,
+    );
+  });
+
+  it("list returns newest-first with tag filter", async () => {
+    const nowA = new Date("2026-04-21T10:00:00Z");
+    const nowB = new Date("2026-04-22T10:00:00Z");
+    const storeA = createMockEvidenceStore({ resolveRole: adminRole, now: () => nowA });
+    await storeA.put({
+      bytes: bytesOf("one"),
+      mimeType: "text/plain",
+      retentionMode: "compliance",
+      retainUntil: "2030-01-01T00:00:00Z",
+      tags: { class: "sbom" },
+      actor: ALICE,
+    });
+    // Use a second store instance with different clock, then merge for assertion
+    const storeB = createMockEvidenceStore({ resolveRole: adminRole, now: () => nowB });
+    await storeB.put({
+      bytes: bytesOf("two"),
+      mimeType: "text/plain",
+      retentionMode: "compliance",
+      retainUntil: "2030-01-01T00:00:00Z",
+      tags: { class: "release-notes" },
+      actor: BOB,
+    });
+
+    const listA = await storeA.list({}, { actor: ALICE });
+    expect(listA).toHaveLength(1);
+    const filtered = await storeA.list({ tags: { class: "sbom" } }, { actor: ALICE });
+    expect(filtered).toHaveLength(1);
+    const none = await storeA.list({ tags: { class: "unknown" } }, { actor: ALICE });
+    expect(none).toHaveLength(0);
+  });
+
+  it("denies put + read when RBAC fails", async () => {
+    const denyStore = createMockEvidenceStore({ resolveRole: viewerRole, now: fixedNow });
+    await expect(
+      denyStore.put({
+        bytes: bytesOf("denied"),
+        mimeType: "text/plain",
+        retentionMode: "compliance",
+        retainUntil: "2030-01-01T00:00:00Z",
+        actor: ALICE,
+      }),
+    ).rejects.toBeInstanceOf(AccessDeniedError);
+  });
+
+  it("EvidenceImmutabilityError is a distinct, catchable error", () => {
+    const err = new EvidenceImmutabilityError("ev-1", "delete");
+    expect(err).toBeInstanceOf(EvidenceImmutabilityError);
+    expect(err.kind).toBe("compliance.evidence.immutability");
+  });
+});

--- a/src/app/components/compliance/approval-decision-panel.tsx
+++ b/src/app/components/compliance/approval-decision-panel.tsx
@@ -1,0 +1,196 @@
+/**
+ * <ApprovalDecisionPanel /> — reviewer UI for deciding an approval
+ * (Story 28.3 AC10-AC12). Renders Approve / Conditional Approve / Reject
+ * actions; buttons enabled only when the transition is legal given the
+ * current approval state + checklist completeness.
+ *
+ * Server-side enforcement is the ground truth; client-side disabling is an
+ * ergonomic layer (the adapter re-validates every decision).
+ */
+
+import { useState } from "react";
+
+import { cn } from "@/lib/utils";
+import { ApprovalGateBadge } from "./approval-gate-badge";
+import { isTransitionAllowed, type Approval, type ApprovalState } from "@/lib/compliance/approval";
+import type { Completeness } from "@/lib/compliance/checklist";
+
+export interface ApprovalDecisionPanelProps {
+  readonly approval: Approval | null | undefined;
+  readonly completeness: Completeness | undefined;
+  readonly canDecide: boolean;
+  readonly onDecide: (input: {
+    readonly nextState: Exclude<ApprovalState, "pending">;
+    readonly reason?: string;
+  }) => Promise<void>;
+  readonly className?: string;
+}
+
+export function ApprovalDecisionPanel({
+  approval,
+  completeness,
+  canDecide,
+  onDecide,
+  className,
+}: ApprovalDecisionPanelProps) {
+  const [reason, setReason] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const state: ApprovalState = approval?.state ?? "pending";
+  const canApprove =
+    isTransitionAllowed(state, "approved") &&
+    (completeness?.kind === "complete" ||
+      (state === "conditionally-approved" && completeness?.kind !== "incomplete"));
+  const canConditional =
+    isTransitionAllowed(state, "conditionally-approved") &&
+    completeness?.kind === "conditionally-complete";
+  const canReject = isTransitionAllowed(state, "rejected");
+
+  const reasonValid = reason.length >= 10 && reason.length <= 500;
+
+  const decide = async (next: Exclude<ApprovalState, "pending">) => {
+    if (!canDecide || submitting) return;
+    if ((next === "rejected" || next === "conditionally-approved") && !reasonValid) {
+      setErr("A 10-500 character reason is required.");
+      return;
+    }
+    setSubmitting(true);
+    setErr(null);
+    try {
+      await onDecide({ nextState: next, reason: reason || undefined });
+      setReason("");
+    } catch (e) {
+      setErr((e as Error).message ?? "Decision failed");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className={cn("rounded-lg border border-border bg-card", className)}>
+      <header className="flex items-center justify-between border-b border-border px-4 py-3">
+        <h3 className="text-[14px] font-semibold text-foreground">Approval decision</h3>
+        <ApprovalGateBadge approval={approval} />
+      </header>
+
+      {canDecide ? (
+        <div className="space-y-3 px-4 py-3">
+          <div>
+            <label
+              htmlFor="decision-reason"
+              className="mb-1 block text-[12px] font-medium text-foreground"
+            >
+              Reason (required for reject / conditional)
+            </label>
+            <textarea
+              id="decision-reason"
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              rows={3}
+              maxLength={500}
+              placeholder="Why?"
+              className="w-full rounded-md border border-border bg-card px-2 py-1.5 text-[12px] text-foreground outline-none focus:border-primary"
+            />
+            <p className="mt-0.5 text-[10px] text-muted-foreground">
+              {reason.length}/500 characters
+            </p>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2">
+            <ActionButton
+              disabled={!canApprove || submitting}
+              tooltip={canApprove ? undefined : tooltipFor("approve", state, completeness)}
+              variant="primary"
+              label="Approve"
+              onClick={() => void decide("approved")}
+            />
+            <ActionButton
+              disabled={!canConditional || submitting}
+              tooltip={canConditional ? undefined : tooltipFor("conditional", state, completeness)}
+              variant="amber"
+              label="Conditional Approve"
+              onClick={() => void decide("conditionally-approved")}
+            />
+            <ActionButton
+              disabled={!canReject || submitting}
+              tooltip={canReject ? undefined : tooltipFor("reject", state, completeness)}
+              variant="danger"
+              label="Reject"
+              onClick={() => void decide("rejected")}
+            />
+          </div>
+
+          {err && (
+            <p
+              role="alert"
+              className="rounded-md border border-red-200 bg-red-50 p-2 text-[12px] text-red-800"
+            >
+              {err}
+            </p>
+          )}
+        </div>
+      ) : (
+        <p className="px-4 py-3 text-[12px] text-muted-foreground">
+          You do not have permission to decide this approval.
+        </p>
+      )}
+    </div>
+  );
+}
+
+type Variant = "primary" | "amber" | "danger";
+
+function ActionButton({
+  label,
+  onClick,
+  disabled,
+  tooltip,
+  variant,
+}: {
+  readonly label: string;
+  readonly onClick: () => void;
+  readonly disabled: boolean;
+  readonly tooltip: string | undefined;
+  readonly variant: Variant;
+}) {
+  const cls: Record<Variant, string> = {
+    primary: "bg-emerald-600 text-white hover:bg-emerald-700",
+    amber: "bg-amber-600 text-white hover:bg-amber-700",
+    danger: "border border-red-300 text-red-700 hover:bg-red-50",
+  };
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      title={tooltip}
+      className={cn(
+        "inline-flex items-center rounded-md px-3 py-1.5 text-[12px] font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50",
+        cls[variant],
+      )}
+    >
+      {label}
+    </button>
+  );
+}
+
+function tooltipFor(
+  action: "approve" | "conditional" | "reject",
+  state: ApprovalState,
+  completeness: Completeness | undefined,
+): string {
+  if (action === "approve") {
+    if (completeness?.kind === "incomplete") return "Checklist incomplete";
+    if (!isTransitionAllowed(state, "approved")) return `Cannot approve from ${state}`;
+  }
+  if (action === "conditional") {
+    if (completeness?.kind !== "conditionally-complete") return "No conditional waivers";
+    if (!isTransitionAllowed(state, "conditionally-approved"))
+      return `Cannot conditionally approve from ${state}`;
+  }
+  if (action === "reject") {
+    if (!isTransitionAllowed(state, "rejected")) return `Cannot reject from ${state}`;
+  }
+  return "";
+}

--- a/src/app/components/compliance/approval-gate-badge.tsx
+++ b/src/app/components/compliance/approval-gate-badge.tsx
@@ -1,0 +1,68 @@
+/**
+ * <ApprovalGateBadge /> — compact state pill for an approval (Story 28.3 AC9).
+ */
+
+import { AlertTriangle, Ban, CheckCircle2, Clock } from "lucide-react";
+import type { ReactNode } from "react";
+import type { Approval, ApprovalState } from "@/lib/compliance/approval";
+import { cn } from "@/lib/utils";
+
+export interface ApprovalGateBadgeProps {
+  readonly approval: Approval | null | undefined;
+  readonly className?: string;
+}
+
+export function ApprovalGateBadge({ approval, className }: ApprovalGateBadgeProps) {
+  const state: ApprovalState = approval?.state ?? "pending";
+  const variant = VARIANTS[state];
+  const tooltip = approval
+    ? [
+        `State: ${state}`,
+        approval.reviewer ? `Reviewer: ${approval.reviewer.displayName}` : null,
+        approval.decidedAt ? `Decided: ${new Date(approval.decidedAt).toLocaleString()}` : null,
+        approval.reason ? `Reason: ${approval.reason}` : null,
+      ]
+        .filter(Boolean)
+        .join("\n")
+    : `State: ${state}`;
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-medium",
+        variant.className,
+        className,
+      )}
+      title={tooltip}
+    >
+      {variant.icon}
+      {variant.label}
+    </span>
+  );
+}
+
+const VARIANTS: Record<
+  ApprovalState,
+  { readonly label: string; readonly icon: ReactNode; readonly className: string }
+> = {
+  pending: {
+    label: "Pending",
+    icon: <Clock className="h-3 w-3" aria-hidden="true" />,
+    className: "border-muted-foreground/30 bg-muted text-muted-foreground",
+  },
+  approved: {
+    label: "Approved",
+    icon: <CheckCircle2 className="h-3 w-3" aria-hidden="true" />,
+    className: "border-emerald-300 bg-emerald-50 text-emerald-800",
+  },
+  "conditionally-approved": {
+    label: "Conditional",
+    icon: <AlertTriangle className="h-3 w-3" aria-hidden="true" />,
+    className: "border-amber-300 bg-amber-50 text-amber-900",
+  },
+  rejected: {
+    label: "Rejected",
+    icon: <Ban className="h-3 w-3" aria-hidden="true" />,
+    className: "border-red-300 bg-red-50 text-red-800",
+  },
+};

--- a/src/app/components/compliance/checklist-panel.tsx
+++ b/src/app/components/compliance/checklist-panel.tsx
@@ -1,0 +1,248 @@
+/**
+ * <ChecklistPanel /> — renders the slot-by-slot state with attach / waive
+ * actions (Story 28.2 AC7-AC10). Domain-agnostic: driven by the schema
+ * passed in; the primitive has no IMS knowledge.
+ *
+ * Waive actions (`<WaiverDialog>`) are rendered only for principals with
+ * `canPerformAction(role, "checklist:waive")`; the server re-validates
+ * so hiding in the UI is an ergonomic layer, not the security boundary.
+ */
+
+import { useState } from "react";
+import { AlertCircle, CheckCircle2, Clock, Paperclip, ShieldCheck, X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { useChecklist, type ChecklistSchema, type SlotState } from "@/lib/compliance/checklist";
+import { WaiverDialog } from "./waiver-dialog";
+
+export interface ChecklistPanelProps {
+  readonly schemaId: string;
+  readonly subjectId: string;
+  readonly canAttach: boolean;
+  readonly canWaive: boolean;
+  readonly onAttach?: (slotKey: string) => void;
+  readonly className?: string;
+}
+
+export function ChecklistPanel({
+  schemaId,
+  subjectId,
+  canAttach,
+  canWaive,
+  onAttach,
+  className,
+}: ChecklistPanelProps) {
+  const {
+    schema,
+    state,
+    completeness,
+    isLoading,
+    error,
+    waivePermanent,
+    waiveConditional,
+    unwaive,
+  } = useChecklist(schemaId, subjectId);
+  const [waiverSlot, setWaiverSlot] = useState<string | null>(null);
+
+  if (isLoading) {
+    return (
+      <div className={cn("rounded-lg border border-border bg-card p-4", className)}>
+        <div className="h-4 w-40 animate-pulse rounded bg-muted" />
+        <div className="mt-3 space-y-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="h-10 animate-pulse rounded bg-muted" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !schema || !state) {
+    return (
+      <div role="alert" className={cn("rounded-lg border border-red-200 bg-red-50 p-4", className)}>
+        <div className="flex items-center gap-2 text-red-800">
+          <AlertCircle className="h-4 w-4" aria-hidden="true" />
+          <span className="text-sm">Unable to load checklist.</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("rounded-lg border border-border bg-card", className)}>
+      <header className="flex items-center justify-between border-b border-border px-4 py-3">
+        <div>
+          <h3 className="text-[14px] font-semibold text-foreground">{schema.label}</h3>
+          <p className="mt-0.5 text-[11px] text-muted-foreground">
+            <ChecklistSummaryText schema={schema} state={state} completeness={completeness} />
+          </p>
+        </div>
+        <CompletenessPill completeness={completeness} />
+      </header>
+
+      <ul className="divide-y divide-border">
+        {schema.slots.map((slot) => {
+          const slotState: SlotState = state.slots[slot.key] ?? { kind: "missing" };
+          return (
+            <li key={slot.key} className="flex items-center justify-between gap-3 px-4 py-3">
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <SlotIcon kind={slotState.kind} />
+                  <span className="text-[13px] font-medium text-foreground">{slot.label}</span>
+                  {slot.required && (
+                    <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] uppercase text-muted-foreground">
+                      required
+                    </span>
+                  )}
+                </div>
+                <SlotStateLine state={slotState} />
+              </div>
+              <div className="flex items-center gap-2">
+                {slotState.kind !== "present" && canAttach && (
+                  <button
+                    type="button"
+                    onClick={() => onAttach?.(slot.key)}
+                    className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-1 text-[11px] text-foreground hover:bg-muted"
+                  >
+                    <Paperclip className="h-3 w-3" aria-hidden="true" /> Attach
+                  </button>
+                )}
+                {canWaive && slotState.kind === "missing" && (
+                  <button
+                    type="button"
+                    onClick={() => setWaiverSlot(slot.key)}
+                    className="inline-flex items-center gap-1 rounded-md border border-amber-300 bg-amber-50 px-2 py-1 text-[11px] text-amber-900 hover:bg-amber-100"
+                  >
+                    <ShieldCheck className="h-3 w-3" aria-hidden="true" /> Waive
+                  </button>
+                )}
+                {canWaive &&
+                  (slotState.kind === "waived-permanent" ||
+                    slotState.kind === "waived-conditional") && (
+                    <button
+                      type="button"
+                      onClick={() => void unwaive(slot.key)}
+                      className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-1 text-[11px] text-muted-foreground hover:bg-muted"
+                    >
+                      <X className="h-3 w-3" aria-hidden="true" /> Unwaive
+                    </button>
+                  )}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+
+      {waiverSlot && (
+        <WaiverDialog
+          slotKey={waiverSlot}
+          onClose={() => setWaiverSlot(null)}
+          onPermanent={async (reason) => {
+            await waivePermanent(waiverSlot, reason);
+            setWaiverSlot(null);
+          }}
+          onConditional={async (reason, dueAt) => {
+            await waiveConditional(waiverSlot, reason, dueAt);
+            setWaiverSlot(null);
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function SlotIcon({ kind }: { readonly kind: SlotState["kind"] }) {
+  switch (kind) {
+    case "present":
+      return <CheckCircle2 className="h-4 w-4 text-emerald-600" aria-hidden="true" />;
+    case "missing":
+      return <AlertCircle className="h-4 w-4 text-red-600" aria-hidden="true" />;
+    case "waived-permanent":
+      return <ShieldCheck className="h-4 w-4 text-muted-foreground" aria-hidden="true" />;
+    case "waived-conditional":
+      return <Clock className="h-4 w-4 text-amber-600" aria-hidden="true" />;
+  }
+}
+
+function SlotStateLine({ state }: { readonly state: SlotState }) {
+  switch (state.kind) {
+    case "present":
+      return (
+        <p className="mt-0.5 text-[11px] text-muted-foreground">
+          Filled by {state.filledBy.displayName} · {short(state.filledAt)}
+        </p>
+      );
+    case "missing":
+      return <p className="mt-0.5 text-[11px] text-muted-foreground">No evidence attached</p>;
+    case "waived-permanent":
+      return (
+        <p className="mt-0.5 text-[11px] text-muted-foreground">
+          Waived permanently by {state.waivedBy.displayName} · {state.reason}
+        </p>
+      );
+    case "waived-conditional":
+      return (
+        <p className="mt-0.5 text-[11px] text-amber-800">
+          Conditional waiver — due {short(state.dueAt)} · {state.reason}
+        </p>
+      );
+  }
+}
+
+function CompletenessPill({
+  completeness,
+}: {
+  readonly completeness: { kind: string } | undefined;
+}) {
+  if (!completeness) return null;
+  const map: Record<string, { label: string; className: string }> = {
+    complete: { label: "Complete", className: "border-emerald-300 bg-emerald-50 text-emerald-800" },
+    "conditionally-complete": {
+      label: "Conditional",
+      className: "border-amber-300 bg-amber-50 text-amber-900",
+    },
+    incomplete: { label: "Incomplete", className: "border-red-300 bg-red-50 text-red-800" },
+  };
+  const v = map[completeness.kind];
+  if (!v) return null;
+  return (
+    <span className={cn("rounded-full border px-2 py-0.5 text-[11px] font-medium", v.className)}>
+      {v.label}
+    </span>
+  );
+}
+
+function ChecklistSummaryText({
+  schema,
+  state,
+  completeness,
+}: {
+  readonly schema: ChecklistSchema;
+  readonly state: { readonly slots: Readonly<Record<string, SlotState>> };
+  readonly completeness: { kind: string } | undefined;
+}) {
+  const required = schema.slots.filter((s) => s.required);
+  const present = required.filter((s) => state.slots[s.key]?.kind === "present").length;
+  const conditional = required.filter(
+    (s) => state.slots[s.key]?.kind === "waived-conditional",
+  ).length;
+  const missing = required.filter(
+    (s) => (state.slots[s.key]?.kind ?? "missing") === "missing",
+  ).length;
+  void completeness;
+  return (
+    <>
+      {present}/{required.length} complete
+      {conditional > 0 && ` · ${conditional} conditional`}
+      {missing > 0 && ` · ${missing} missing`}
+    </>
+  );
+}
+
+function short(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString();
+  } catch {
+    return iso;
+  }
+}

--- a/src/app/components/compliance/evidence-viewer.stories.tsx
+++ b/src/app/components/compliance/evidence-viewer.stories.tsx
@@ -1,0 +1,110 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useEffect, useState, type ReactNode } from "react";
+
+import { EvidenceViewer } from "./evidence-viewer";
+import { EvidenceStoreProvider, createMockEvidenceStore } from "@/lib/compliance/evidence";
+import type { EvidenceMetadata, IEvidenceStore } from "@/lib/compliance/evidence";
+
+const DEMO_ACTOR = { userId: "demo-user", displayName: "Demo User" } as const;
+
+function makePdfBytes(): Uint8Array {
+  const header = "%PDF-1.4\n% Demo evidence payload for Storybook";
+  return new TextEncoder().encode(header);
+}
+
+function makePngBytes(): Uint8Array {
+  // 1x1 transparent PNG
+  return Uint8Array.from([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+    0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
+    0x89, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x63, 0x00, 0x01, 0x00, 0x00,
+    0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae,
+    0x42, 0x60, 0x82,
+  ]);
+}
+
+interface HarnessProps {
+  readonly mimeType: string;
+  readonly bytes: Uint8Array;
+  readonly children: (id: string) => ReactNode;
+}
+
+function EvidenceHarness({ mimeType, bytes, children }: HarnessProps) {
+  const [id, setId] = useState<string | undefined>(undefined);
+  const [store] = useState<IEvidenceStore>(() => createMockEvidenceStore());
+  const [qc] = useState(() => new QueryClient({ defaultOptions: { queries: { retry: false } } }));
+
+  useEffect(() => {
+    let cancelled = false;
+    void store
+      .put({
+        bytes,
+        mimeType,
+        retentionMode: "compliance",
+        retainUntil: "2099-01-01T00:00:00Z",
+        tags: { demo: "true" },
+        actor: DEMO_ACTOR,
+      })
+      .then((meta: EvidenceMetadata) => {
+        if (!cancelled) setId(meta.id);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [store, bytes, mimeType]);
+
+  return (
+    <QueryClientProvider client={qc}>
+      <EvidenceStoreProvider store={store} actor={DEMO_ACTOR}>
+        <div className="max-w-xl p-4">
+          {id ? children(id) : <p className="text-xs">Seeding mock store…</p>}
+        </div>
+      </EvidenceStoreProvider>
+    </QueryClientProvider>
+  );
+}
+
+const meta: Meta<typeof EvidenceViewer> = {
+  title: "Compliance/EvidenceViewer",
+  component: EvidenceViewer,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof EvidenceViewer>;
+
+export const PdfPreview: Story = {
+  render: () => (
+    <EvidenceHarness mimeType="application/pdf" bytes={makePdfBytes()}>
+      {(id) => <EvidenceViewer evidenceId={id} />}
+    </EvidenceHarness>
+  ),
+};
+
+export const ImagePreview: Story = {
+  render: () => (
+    <EvidenceHarness mimeType="image/png" bytes={makePngBytes()}>
+      {(id) => <EvidenceViewer evidenceId={id} />}
+    </EvidenceHarness>
+  ),
+};
+
+export const UnsupportedMime: Story = {
+  render: () => (
+    <EvidenceHarness
+      mimeType="application/octet-stream"
+      bytes={new TextEncoder().encode("binary payload")}
+    >
+      {(id) => <EvidenceViewer evidenceId={id} />}
+    </EvidenceHarness>
+  ),
+};
+
+export const NoPreview: Story = {
+  render: () => (
+    <EvidenceHarness mimeType="application/pdf" bytes={makePdfBytes()}>
+      {(id) => <EvidenceViewer evidenceId={id} preview={false} />}
+    </EvidenceHarness>
+  ),
+};

--- a/src/app/components/compliance/evidence-viewer.tsx
+++ b/src/app/components/compliance/evidence-viewer.tsx
@@ -1,0 +1,175 @@
+/**
+ * <EvidenceViewer /> — read-only display of an immutable evidence record
+ * (Story 28.1 AC8). Renders metadata, an inline preview for common mime
+ * types, a download button via signed URL, and an immutability badge.
+ *
+ * This component renders NO edit, delete, or replace affordances — the
+ * underlying store does not support mutation, and the UI must not imply
+ * otherwise (NIST MP-6).
+ */
+
+import { AlertTriangle, Download, FileText, Lock } from "lucide-react";
+import { useState } from "react";
+
+import { cn } from "@/lib/utils";
+import { useEvidence, useEvidenceSignedUrl } from "@/lib/compliance/evidence/use-evidence";
+
+export interface EvidenceViewerProps {
+  readonly evidenceId: string;
+  readonly className?: string;
+  /** Show inline preview for image/pdf/json/text mime types (default: true). */
+  readonly preview?: boolean;
+  /** Expiry for the signed download URL in seconds (default: 300 = 5 min). */
+  readonly signedUrlExpirySeconds?: number;
+}
+
+export function EvidenceViewer({
+  evidenceId,
+  className,
+  preview = true,
+  signedUrlExpirySeconds = 300,
+}: EvidenceViewerProps) {
+  const evidence = useEvidence(evidenceId);
+  const signed = useEvidenceSignedUrl(evidenceId, signedUrlExpirySeconds);
+  const [downloadLocked, setDownloadLocked] = useState(false);
+
+  if (evidence.isLoading) {
+    return (
+      <div className={cn("rounded-lg border border-border bg-card p-4", className)}>
+        <div className="h-4 w-32 animate-pulse rounded bg-muted" />
+        <div className="mt-3 h-24 animate-pulse rounded bg-muted" />
+      </div>
+    );
+  }
+
+  if (evidence.error) {
+    const isDenied = (evidence.error as { kind?: string }).kind === "compliance.access-denied";
+    return (
+      <div role="alert" className={cn("rounded-lg border border-red-200 bg-red-50 p-4", className)}>
+        <div className="flex items-center gap-2 text-red-800">
+          <AlertTriangle className="h-4 w-4" aria-hidden="true" />
+          <span className="text-sm font-medium">
+            {isDenied ? "You do not have access to this evidence" : "Evidence not found"}
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  const meta = evidence.data;
+  if (!meta) return null;
+
+  const onDownload = () => {
+    if (!signed.url || downloadLocked) return;
+    const a = document.createElement("a");
+    a.href = signed.url;
+    a.download = meta.id;
+    a.rel = "noopener";
+    a.click();
+    setDownloadLocked(true);
+    setTimeout(() => setDownloadLocked(false), 2_000);
+  };
+
+  return (
+    <div className={cn("rounded-lg border border-border bg-card", className)}>
+      <header className="flex items-start justify-between gap-3 border-b border-border px-4 py-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2 text-[13px] font-medium text-foreground">
+            <FileText className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+            <span className="truncate">{meta.id}</span>
+          </div>
+          <dl className="mt-1 grid grid-cols-2 gap-x-4 gap-y-1 text-[11px] text-muted-foreground">
+            <dt className="sr-only">Mime type</dt>
+            <dd>{meta.mimeType}</dd>
+            <dt className="sr-only">Size</dt>
+            <dd>{formatBytes(meta.sizeBytes)}</dd>
+            <dt className="sr-only">Uploaded by</dt>
+            <dd className="col-span-2 truncate">
+              uploaded by {meta.uploadedBy.displayName} · {formatDate(meta.uploadedAt)}
+            </dd>
+          </dl>
+        </div>
+        <ImmutabilityBadge retainUntil={meta.retention.retainUntil} />
+      </header>
+
+      {preview && <PreviewBlock url={signed.url} mime={meta.mimeType} />}
+
+      <footer className="flex items-center justify-between border-t border-border px-4 py-3 text-[11px] text-muted-foreground">
+        <span>SHA-256 {meta.contentHash.slice(0, 16)}…</span>
+        <button
+          type="button"
+          onClick={onDownload}
+          disabled={!signed.url || downloadLocked}
+          className={cn(
+            "inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-[12px] font-medium text-primary-foreground transition-colors",
+            "hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50",
+          )}
+          aria-label={`Download ${meta.id}`}
+        >
+          <Download className="h-3.5 w-3.5" aria-hidden="true" />
+          {signed.isLoading ? "Preparing…" : "Download"}
+        </button>
+      </footer>
+    </div>
+  );
+}
+
+function ImmutabilityBadge({ retainUntil }: { readonly retainUntil: string }) {
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-full border border-amber-300 bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-900"
+      title={`Stored under COMPLIANCE mode retention until ${formatDate(retainUntil)}. No user can modify or delete this record.`}
+    >
+      <Lock className="h-3 w-3" aria-hidden="true" />
+      Immutable
+    </span>
+  );
+}
+
+function PreviewBlock({ url, mime }: { readonly url: string | undefined; readonly mime: string }) {
+  if (!url) {
+    return (
+      <div className="border-b border-border bg-muted/30 px-4 py-6 text-center text-[12px] text-muted-foreground">
+        Preparing preview…
+      </div>
+    );
+  }
+  if (mime.startsWith("image/")) {
+    return (
+      <div className="border-b border-border bg-muted/30 p-4">
+        <img src={url} alt="Evidence preview" className="max-h-64 rounded border border-border" />
+      </div>
+    );
+  }
+  if (mime === "application/pdf") {
+    return (
+      <div className="border-b border-border bg-muted/30">
+        <iframe
+          title="Evidence PDF preview"
+          src={url}
+          className="h-64 w-full"
+          sandbox="allow-same-origin"
+        />
+      </div>
+    );
+  }
+  return (
+    <div className="border-b border-border bg-muted/30 px-4 py-6 text-center text-[12px] text-muted-foreground">
+      Preview unavailable for <code>{mime}</code> — use Download.
+    </div>
+  );
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / 1024 / 1024).toFixed(1)} MB`;
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+}

--- a/src/app/components/compliance/waiver-dialog.tsx
+++ b/src/app/components/compliance/waiver-dialog.tsx
@@ -1,0 +1,172 @@
+/**
+ * <WaiverDialog /> — reviewer-only UI for capturing a permanent or
+ * conditional waiver reason (Story 28.2 AC9).
+ *
+ * Reason: 10-500 chars (SI-10). Due date for conditional: today..+365d.
+ * Server-side validation in the adapter is the ground truth; this form
+ * provides ergonomic feedback.
+ */
+
+import { useState } from "react";
+import { DialogBase } from "@/components/dialog-base";
+
+export interface WaiverDialogProps {
+  readonly slotKey: string;
+  readonly onPermanent: (reason: string) => void | Promise<void>;
+  readonly onConditional: (reason: string, dueAt: string) => void | Promise<void>;
+  readonly onClose: () => void;
+}
+
+type Mode = "permanent" | "conditional";
+
+export function WaiverDialog({ slotKey, onPermanent, onConditional, onClose }: WaiverDialogProps) {
+  const [mode, setMode] = useState<Mode>("conditional");
+  const [reason, setReason] = useState("");
+  const [dueAt, setDueAt] = useState(defaultDueDate());
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const reasonValid = reason.length >= 10 && reason.length <= 500;
+  const dueValid = mode === "permanent" || Boolean(dueAt);
+
+  const submit = async () => {
+    if (!reasonValid || !dueValid || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      if (mode === "permanent") {
+        await onPermanent(reason);
+      } else {
+        await onConditional(reason, new Date(dueAt).toISOString());
+      }
+    } catch (e) {
+      setError((e as Error).message ?? "Failed to record waiver");
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <DialogBase
+      title={`Waive "${slotKey}"`}
+      open
+      onClose={onClose}
+      footer={
+        <>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border border-border px-3 py-1.5 text-[12px] text-foreground hover:bg-muted"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={submit}
+            disabled={!reasonValid || !dueValid || submitting}
+            className="rounded-md bg-primary px-3 py-1.5 text-[12px] font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          >
+            {submitting ? "Saving…" : "Record waiver"}
+          </button>
+        </>
+      }
+    >
+      <div className="space-y-4 text-[13px]">
+        <fieldset>
+          <legend className="mb-2 text-[12px] font-medium text-foreground">Waiver type</legend>
+          <div className="flex gap-3">
+            <label className="flex items-center gap-2 text-[12px]">
+              <input
+                type="radio"
+                name="waiver-mode"
+                value="conditional"
+                checked={mode === "conditional"}
+                onChange={() => setMode("conditional")}
+              />
+              Conditional (with SLA)
+            </label>
+            <label className="flex items-center gap-2 text-[12px]">
+              <input
+                type="radio"
+                name="waiver-mode"
+                value="permanent"
+                checked={mode === "permanent"}
+                onChange={() => setMode("permanent")}
+              />
+              Permanent
+            </label>
+          </div>
+        </fieldset>
+
+        <div>
+          <label
+            htmlFor="waiver-reason"
+            className="mb-1 block text-[12px] font-medium text-foreground"
+          >
+            Reason
+          </label>
+          <textarea
+            id="waiver-reason"
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            maxLength={500}
+            rows={4}
+            placeholder={
+              mode === "permanent"
+                ? "Why is this artifact formally not required?"
+                : "Why conditional? State the remediation plan."
+            }
+            className="w-full rounded-md border border-border bg-card px-2 py-1.5 text-[12px] text-foreground outline-none focus:border-primary"
+          />
+          <p className="mt-0.5 text-[10px] text-muted-foreground">
+            {reason.length}/500 characters (min 10)
+          </p>
+        </div>
+
+        {mode === "conditional" && (
+          <div>
+            <label
+              htmlFor="waiver-due"
+              className="mb-1 block text-[12px] font-medium text-foreground"
+            >
+              Due date
+            </label>
+            <input
+              id="waiver-due"
+              type="date"
+              value={dueAt}
+              min={todayISODate()}
+              max={oneYearFromTodayISO()}
+              onChange={(e) => setDueAt(e.target.value)}
+              className="rounded-md border border-border bg-card px-2 py-1.5 text-[12px] text-foreground outline-none focus:border-primary"
+            />
+          </div>
+        )}
+
+        {error && (
+          <p
+            role="alert"
+            className="rounded-md border border-red-200 bg-red-50 p-2 text-[12px] text-red-800"
+          >
+            {error}
+          </p>
+        )}
+      </div>
+    </DialogBase>
+  );
+}
+
+function todayISODate(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function oneYearFromTodayISO(): string {
+  const d = new Date();
+  d.setDate(d.getDate() + 365);
+  return d.toISOString().slice(0, 10);
+}
+
+function defaultDueDate(): string {
+  const d = new Date();
+  d.setDate(d.getDate() + 30);
+  return d.toISOString().slice(0, 10);
+}

--- a/src/lib/audit/log-audit.ts
+++ b/src/lib/audit/log-audit.ts
@@ -1,0 +1,82 @@
+/**
+ * Centralized audit-log writer for compliance primitives.
+ *
+ * Wraps the existing audit trail (Epic 8). All compliance state transitions,
+ * access-denial events, and immutable-operation audits flow through this helper
+ * so they are uniformly classified and NIST-traceable (AU-2 / AU-3).
+ *
+ * NOTE: In production, `logAudit` dispatches to the server-side audit pipeline.
+ * In tests and the in-app client, it writes to the local audit-log query cache.
+ */
+
+import type { QueryClient } from "@tanstack/react-query";
+
+export type AuditOutcome = "success" | "denied" | "error";
+
+export interface AuditRecord {
+  /** Fully-qualified action name, e.g. `"compliance.evidence.put"` */
+  readonly action: string;
+  /** Primary resource type, e.g. `"Evidence"`, `"Approval"`, `"Checklist"` */
+  readonly resourceType: string;
+  /** Primary resource id */
+  readonly resourceId: string;
+  /** Principal that performed the action */
+  readonly actor: { readonly userId: string; readonly displayName: string };
+  /** Outcome classification — success/denied/error */
+  readonly outcome: AuditOutcome;
+  /** Optional typed context payload */
+  readonly context?: Readonly<Record<string, unknown>>;
+  /** Optional failure reason when outcome !== "success" */
+  readonly reason?: string;
+  /** ISO-8601 timestamp; defaulted to now if omitted */
+  readonly at?: string;
+}
+
+export interface LogAuditOptions {
+  /** TanStack queryClient — required in-app; tests may pass a stub */
+  readonly queryClient?: QueryClient;
+}
+
+interface InternalEntry extends AuditRecord {
+  readonly id: string;
+  readonly at: string;
+}
+
+const AUDIT_CACHE_KEY = ["auditLogs", "list", undefined] as const;
+
+/**
+ * Write an audit record. Returns the full entry (with id + timestamp).
+ *
+ * @example
+ * await logAudit({
+ *   action: "compliance.evidence.put",
+ *   resourceType: "Evidence",
+ *   resourceId: evidenceId,
+ *   actor: { userId, displayName },
+ *   outcome: "success",
+ *   context: { contentHash },
+ * });
+ */
+export function logAudit(record: AuditRecord, options: LogAuditOptions = {}): InternalEntry {
+  const entry: InternalEntry = {
+    ...record,
+    id: `audit-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+    at: record.at ?? new Date().toISOString(),
+  };
+
+  const qc = options.queryClient;
+  if (qc) {
+    const prev = qc.getQueryData<InternalEntry[]>(AUDIT_CACHE_KEY) ?? [];
+    qc.setQueryData<InternalEntry[]>(AUDIT_CACHE_KEY, [entry, ...prev]);
+  }
+
+  // Server-side audit dispatch happens through the existing API pipeline.
+  // For the current in-app implementation, the cache update above is the store.
+
+  return entry;
+}
+
+/** Test helper — read audit log entries from the cache without mutating. */
+export function readAuditLog(queryClient: QueryClient): readonly InternalEntry[] {
+  return queryClient.getQueryData<InternalEntry[]>(AUDIT_CACHE_KEY) ?? [];
+}

--- a/src/lib/compliance/approval/approval-engine.interface.ts
+++ b/src/lib/compliance/approval/approval-engine.interface.ts
@@ -1,0 +1,26 @@
+/**
+ * Approval engine interface — adapter-pluggable persistence (Story 28.3 AC4).
+ */
+
+import type { ComplianceActor } from "../types";
+import type { Approval, ApprovalState, SlaCondition } from "./approval-state-machine";
+import type { Completeness } from "../checklist";
+
+export interface DecideInput {
+  readonly nextState: Exclude<ApprovalState, "pending">;
+  readonly reviewer: ComplianceActor;
+  readonly reason?: string;
+  readonly conditions?: readonly SlaCondition[];
+}
+
+export interface IApprovalEngine {
+  create(subjectId: string, submittedBy: ComplianceActor): Promise<Approval>;
+  loadBySubject(subjectId: string): Promise<Approval | null>;
+  decide(
+    id: string,
+    input: DecideInput,
+    context: { readonly completeness: Completeness },
+  ): Promise<Approval>;
+  resubmit(id: string, resubmittedBy: ComplianceActor): Promise<Approval>;
+  listPending(filter: { readonly limit?: number }): Promise<readonly Approval[]>;
+}

--- a/src/lib/compliance/approval/approval-errors.ts
+++ b/src/lib/compliance/approval/approval-errors.ts
@@ -1,0 +1,41 @@
+/**
+ * Typed errors for the approval primitive (Story 28.3).
+ */
+
+import { ComplianceError } from "../types";
+
+export class SelfApprovalError extends ComplianceError {
+  public readonly kind = "compliance.approval.self-approval";
+
+  public constructor(actorId: string) {
+    super(
+      `NIST AC-5 (Separation of Duties): actor ${actorId} cannot decide an approval they submitted.`,
+    );
+  }
+}
+
+export class ChecklistIncompleteForApprovalError extends ComplianceError {
+  public readonly kind = "compliance.approval.checklist-incomplete";
+
+  public constructor(subjectId: string) {
+    super(`Subject ${subjectId} cannot be approved — checklist is incomplete.`);
+  }
+}
+
+export class NoConditionalWaiverError extends ComplianceError {
+  public readonly kind = "compliance.approval.no-conditional-waiver";
+
+  public constructor(subjectId: string) {
+    super(
+      `Subject ${subjectId} cannot be conditionally-approved — no conditional waivers exist on the checklist.`,
+    );
+  }
+}
+
+export class ApprovalNotFoundError extends ComplianceError {
+  public readonly kind = "compliance.approval.not-found";
+
+  public constructor(id: string) {
+    super(`Approval ${id} not found.`);
+  }
+}

--- a/src/lib/compliance/approval/approval-state-machine.ts
+++ b/src/lib/compliance/approval/approval-state-machine.ts
@@ -1,0 +1,164 @@
+/**
+ * Approval state machine (Story 28.3).
+ *
+ * Pure module — no I/O, no clock, no globals. The `transition()` function
+ * validates every state change against `approvalTransitionTable` and throws
+ * `ApprovalTransitionError` for anything not in the table.
+ *
+ * States:
+ * - pending                 → initial and post-resubmit
+ * - approved                → terminal (for this subject version)
+ * - conditionally-approved  → transient: requires all SLA conditions satisfied
+ * - rejected                → transient: caller resubmits → pending
+ */
+
+import { ComplianceError } from "../types";
+import type { ComplianceActor } from "../types";
+
+export type ApprovalState = "pending" | "approved" | "conditionally-approved" | "rejected";
+
+export interface SlaCondition {
+  readonly id: string;
+  readonly description: string;
+  readonly dueAt: string;
+  readonly status: "pending" | "satisfied" | "breached";
+}
+
+export interface Approval<TSubjectId extends string = string> {
+  readonly id: string;
+  readonly subjectId: TSubjectId;
+  readonly state: ApprovalState;
+  readonly submittedBy: ComplianceActor;
+  readonly reviewer: ComplianceActor | null;
+  readonly reason: string | null;
+  readonly decidedAt: string | null;
+  readonly conditions: readonly SlaCondition[];
+  readonly history: readonly {
+    readonly at: string;
+    readonly from: ApprovalState;
+    readonly to: ApprovalState;
+    readonly actor: ComplianceActor;
+    readonly reason: string | null;
+  }[];
+}
+
+/** Allowed transitions. Every pair in the table is exercised by unit tests. */
+export const approvalTransitionTable: ReadonlyArray<{
+  readonly from: ApprovalState;
+  readonly to: ApprovalState;
+}> = [
+  { from: "pending", to: "approved" },
+  { from: "pending", to: "conditionally-approved" },
+  { from: "pending", to: "rejected" },
+  { from: "conditionally-approved", to: "approved" },
+  { from: "conditionally-approved", to: "rejected" },
+  { from: "rejected", to: "pending" },
+];
+
+export class ApprovalTransitionError extends ComplianceError {
+  public readonly kind = "compliance.approval.invalid-transition";
+
+  public constructor(
+    public readonly from: ApprovalState,
+    public readonly to: ApprovalState,
+  ) {
+    super(`Invalid approval transition: ${from} → ${to}`);
+  }
+}
+
+export class ApprovalReasonError extends ComplianceError {
+  public readonly kind = "compliance.approval.reason-required";
+
+  public constructor(message: string) {
+    super(message);
+  }
+}
+
+const MIN_REASON = 10;
+const MAX_REASON = 500;
+
+export function isTransitionAllowed(from: ApprovalState, to: ApprovalState): boolean {
+  return approvalTransitionTable.some((t) => t.from === from && t.to === to);
+}
+
+export interface TransitionInput {
+  readonly actor: ComplianceActor;
+  readonly at: string;
+  readonly reason?: string;
+  readonly conditions?: readonly SlaCondition[];
+}
+
+export function transition<T extends string>(
+  current: Approval<T>,
+  next: ApprovalState,
+  ctx: TransitionInput,
+): Approval<T> {
+  if (!isTransitionAllowed(current.state, next)) {
+    throw new ApprovalTransitionError(current.state, next);
+  }
+
+  if (next === "rejected" || next === "conditionally-approved") {
+    const r = ctx.reason ?? "";
+    if (r.length < MIN_REASON || r.length > MAX_REASON) {
+      throw new ApprovalReasonError(
+        `A ${MIN_REASON}-${MAX_REASON} char reason is required for "${next}" (got ${r.length}).`,
+      );
+    }
+  }
+
+  // Transition from conditionally-approved → approved requires all conditions satisfied.
+  if (current.state === "conditionally-approved" && next === "approved") {
+    const unsatisfied = current.conditions.filter((c) => c.status !== "satisfied");
+    if (unsatisfied.length > 0) {
+      throw new ApprovalTransitionError(current.state, next);
+    }
+  }
+
+  const reviewerOnDecide: ComplianceActor | null = next === "pending" ? null : ctx.actor;
+
+  return {
+    ...current,
+    state: next,
+    reviewer: reviewerOnDecide,
+    reason: next === "pending" ? null : (ctx.reason ?? null),
+    decidedAt: next === "pending" ? null : ctx.at,
+    conditions: ctx.conditions ?? current.conditions,
+    history: [
+      ...current.history,
+      {
+        at: ctx.at,
+        from: current.state,
+        to: next,
+        actor: ctx.actor,
+        reason: ctx.reason ?? null,
+      },
+    ],
+  };
+}
+
+export function newPendingApproval<T extends string>(input: {
+  readonly id: string;
+  readonly subjectId: T;
+  readonly submittedBy: ComplianceActor;
+  readonly at: string;
+}): Approval<T> {
+  return {
+    id: input.id,
+    subjectId: input.subjectId,
+    state: "pending",
+    submittedBy: input.submittedBy,
+    reviewer: null,
+    reason: null,
+    decidedAt: null,
+    conditions: [],
+    history: [
+      {
+        at: input.at,
+        from: "pending",
+        to: "pending",
+        actor: input.submittedBy,
+        reason: null,
+      },
+    ],
+  };
+}

--- a/src/lib/compliance/approval/index.ts
+++ b/src/lib/compliance/approval/index.ts
@@ -1,0 +1,27 @@
+/** Barrel for the approval primitive (Story 28.3). */
+
+export type {
+  Approval,
+  ApprovalState,
+  SlaCondition,
+  TransitionInput,
+} from "./approval-state-machine";
+export {
+  ApprovalReasonError,
+  ApprovalTransitionError,
+  approvalTransitionTable,
+  isTransitionAllowed,
+  newPendingApproval,
+  transition,
+} from "./approval-state-machine";
+export type { DecideInput, IApprovalEngine } from "./approval-engine.interface";
+export { createMockApprovalEngine } from "./mock-approval-engine";
+export type { MockApprovalEngineOptions } from "./mock-approval-engine";
+export {
+  ApprovalNotFoundError,
+  ChecklistIncompleteForApprovalError,
+  NoConditionalWaiverError,
+  SelfApprovalError,
+} from "./approval-errors";
+export { ApprovalProvider, useApproval } from "./use-approval";
+export type { ApprovalProviderProps, UseApprovalResult } from "./use-approval";

--- a/src/lib/compliance/approval/mock-approval-engine.ts
+++ b/src/lib/compliance/approval/mock-approval-engine.ts
@@ -1,0 +1,207 @@
+/**
+ * In-memory mock `IApprovalEngine` (Story 28.3).
+ *
+ * Enforces:
+ * - RBAC via canPerformAction (NIST AC-3)
+ * - Separation of duties — reviewer.userId !== submittedBy.userId (NIST AC-5)
+ * - Checklist gating — "approved" requires complete; "conditionally-approved"
+ *   requires at least one conditional waiver
+ *
+ * Every transition and every denial writes an AUDIT# record (NIST AU-2/AU-3).
+ */
+
+import { AccessDeniedError, type ComplianceActor } from "../types";
+import { canPerformAction, type Role } from "../../rbac";
+import { logAudit } from "../../audit/log-audit";
+import {
+  ApprovalTransitionError,
+  newPendingApproval,
+  transition,
+  type Approval,
+} from "./approval-state-machine";
+import type { IApprovalEngine } from "./approval-engine.interface";
+import {
+  ApprovalNotFoundError,
+  ChecklistIncompleteForApprovalError,
+  NoConditionalWaiverError,
+  SelfApprovalError,
+} from "./approval-errors";
+
+export interface MockApprovalEngineOptions {
+  readonly resolveRole?: (actor: ComplianceActor) => Role;
+  readonly now?: () => Date;
+}
+
+export function createMockApprovalEngine(options: MockApprovalEngineOptions = {}): IApprovalEngine {
+  const byId = new Map<string, Approval>();
+  const bySubject = new Map<string, string>();
+  const resolveRole = options.resolveRole ?? (() => "Admin" as Role);
+  const now = options.now ?? (() => new Date());
+
+  function authorize(
+    actor: ComplianceActor,
+    action: "approval:submit" | "approval:decide",
+    subjectId: string,
+  ): void {
+    const role = resolveRole(actor);
+    if (!canPerformAction(role, action)) {
+      logAudit({
+        action: `compliance.${action}`,
+        resourceType: "Approval",
+        resourceId: subjectId,
+        actor,
+        outcome: "denied",
+        reason: `role ${role} lacks ${action}`,
+      });
+      throw new AccessDeniedError(action, actor.userId);
+    }
+  }
+
+  function mintId(): string {
+    return `appr-${Math.random().toString(36).slice(2, 11)}`;
+  }
+
+  return {
+    async create(subjectId, submittedBy): Promise<Approval> {
+      authorize(submittedBy, "approval:submit", subjectId);
+      const existingId = bySubject.get(subjectId);
+      if (existingId) {
+        const existing = byId.get(existingId);
+        if (existing) return existing;
+      }
+      const appr = newPendingApproval({
+        id: mintId(),
+        subjectId,
+        submittedBy,
+        at: now().toISOString(),
+      });
+      byId.set(appr.id, appr);
+      bySubject.set(subjectId, appr.id);
+      logAudit({
+        action: "compliance.approval.create",
+        resourceType: "Approval",
+        resourceId: appr.id,
+        actor: submittedBy,
+        outcome: "success",
+        context: { subjectId, state: "pending" },
+      });
+      return appr;
+    },
+
+    async loadBySubject(subjectId) {
+      const id = bySubject.get(subjectId);
+      if (!id) return null;
+      return byId.get(id) ?? null;
+    },
+
+    async decide(id, input, ctx): Promise<Approval> {
+      authorize(input.reviewer, "approval:decide", id);
+      const current = byId.get(id);
+      if (!current) throw new ApprovalNotFoundError(id);
+
+      if (current.submittedBy.userId === input.reviewer.userId) {
+        logAudit({
+          action: "compliance.approval.decide",
+          resourceType: "Approval",
+          resourceId: id,
+          actor: input.reviewer,
+          outcome: "denied",
+          reason: "AC-5: reviewer equals submitter",
+        });
+        throw new SelfApprovalError(input.reviewer.userId);
+      }
+
+      if (input.nextState === "approved" && ctx.completeness.kind === "incomplete") {
+        logAudit({
+          action: "compliance.approval.decide",
+          resourceType: "Approval",
+          resourceId: id,
+          actor: input.reviewer,
+          outcome: "denied",
+          reason: "checklist incomplete",
+        });
+        throw new ChecklistIncompleteForApprovalError(current.subjectId);
+      }
+      if (
+        input.nextState === "conditionally-approved" &&
+        ctx.completeness.kind !== "conditionally-complete"
+      ) {
+        logAudit({
+          action: "compliance.approval.decide",
+          resourceType: "Approval",
+          resourceId: id,
+          actor: input.reviewer,
+          outcome: "denied",
+          reason: "no conditional waivers",
+        });
+        throw new NoConditionalWaiverError(current.subjectId);
+      }
+
+      let updated: Approval;
+      try {
+        updated = transition(current, input.nextState, {
+          actor: input.reviewer,
+          at: now().toISOString(),
+          reason: input.reason,
+          conditions: input.conditions,
+        });
+      } catch (e) {
+        if (e instanceof ApprovalTransitionError) {
+          logAudit({
+            action: "compliance.approval.decide",
+            resourceType: "Approval",
+            resourceId: id,
+            actor: input.reviewer,
+            outcome: "denied",
+            reason: `invalid transition ${e.from} → ${e.to}`,
+          });
+        }
+        throw e;
+      }
+
+      byId.set(id, updated);
+      logAudit({
+        action: "compliance.approval.decide",
+        resourceType: "Approval",
+        resourceId: id,
+        actor: input.reviewer,
+        outcome: "success",
+        context: {
+          subjectId: current.subjectId,
+          priorState: current.state,
+          nextState: updated.state,
+          checklistCompleteness: ctx.completeness.kind,
+        },
+        reason: input.reason,
+      });
+
+      return updated;
+    },
+
+    async resubmit(id, resubmittedBy): Promise<Approval> {
+      authorize(resubmittedBy, "approval:submit", id);
+      const current = byId.get(id);
+      if (!current) throw new ApprovalNotFoundError(id);
+      const updated = transition(current, "pending", {
+        actor: resubmittedBy,
+        at: now().toISOString(),
+      });
+      byId.set(id, updated);
+      logAudit({
+        action: "compliance.approval.resubmit",
+        resourceType: "Approval",
+        resourceId: id,
+        actor: resubmittedBy,
+        outcome: "success",
+        context: { subjectId: current.subjectId },
+      });
+      return updated;
+    },
+
+    async listPending({ limit }): Promise<readonly Approval[]> {
+      const all = [...byId.values()].filter((a) => a.state === "pending");
+      all.sort((a, b) => (a.history[0]?.at ?? "").localeCompare(b.history[0]?.at ?? ""));
+      return limit ? all.slice(0, limit) : all;
+    },
+  };
+}

--- a/src/lib/compliance/approval/use-approval.tsx
+++ b/src/lib/compliance/approval/use-approval.tsx
@@ -1,0 +1,110 @@
+/**
+ * React hooks + provider for the approval primitive (Story 28.3).
+ */
+
+import { createContext, useContext, useMemo } from "react";
+import type { ReactNode } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { queryKeys } from "../../query-keys";
+import type { ComplianceActor } from "../types";
+import type { IApprovalEngine } from "./approval-engine.interface";
+import type { Approval, ApprovalState, SlaCondition } from "./approval-state-machine";
+import type { Completeness } from "../checklist";
+
+interface ApprovalCtxValue {
+  readonly engine: IApprovalEngine;
+  readonly actor: ComplianceActor;
+}
+
+const ApprovalContext = createContext<ApprovalCtxValue | null>(null);
+
+export interface ApprovalProviderProps {
+  readonly engine: IApprovalEngine;
+  readonly actor: ComplianceActor;
+  readonly children: ReactNode;
+}
+
+export function ApprovalProvider({ engine, actor, children }: ApprovalProviderProps) {
+  const value = useMemo(() => ({ engine, actor }), [engine, actor]);
+  return <ApprovalContext.Provider value={value}>{children}</ApprovalContext.Provider>;
+}
+
+function useCtx(): ApprovalCtxValue {
+  const ctx = useContext(ApprovalContext);
+  if (!ctx) throw new Error("useApproval requires <ApprovalProvider>.");
+  return ctx;
+}
+
+export interface UseApprovalResult {
+  readonly approval: Approval | null | undefined;
+  readonly isLoading: boolean;
+  readonly error: Error | undefined;
+  readonly create: () => Promise<Approval>;
+  readonly decide: (input: {
+    readonly nextState: Exclude<ApprovalState, "pending">;
+    readonly reason?: string;
+    readonly conditions?: readonly SlaCondition[];
+    readonly completeness: Completeness;
+  }) => Promise<Approval>;
+  readonly resubmit: () => Promise<Approval>;
+}
+
+export function useApproval(subjectId: string): UseApprovalResult {
+  const { engine, actor } = useCtx();
+  const qc = useQueryClient();
+
+  const q = useQuery({
+    queryKey: queryKeys.compliance.approval.bySubject(subjectId),
+    queryFn: () => engine.loadBySubject(subjectId),
+  });
+
+  const invalidate = () =>
+    qc.invalidateQueries({ queryKey: queryKeys.compliance.approval.bySubject(subjectId) });
+
+  const createM = useMutation({
+    mutationFn: () => engine.create(subjectId, actor),
+    onSuccess: invalidate,
+  });
+
+  const decideM = useMutation({
+    mutationFn: async (input: {
+      readonly nextState: Exclude<ApprovalState, "pending">;
+      readonly reason?: string;
+      readonly conditions?: readonly SlaCondition[];
+      readonly completeness: Completeness;
+    }) => {
+      const appr = q.data;
+      if (!appr) throw new Error("No approval loaded for subject");
+      return engine.decide(
+        appr.id,
+        {
+          nextState: input.nextState,
+          reviewer: actor,
+          reason: input.reason,
+          conditions: input.conditions,
+        },
+        { completeness: input.completeness },
+      );
+    },
+    onSuccess: invalidate,
+  });
+
+  const resubmitM = useMutation({
+    mutationFn: async () => {
+      const appr = q.data;
+      if (!appr) throw new Error("No approval loaded for subject");
+      return engine.resubmit(appr.id, actor);
+    },
+    onSuccess: invalidate,
+  });
+
+  return {
+    approval: q.data ?? null,
+    isLoading: q.isLoading,
+    error: q.error as Error | undefined,
+    create: () => createM.mutateAsync(),
+    decide: (input) => decideM.mutateAsync(input),
+    resubmit: () => resubmitM.mutateAsync(),
+  };
+}

--- a/src/lib/compliance/checklist/checklist-errors.ts
+++ b/src/lib/compliance/checklist/checklist-errors.ts
@@ -1,0 +1,29 @@
+/**
+ * Typed errors for the checklist primitive (Story 28.2).
+ */
+
+import { ComplianceError } from "../types";
+
+export class ChecklistSchemaNotFoundError extends ComplianceError {
+  public readonly kind = "compliance.checklist.schema-not-found";
+
+  public constructor(schemaId: string) {
+    super(`Checklist schema "${schemaId}" not found.`);
+  }
+}
+
+export class ChecklistIncompleteError extends ComplianceError {
+  public readonly kind = "compliance.checklist.incomplete";
+
+  public constructor(subjectId: string, missing: readonly string[]) {
+    super(`Checklist for subject ${subjectId} is incomplete — missing: ${missing.join(", ")}.`);
+  }
+}
+
+export class ChecklistValidationError extends ComplianceError {
+  public readonly kind = "compliance.checklist.validation";
+
+  public constructor(message: string) {
+    super(`Checklist validation failed: ${message}`);
+  }
+}

--- a/src/lib/compliance/checklist/checklist-schema.ts
+++ b/src/lib/compliance/checklist/checklist-schema.ts
@@ -1,0 +1,56 @@
+/**
+ * Generic checklist types for the document-completeness engine (Story 28.2).
+ *
+ * Schemas are caller-defined. The primitive carries no domain knowledge —
+ * it does not know what an SBOM, FAT report, or release note is. Callers
+ * declare a `ChecklistSchema<TKey>` describing the slots they require and
+ * pass it to `<ChecklistPanel>` / `evaluateCompleteness()`.
+ */
+
+import type { ComplianceActor } from "../types";
+
+export interface ChecklistSlot<TKey extends string = string> {
+  readonly key: TKey;
+  readonly label: string;
+  readonly required: boolean;
+  readonly description?: string;
+}
+
+export interface ChecklistSchema<TKey extends string = string> {
+  readonly schemaId: string;
+  readonly label: string;
+  readonly slots: readonly ChecklistSlot<TKey>[];
+}
+
+export type SlotState =
+  | { readonly kind: "missing" }
+  | {
+      readonly kind: "present";
+      readonly evidenceId: string;
+      readonly filledAt: string;
+      readonly filledBy: ComplianceActor;
+    }
+  | {
+      readonly kind: "waived-permanent";
+      readonly reason: string;
+      readonly waivedAt: string;
+      readonly waivedBy: ComplianceActor;
+    }
+  | {
+      readonly kind: "waived-conditional";
+      readonly reason: string;
+      readonly dueAt: string;
+      readonly waivedAt: string;
+      readonly waivedBy: ComplianceActor;
+    };
+
+export interface ChecklistState<TKey extends string = string> {
+  readonly schemaId: string;
+  readonly subjectId: string;
+  readonly slots: Readonly<Record<TKey, SlotState>>;
+}
+
+export type Completeness =
+  | { readonly kind: "complete" }
+  | { readonly kind: "conditionally-complete"; readonly pendingWaivers: readonly string[] }
+  | { readonly kind: "incomplete"; readonly missing: readonly string[] };

--- a/src/lib/compliance/checklist/checklist-store.interface.ts
+++ b/src/lib/compliance/checklist/checklist-store.interface.ts
@@ -1,0 +1,46 @@
+/**
+ * Checklist store interface — adapter-pluggable persistence for schemas and
+ * states. Story 28.2 AC4. Every write method is RBAC-gated server-side and
+ * writes an AUDIT# record with the prior/new state.
+ */
+
+import type { ComplianceActor } from "../types";
+import type { ChecklistSchema, ChecklistState, SlotState } from "./checklist-schema";
+
+export interface IChecklistStore {
+  loadSchema(schemaId: string): Promise<ChecklistSchema>;
+  loadState(schemaId: string, subjectId: string): Promise<ChecklistState>;
+  attachSlot(
+    schemaId: string,
+    subjectId: string,
+    slotKey: string,
+    evidenceId: string,
+    actor: ComplianceActor,
+  ): Promise<SlotState>;
+  waivePermanent(
+    schemaId: string,
+    subjectId: string,
+    slotKey: string,
+    reason: string,
+    actor: ComplianceActor,
+  ): Promise<SlotState>;
+  waiveConditional(
+    schemaId: string,
+    subjectId: string,
+    slotKey: string,
+    reason: string,
+    dueAt: string,
+    actor: ComplianceActor,
+  ): Promise<SlotState>;
+  unwaive(
+    schemaId: string,
+    subjectId: string,
+    slotKey: string,
+    actor: ComplianceActor,
+  ): Promise<SlotState>;
+  /**
+   * Register a schema — schemas are code-defined (no dynamic editor) so
+   * this is usually called once at app boot.
+   */
+  registerSchema(schema: ChecklistSchema): void;
+}

--- a/src/lib/compliance/checklist/completeness-engine.ts
+++ b/src/lib/compliance/checklist/completeness-engine.ts
@@ -1,0 +1,51 @@
+/**
+ * Pure completeness evaluator (Story 28.2 AC2).
+ *
+ * Given a schema and the current slot state, classify the subject as
+ * `complete`, `conditionally-complete`, or `incomplete`. The function has
+ * no I/O, no clock, and no dependency on globals — every branch is covered
+ * by unit tests (100% branch coverage required).
+ */
+
+import type { ChecklistSchema, ChecklistState, Completeness, SlotState } from "./checklist-schema";
+
+export function evaluateCompleteness<TKey extends string>(
+  schema: ChecklistSchema<TKey>,
+  state: ChecklistState<TKey>,
+): Completeness {
+  if (schema.schemaId !== state.schemaId) {
+    // Caller passed a mismatched pair. Treat as incomplete and surface all
+    // required slot keys — defensive, even though this shouldn't happen.
+    return {
+      kind: "incomplete",
+      missing: schema.slots.filter((s) => s.required).map((s) => s.key),
+    };
+  }
+
+  const missing: string[] = [];
+  const pendingWaivers: string[] = [];
+
+  for (const slot of schema.slots) {
+    if (!slot.required) continue;
+    const slotState: SlotState = state.slots[slot.key] ?? { kind: "missing" };
+    switch (slotState.kind) {
+      case "present":
+      case "waived-permanent":
+        break;
+      case "waived-conditional":
+        pendingWaivers.push(slot.key);
+        break;
+      case "missing":
+        missing.push(slot.key);
+        break;
+    }
+  }
+
+  if (missing.length > 0) {
+    return { kind: "incomplete", missing };
+  }
+  if (pendingWaivers.length > 0) {
+    return { kind: "conditionally-complete", pendingWaivers };
+  }
+  return { kind: "complete" };
+}

--- a/src/lib/compliance/checklist/index.ts
+++ b/src/lib/compliance/checklist/index.ts
@@ -1,0 +1,20 @@
+/** Barrel for the checklist primitive (Story 28.2). */
+
+export type {
+  ChecklistSchema,
+  ChecklistSlot,
+  ChecklistState,
+  Completeness,
+  SlotState,
+} from "./checklist-schema";
+export { evaluateCompleteness } from "./completeness-engine";
+export type { IChecklistStore } from "./checklist-store.interface";
+export { createMockChecklistStore } from "./mock-checklist-store";
+export type { MockChecklistStoreOptions } from "./mock-checklist-store";
+export {
+  ChecklistIncompleteError,
+  ChecklistSchemaNotFoundError,
+  ChecklistValidationError,
+} from "./checklist-errors";
+export { ChecklistProvider, useChecklist } from "./use-checklist";
+export type { ChecklistProviderProps, UseChecklistResult } from "./use-checklist";

--- a/src/lib/compliance/checklist/mock-checklist-store.ts
+++ b/src/lib/compliance/checklist/mock-checklist-store.ts
@@ -1,0 +1,210 @@
+/**
+ * In-memory mock `IChecklistStore` (Story 28.2).
+ *
+ * Schemas registered by code; state kept per-subject in a Map. Every write
+ * method enforces RBAC (AC-3) and writes an AUDIT# record with the prior
+ * and new slot state (AU-2/AU-3).
+ */
+
+import { AccessDeniedError, type ComplianceActor } from "../types";
+import { canPerformAction, type Role } from "../../rbac";
+import { logAudit } from "../../audit/log-audit";
+import type { ChecklistSchema, ChecklistState, SlotState } from "./checklist-schema";
+import type { IChecklistStore } from "./checklist-store.interface";
+import { ChecklistSchemaNotFoundError, ChecklistValidationError } from "./checklist-errors";
+
+export interface MockChecklistStoreOptions {
+  readonly resolveRole?: (actor: ComplianceActor) => Role;
+  readonly now?: () => Date;
+  readonly seedSchemas?: readonly ChecklistSchema[];
+}
+
+const MIN_REASON = 10;
+const MAX_REASON = 500;
+
+function validateReason(reason: string): void {
+  if (reason.length < MIN_REASON || reason.length > MAX_REASON) {
+    throw new ChecklistValidationError(
+      `reason must be ${MIN_REASON}-${MAX_REASON} chars (got ${reason.length}).`,
+    );
+  }
+}
+
+function validateDueDate(iso: string, now: Date): void {
+  const due = Date.parse(iso);
+  if (Number.isNaN(due)) {
+    throw new ChecklistValidationError("dueAt must be an ISO-8601 timestamp.");
+  }
+  const nowMs = now.getTime();
+  const oneYear = 365 * 24 * 60 * 60 * 1000;
+  if (due <= nowMs) {
+    throw new ChecklistValidationError("dueAt must be in the future.");
+  }
+  if (due > nowMs + oneYear) {
+    throw new ChecklistValidationError("dueAt cannot be more than 365 days in the future.");
+  }
+}
+
+export function createMockChecklistStore(options: MockChecklistStoreOptions = {}): IChecklistStore {
+  const schemas = new Map<string, ChecklistSchema>();
+  const states = new Map<string, ChecklistState>();
+  const resolveRole = options.resolveRole ?? (() => "Admin" as Role);
+  const now = options.now ?? (() => new Date());
+
+  for (const s of options.seedSchemas ?? []) {
+    schemas.set(s.schemaId, s);
+  }
+
+  function stateKey(schemaId: string, subjectId: string): string {
+    return `${schemaId}|${subjectId}`;
+  }
+
+  function loadOrInitState(schemaId: string, subjectId: string): ChecklistState {
+    const key = stateKey(schemaId, subjectId);
+    const existing = states.get(key);
+    if (existing) return existing;
+    const schema = schemas.get(schemaId);
+    if (!schema) throw new ChecklistSchemaNotFoundError(schemaId);
+    const slots = Object.fromEntries(
+      schema.slots.map((s) => [s.key, { kind: "missing" } as SlotState]),
+    );
+    const fresh: ChecklistState = { schemaId, subjectId, slots };
+    states.set(key, fresh);
+    return fresh;
+  }
+
+  function updateSlot(
+    schemaId: string,
+    subjectId: string,
+    slotKey: string,
+    next: SlotState,
+  ): ChecklistState {
+    const prev = loadOrInitState(schemaId, subjectId);
+    const nextSlots = { ...prev.slots, [slotKey]: next };
+    const nextState: ChecklistState = { ...prev, slots: nextSlots };
+    states.set(stateKey(schemaId, subjectId), nextState);
+    return nextState;
+  }
+
+  function authorize(
+    actor: ComplianceActor,
+    action: "checklist:attach" | "checklist:waive",
+    subjectId: string,
+  ): void {
+    const role = resolveRole(actor);
+    if (!canPerformAction(role, action)) {
+      logAudit({
+        action: `compliance.${action}`,
+        resourceType: "Checklist",
+        resourceId: subjectId,
+        actor,
+        outcome: "denied",
+        reason: `role ${role} lacks ${action}`,
+      });
+      throw new AccessDeniedError(action, actor.userId);
+    }
+  }
+
+  function audit(
+    action: string,
+    subjectId: string,
+    slotKey: string,
+    prior: SlotState,
+    next: SlotState,
+    actor: ComplianceActor,
+    reason?: string,
+  ): void {
+    logAudit({
+      action,
+      resourceType: "Checklist",
+      resourceId: subjectId,
+      actor,
+      outcome: "success",
+      context: { slotKey, priorKind: prior.kind, nextKind: next.kind },
+      reason,
+    });
+  }
+
+  return {
+    registerSchema(schema) {
+      schemas.set(schema.schemaId, schema);
+    },
+
+    async loadSchema(schemaId) {
+      const s = schemas.get(schemaId);
+      if (!s) throw new ChecklistSchemaNotFoundError(schemaId);
+      return s;
+    },
+
+    async loadState(schemaId, subjectId) {
+      return loadOrInitState(schemaId, subjectId);
+    },
+
+    async attachSlot(schemaId, subjectId, slotKey, evidenceId, actor) {
+      authorize(actor, "checklist:attach", subjectId);
+      const prior =
+        loadOrInitState(schemaId, subjectId).slots[slotKey] ?? ({ kind: "missing" } as SlotState);
+      const next: SlotState = {
+        kind: "present",
+        evidenceId,
+        filledAt: now().toISOString(),
+        filledBy: actor,
+      };
+      updateSlot(schemaId, subjectId, slotKey, next);
+      audit("compliance.checklist.attach", subjectId, slotKey, prior, next, actor);
+      return next;
+    },
+
+    async waivePermanent(schemaId, subjectId, slotKey, reason, actor) {
+      authorize(actor, "checklist:waive", subjectId);
+      validateReason(reason);
+      const prior =
+        loadOrInitState(schemaId, subjectId).slots[slotKey] ?? ({ kind: "missing" } as SlotState);
+      const next: SlotState = {
+        kind: "waived-permanent",
+        reason,
+        waivedAt: now().toISOString(),
+        waivedBy: actor,
+      };
+      updateSlot(schemaId, subjectId, slotKey, next);
+      audit("compliance.checklist.waive.permanent", subjectId, slotKey, prior, next, actor, reason);
+      return next;
+    },
+
+    async waiveConditional(schemaId, subjectId, slotKey, reason, dueAt, actor) {
+      authorize(actor, "checklist:waive", subjectId);
+      validateReason(reason);
+      validateDueDate(dueAt, now());
+      const prior =
+        loadOrInitState(schemaId, subjectId).slots[slotKey] ?? ({ kind: "missing" } as SlotState);
+      const next: SlotState = {
+        kind: "waived-conditional",
+        reason,
+        dueAt,
+        waivedAt: now().toISOString(),
+        waivedBy: actor,
+      };
+      updateSlot(schemaId, subjectId, slotKey, next);
+      audit(
+        "compliance.checklist.waive.conditional",
+        subjectId,
+        slotKey,
+        prior,
+        next,
+        actor,
+        reason,
+      );
+      return next;
+    },
+
+    async unwaive(schemaId, subjectId, slotKey, actor) {
+      authorize(actor, "checklist:waive", subjectId);
+      const prior =
+        loadOrInitState(schemaId, subjectId).slots[slotKey] ?? ({ kind: "missing" } as SlotState);
+      const next: SlotState = { kind: "missing" };
+      updateSlot(schemaId, subjectId, slotKey, next);
+      audit("compliance.checklist.unwaive", subjectId, slotKey, prior, next, actor);
+      return next;
+    },
+  };
+}

--- a/src/lib/compliance/checklist/use-checklist.tsx
+++ b/src/lib/compliance/checklist/use-checklist.tsx
@@ -1,0 +1,113 @@
+/**
+ * React hooks + provider for the checklist primitive (Story 28.2).
+ */
+
+import { createContext, useContext, useMemo } from "react";
+import type { ReactNode } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { queryKeys } from "../../query-keys";
+import type { ComplianceActor } from "../types";
+import type { IChecklistStore } from "./checklist-store.interface";
+import type { ChecklistSchema, ChecklistState, Completeness } from "./checklist-schema";
+import { evaluateCompleteness } from "./completeness-engine";
+
+interface ChecklistCtxValue {
+  readonly store: IChecklistStore;
+  readonly actor: ComplianceActor;
+}
+
+const ChecklistContext = createContext<ChecklistCtxValue | null>(null);
+
+export interface ChecklistProviderProps {
+  readonly store: IChecklistStore;
+  readonly actor: ComplianceActor;
+  readonly children: ReactNode;
+}
+
+export function ChecklistProvider({ store, actor, children }: ChecklistProviderProps) {
+  const value = useMemo(() => ({ store, actor }), [store, actor]);
+  return <ChecklistContext.Provider value={value}>{children}</ChecklistContext.Provider>;
+}
+
+function useCtx(): ChecklistCtxValue {
+  const ctx = useContext(ChecklistContext);
+  if (!ctx) throw new Error("useChecklist requires <ChecklistProvider>.");
+  return ctx;
+}
+
+export interface UseChecklistResult {
+  readonly schema: ChecklistSchema | undefined;
+  readonly state: ChecklistState | undefined;
+  readonly completeness: Completeness | undefined;
+  readonly isLoading: boolean;
+  readonly error: Error | undefined;
+  readonly attachSlot: (slotKey: string, evidenceId: string) => Promise<void>;
+  readonly waivePermanent: (slotKey: string, reason: string) => Promise<void>;
+  readonly waiveConditional: (slotKey: string, reason: string, dueAt: string) => Promise<void>;
+  readonly unwaive: (slotKey: string) => Promise<void>;
+}
+
+export function useChecklist(schemaId: string, subjectId: string): UseChecklistResult {
+  const { store, actor } = useCtx();
+  const qc = useQueryClient();
+
+  const schemaQ = useQuery({
+    queryKey: queryKeys.compliance.checklist.schema(schemaId),
+    queryFn: () => store.loadSchema(schemaId),
+    staleTime: Number.POSITIVE_INFINITY,
+  });
+
+  const stateQ = useQuery({
+    queryKey: queryKeys.compliance.checklist.state(schemaId, subjectId),
+    queryFn: () => store.loadState(schemaId, subjectId),
+  });
+
+  const invalidate = () =>
+    qc.invalidateQueries({ queryKey: queryKeys.compliance.checklist.state(schemaId, subjectId) });
+
+  const attachM = useMutation({
+    mutationFn: (args: { slotKey: string; evidenceId: string }) =>
+      store.attachSlot(schemaId, subjectId, args.slotKey, args.evidenceId, actor),
+    onSuccess: invalidate,
+  });
+  const waivePM = useMutation({
+    mutationFn: (args: { slotKey: string; reason: string }) =>
+      store.waivePermanent(schemaId, subjectId, args.slotKey, args.reason, actor),
+    onSuccess: invalidate,
+  });
+  const waiveCM = useMutation({
+    mutationFn: (args: { slotKey: string; reason: string; dueAt: string }) =>
+      store.waiveConditional(schemaId, subjectId, args.slotKey, args.reason, args.dueAt, actor),
+    onSuccess: invalidate,
+  });
+  const unwaiveM = useMutation({
+    mutationFn: (slotKey: string) => store.unwaive(schemaId, subjectId, slotKey, actor),
+    onSuccess: invalidate,
+  });
+
+  const completeness = useMemo<Completeness | undefined>(() => {
+    if (!schemaQ.data || !stateQ.data) return undefined;
+    return evaluateCompleteness(schemaQ.data, stateQ.data);
+  }, [schemaQ.data, stateQ.data]);
+
+  return {
+    schema: schemaQ.data,
+    state: stateQ.data,
+    completeness,
+    isLoading: schemaQ.isLoading || stateQ.isLoading,
+    error: (schemaQ.error ?? stateQ.error) as Error | undefined,
+    attachSlot: async (slotKey, evidenceId) => {
+      await attachM.mutateAsync({ slotKey, evidenceId });
+    },
+    waivePermanent: async (slotKey, reason) => {
+      await waivePM.mutateAsync({ slotKey, reason });
+    },
+    waiveConditional: async (slotKey, reason, dueAt) => {
+      await waiveCM.mutateAsync({ slotKey, reason, dueAt });
+    },
+    unwaive: async (slotKey) => {
+      await unwaiveM.mutateAsync(slotKey);
+    },
+  };
+}

--- a/src/lib/compliance/evidence/evidence-errors.ts
+++ b/src/lib/compliance/evidence/evidence-errors.ts
@@ -1,0 +1,44 @@
+/**
+ * Typed errors for the evidence store primitive (Story 28.1).
+ *
+ * Every adapter failure path throws a specific subclass so the global
+ * error boundary and toast pipeline can classify messages and the audit
+ * log can record `outcome: "denied"` / `"error"` with a machine-readable
+ * reason. NIST AU-3 (Content of Audit Records) requires this specificity.
+ */
+
+import { ComplianceError } from "../types";
+
+/**
+ * Thrown when any caller attempts to mutate, delete, or overwrite stored
+ * evidence. The interface does not expose these operations; this error is
+ * reserved for adapter-internal invariant violations and for test harnesses
+ * that probe the immutability contract.
+ */
+export class EvidenceImmutabilityError extends ComplianceError {
+  public readonly kind = "compliance.evidence.immutability";
+
+  public constructor(evidenceId: string, attemptedOp: string) {
+    super(
+      `Evidence ${evidenceId} is immutable — operation "${attemptedOp}" is not permitted (NIST MP-6).`,
+    );
+  }
+}
+
+/** Thrown when `get` / `getSignedReadUrl` is called for a non-existent record. */
+export class EvidenceNotFoundError extends ComplianceError {
+  public readonly kind = "compliance.evidence.not-found";
+
+  public constructor(evidenceId: string) {
+    super(`Evidence ${evidenceId} not found.`);
+  }
+}
+
+/** Thrown when adapter configuration is invalid (missing bucket, KMS key, etc.). */
+export class EvidenceAdapterConfigError extends ComplianceError {
+  public readonly kind = "compliance.evidence.adapter-config";
+
+  public constructor(message: string) {
+    super(`Evidence adapter misconfigured: ${message}`);
+  }
+}

--- a/src/lib/compliance/evidence/evidence-hash.ts
+++ b/src/lib/compliance/evidence/evidence-hash.ts
@@ -1,0 +1,23 @@
+/**
+ * SHA-256 hex digest for evidence content addressing.
+ *
+ * Uses the Web Crypto API which is available in both browsers and modern
+ * Node (via `globalThis.crypto.subtle`). Falls back to a deterministic
+ * stub only when Web Crypto is unavailable — callers should never hit
+ * that branch in production.
+ */
+
+export async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  const subtle = globalThis.crypto?.subtle;
+  if (!subtle) {
+    throw new Error("Web Crypto (crypto.subtle) is unavailable — cannot compute evidence hash.");
+  }
+  const buf = await subtle.digest("SHA-256", bytes);
+  const view = new Uint8Array(buf);
+  let out = "";
+  for (let i = 0; i < view.length; i++) {
+    const b = view[i] ?? 0;
+    out += b.toString(16).padStart(2, "0");
+  }
+  return out;
+}

--- a/src/lib/compliance/evidence/evidence-store.interface.ts
+++ b/src/lib/compliance/evidence/evidence-store.interface.ts
@@ -1,0 +1,88 @@
+/**
+ * Immutable Evidence Store — provider interface (Story 28.1).
+ *
+ * The interface is the library's guarantee that stored evidence cannot be
+ * mutated, deleted, or overwritten. It deliberately exposes NO `delete`,
+ * `update`, or `patch` methods — immutability is enforced at the type level.
+ *
+ * Adapters back the interface with concrete storage (in-memory mock, AWS S3
+ * with Object Lock COMPLIANCE mode, Azure Immutable Blob, GCS Bucket Lock).
+ * Every adapter MUST:
+ * 1. Compute SHA-256 of payload bytes client-side and expose as `contentHash`
+ * 2. Honor the requested retention mode at the storage-provider level
+ * 3. Invoke `logAudit` on every `put` and every `getSignedReadUrl`
+ * 4. Throw `AccessDeniedError` when RBAC (`canPerformAction`) fails
+ *
+ * NIST controls: AU-2 / AU-3 (audit), AC-3 (access), SC-12 (key mgmt),
+ * SI-10 (adapter input validation), MP-6 (media sanitization forbidden).
+ */
+
+import type { ComplianceActor } from "../types";
+
+export type EvidenceRetentionMode = "compliance" | "governance";
+
+/**
+ * Metadata for a stored evidence record. All fields `readonly` — records are
+ * immutable once written. `immutable: true` is a type-level sentinel.
+ */
+export interface EvidenceMetadata {
+  readonly id: string;
+  readonly contentHash: string;
+  readonly mimeType: string;
+  readonly sizeBytes: number;
+  readonly uploadedAt: string;
+  readonly uploadedBy: { readonly userId: string; readonly displayName: string };
+  readonly retention: {
+    readonly mode: EvidenceRetentionMode;
+    readonly retainUntil: string;
+  };
+  readonly tags: Readonly<Record<string, string>>;
+  readonly immutable: true;
+}
+
+export interface EvidencePutInput {
+  readonly bytes: Uint8Array;
+  readonly mimeType: string;
+  readonly retentionMode: EvidenceRetentionMode;
+  readonly retainUntil: string;
+  readonly tags?: Readonly<Record<string, string>>;
+  readonly actor: ComplianceActor;
+}
+
+export interface EvidenceListFilter {
+  readonly tags?: Readonly<Record<string, string>>;
+  readonly uploadedBy?: string;
+  readonly uploadedAfter?: string;
+  readonly uploadedBefore?: string;
+  readonly limit?: number;
+}
+
+/**
+ * Provider interface for immutable evidence storage.
+ *
+ * @example
+ * const store = createMockEvidenceStore();
+ * const meta = await store.put({
+ *   bytes: pdfBytes,
+ *   mimeType: "application/pdf",
+ *   retentionMode: "compliance",
+ *   retainUntil: "2030-01-01T00:00:00Z",
+ *   tags: { subject: "firmware-1.2.3" },
+ *   actor: { userId: "alice", displayName: "Alice" },
+ * });
+ * const url = await store.getSignedReadUrl(meta.id, 300, { actor: ... });
+ */
+export interface IEvidenceStore {
+  put(input: EvidencePutInput): Promise<EvidenceMetadata>;
+  get(id: string, options: { actor: ComplianceActor }): Promise<EvidenceMetadata>;
+  getSignedReadUrl(
+    id: string,
+    expiresInSeconds: number,
+    options: { actor: ComplianceActor },
+  ): Promise<string>;
+  list(
+    filter: EvidenceListFilter,
+    options: { actor: ComplianceActor },
+  ): Promise<EvidenceMetadata[]>;
+  // Intentionally NO delete / update / patch — immutability is the contract.
+}

--- a/src/lib/compliance/evidence/index.ts
+++ b/src/lib/compliance/evidence/index.ts
@@ -1,0 +1,32 @@
+/**
+ * Barrel for the evidence-store primitive (Story 28.1).
+ *
+ * Callers should import from `@/lib/compliance` (library barrel) rather
+ * than reaching into submodules. This file is the one place inside the
+ * submodule where every public symbol is re-exported.
+ */
+
+export type {
+  EvidenceListFilter,
+  EvidenceMetadata,
+  EvidencePutInput,
+  EvidenceRetentionMode,
+  IEvidenceStore,
+} from "./evidence-store.interface";
+export {
+  EvidenceAdapterConfigError,
+  EvidenceImmutabilityError,
+  EvidenceNotFoundError,
+} from "./evidence-errors";
+export { createMockEvidenceStore } from "./mock-evidence-store";
+export type { MockEvidenceStoreOptions } from "./mock-evidence-store";
+export { createS3EvidenceStore } from "./s3-evidence-store";
+export type { IS3Driver, IS3HeadResult, S3EvidenceStoreConfig } from "./s3-evidence-store";
+export {
+  EvidenceStoreProvider,
+  useEvidence,
+  useEvidenceSignedUrl,
+  useUploadEvidence,
+} from "./use-evidence";
+export type { EvidenceStoreProviderProps, UseEvidenceSignedUrlResult } from "./use-evidence";
+export { sha256Hex } from "./evidence-hash";

--- a/src/lib/compliance/evidence/mock-evidence-store.ts
+++ b/src/lib/compliance/evidence/mock-evidence-store.ts
@@ -1,0 +1,179 @@
+/**
+ * In-memory mock `IEvidenceStore` (Story 28.1).
+ *
+ * Intended for tests, Storybook, and the `VITE_EVIDENCE_STORE_PROVIDER=mock`
+ * path in local dev. Persistence is per-instance and lost on reload.
+ *
+ * Immutability invariant: the internal Map holds frozen `EvidenceMetadata`
+ * and the byte blob separately. Every exported method returns a fresh
+ * shallow clone so callers cannot mutate the store through the returned
+ * reference.
+ */
+
+import { AccessDeniedError, type ComplianceActor } from "../types";
+import { canPerformAction, type Role } from "../../rbac";
+import { logAudit } from "../../audit/log-audit";
+import type {
+  EvidenceMetadata,
+  EvidencePutInput,
+  IEvidenceStore,
+} from "./evidence-store.interface";
+import { EvidenceImmutabilityError, EvidenceNotFoundError } from "./evidence-errors";
+import { sha256Hex } from "./evidence-hash";
+
+export interface MockEvidenceStoreOptions {
+  /**
+   * Resolve the caller's role for RBAC. Defaults to a permissive role for
+   * unit tests; apps MUST pass the authenticated role resolver.
+   */
+  readonly resolveRole?: (actor: ComplianceActor) => Role;
+  /** Injectable clock for deterministic tests. */
+  readonly now?: () => Date;
+}
+
+interface StoredRecord {
+  readonly meta: EvidenceMetadata;
+  readonly bytes: Uint8Array;
+}
+
+export function createMockEvidenceStore(options: MockEvidenceStoreOptions = {}): IEvidenceStore {
+  const records = new Map<string, StoredRecord>();
+  const resolveRole = options.resolveRole ?? (() => "Admin" as Role);
+  const now = options.now ?? (() => new Date());
+
+  function ensureImmutable(id: string): void {
+    const existing = records.get(id);
+    if (existing && Object.isFrozen(existing.meta) === false) {
+      // Paranoid internal check — metadata should always be frozen on insert.
+      throw new EvidenceImmutabilityError(id, "internal-invariant");
+    }
+  }
+
+  function authorize(actor: ComplianceActor, action: "evidence:put" | "evidence:read"): void {
+    const role = resolveRole(actor);
+    if (!canPerformAction(role, action)) {
+      logAudit({
+        action: `compliance.${action}`,
+        resourceType: "Evidence",
+        resourceId: "-",
+        actor,
+        outcome: "denied",
+        reason: `role ${role} lacks ${action}`,
+      });
+      throw new AccessDeniedError(action, actor.userId);
+    }
+  }
+
+  return {
+    async put(input: EvidencePutInput): Promise<EvidenceMetadata> {
+      authorize(input.actor, "evidence:put");
+
+      const contentHash = await sha256Hex(input.bytes);
+      const id = `ev-${contentHash.slice(0, 16)}`;
+
+      if (records.has(id)) {
+        // Content-addressed — identical payload is a no-op put. Return existing
+        // metadata; emit an audit record so the event is still traceable.
+        const existing = records.get(id)!;
+        logAudit({
+          action: "compliance.evidence.put",
+          resourceType: "Evidence",
+          resourceId: id,
+          actor: input.actor,
+          outcome: "success",
+          context: { contentHash, dedup: true },
+        });
+        return existing.meta;
+      }
+
+      const meta: EvidenceMetadata = Object.freeze({
+        id,
+        contentHash,
+        mimeType: input.mimeType,
+        sizeBytes: input.bytes.byteLength,
+        uploadedAt: now().toISOString(),
+        uploadedBy: { userId: input.actor.userId, displayName: input.actor.displayName },
+        retention: { mode: input.retentionMode, retainUntil: input.retainUntil },
+        tags: Object.freeze({ ...(input.tags ?? {}) }),
+        immutable: true,
+      });
+
+      records.set(id, { meta, bytes: input.bytes.slice() });
+
+      logAudit({
+        action: "compliance.evidence.put",
+        resourceType: "Evidence",
+        resourceId: id,
+        actor: input.actor,
+        outcome: "success",
+        context: { contentHash, retentionMode: input.retentionMode },
+      });
+
+      return meta;
+    },
+
+    async get(id, { actor }): Promise<EvidenceMetadata> {
+      authorize(actor, "evidence:read");
+      ensureImmutable(id);
+      const rec = records.get(id);
+      if (!rec) throw new EvidenceNotFoundError(id);
+      return rec.meta;
+    },
+
+    async getSignedReadUrl(id, expiresInSeconds, { actor }): Promise<string> {
+      authorize(actor, "evidence:read");
+      const rec = records.get(id);
+      if (!rec) throw new EvidenceNotFoundError(id);
+
+      const expiresAt = new Date(now().getTime() + expiresInSeconds * 1000).toISOString();
+      // Mock URL — real adapters return a provider-signed URL. The data: URL
+      // encoding lets Storybook and tests exercise the download path.
+      const url = `data:${rec.meta.mimeType};x-evidence-id=${encodeURIComponent(id)};expires=${encodeURIComponent(
+        expiresAt,
+      )};base64,${toBase64(rec.bytes)}`;
+
+      logAudit({
+        action: "compliance.evidence.signedUrl",
+        resourceType: "Evidence",
+        resourceId: id,
+        actor,
+        outcome: "success",
+        context: { expiresAt, expiresInSeconds },
+      });
+
+      return url;
+    },
+
+    async list(filter, { actor }): Promise<EvidenceMetadata[]> {
+      authorize(actor, "evidence:read");
+
+      let items = [...records.values()].map((r) => r.meta);
+      if (filter.uploadedBy) {
+        items = items.filter((m) => m.uploadedBy.userId === filter.uploadedBy);
+      }
+      if (filter.uploadedAfter) {
+        items = items.filter((m) => m.uploadedAt >= filter.uploadedAfter!);
+      }
+      if (filter.uploadedBefore) {
+        items = items.filter((m) => m.uploadedAt <= filter.uploadedBefore!);
+      }
+      if (filter.tags) {
+        items = items.filter((m) =>
+          Object.entries(filter.tags!).every(([k, v]) => m.tags[k] === v),
+        );
+      }
+      items.sort((a, b) => b.uploadedAt.localeCompare(a.uploadedAt));
+      if (typeof filter.limit === "number") items = items.slice(0, filter.limit);
+      return items;
+    },
+  };
+}
+
+function toBase64(bytes: Uint8Array): string {
+  if (typeof Buffer !== "undefined") {
+    return Buffer.from(bytes).toString("base64");
+  }
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i] ?? 0);
+  return typeof btoa !== "undefined" ? btoa(binary) : "";
+}

--- a/src/lib/compliance/evidence/s3-evidence-store.ts
+++ b/src/lib/compliance/evidence/s3-evidence-store.ts
@@ -1,0 +1,224 @@
+/**
+ * AWS S3 reference adapter for `IEvidenceStore` (Story 28.1).
+ *
+ * REQUIRED bucket configuration (enforced at deploy time — NOT by this file):
+ *
+ * 1. Object Lock ENABLED on the bucket at creation time.
+ * 2. Default retention configured with `Mode: COMPLIANCE` (not GOVERNANCE)
+ *    so even the bucket-owner root account cannot delete or overwrite.
+ * 3. Versioning ENABLED (required for Object Lock).
+ * 4. Bucket policy denies `s3:DeleteObject`, `s3:DeleteObjectVersion`,
+ *    `s3:PutBucketObjectLockConfiguration` for ALL principals.
+ * 5. Server-side encryption: `aws:kms` with a CMK whose key policy allows
+ *    only the evidence-service IAM role. NIST SC-12.
+ * 6. Access logs forwarded to a dedicated audit bucket (NIST AU-2 / AU-6).
+ *
+ * NOTE: To keep this repo's runtime dependency surface minimal, the concrete
+ * AWS SDK wiring is intentionally deferred — this file defines the adapter
+ * contract and throws when instantiated without a platform-provided SDK
+ * injector. Real deployments inject the SDK via `s3Client` / `signer`.
+ */
+
+import { AccessDeniedError, type ComplianceActor } from "../types";
+import { canPerformAction, type Role } from "../../rbac";
+import { logAudit } from "../../audit/log-audit";
+import type {
+  EvidenceListFilter,
+  EvidenceMetadata,
+  EvidencePutInput,
+  IEvidenceStore,
+} from "./evidence-store.interface";
+import { EvidenceAdapterConfigError, EvidenceNotFoundError } from "./evidence-errors";
+import { sha256Hex } from "./evidence-hash";
+
+export interface S3EvidenceStoreConfig {
+  readonly bucket: string;
+  readonly region: string;
+  readonly kmsKeyId: string;
+  /**
+   * Injected SDK surface. Real deployments pass an AWS SDK v3 `S3Client`
+   * adapter + presigner; tests pass a mock.
+   */
+  readonly driver: IS3Driver;
+  readonly resolveRole: (actor: ComplianceActor) => Role;
+  readonly now?: () => Date;
+}
+
+export interface IS3Driver {
+  putObject(input: {
+    readonly key: string;
+    readonly body: Uint8Array;
+    readonly contentType: string;
+    readonly kmsKeyId: string;
+    readonly objectLock: { readonly mode: "COMPLIANCE"; readonly retainUntil: string };
+    readonly metadata: Readonly<Record<string, string>>;
+  }): Promise<void>;
+  headObject(key: string): Promise<IS3HeadResult | null>;
+  presignGet(key: string, expiresInSeconds: number): Promise<string>;
+  listObjects(prefix: string): Promise<readonly IS3HeadResult[]>;
+}
+
+export interface IS3HeadResult {
+  readonly key: string;
+  readonly metadata: Readonly<Record<string, string>>;
+  readonly sizeBytes: number;
+  readonly contentType: string;
+  readonly lastModified: string;
+}
+
+export function createS3EvidenceStore(config: S3EvidenceStoreConfig): IEvidenceStore {
+  if (!config.bucket) throw new EvidenceAdapterConfigError("bucket is required");
+  if (!config.kmsKeyId) throw new EvidenceAdapterConfigError("kmsKeyId is required (NIST SC-12)");
+  if (!config.driver) throw new EvidenceAdapterConfigError("driver (S3 SDK) must be injected");
+
+  const now = config.now ?? (() => new Date());
+
+  function authorize(actor: ComplianceActor, action: "evidence:put" | "evidence:read"): void {
+    const role = config.resolveRole(actor);
+    if (!canPerformAction(role, action)) {
+      logAudit({
+        action: `compliance.${action}`,
+        resourceType: "Evidence",
+        resourceId: "-",
+        actor,
+        outcome: "denied",
+        reason: `role ${role} lacks ${action}`,
+      });
+      throw new AccessDeniedError(action, actor.userId);
+    }
+  }
+
+  function keyFor(id: string): string {
+    return `evidence/${id}`;
+  }
+
+  function metaFromHead(head: IS3HeadResult): EvidenceMetadata {
+    const m = head.metadata;
+    const meta: EvidenceMetadata = Object.freeze({
+      id: m["x-evidence-id"] ?? "",
+      contentHash: m["x-content-hash"] ?? "",
+      mimeType: head.contentType,
+      sizeBytes: head.sizeBytes,
+      uploadedAt: m["x-uploaded-at"] ?? head.lastModified,
+      uploadedBy: {
+        userId: m["x-uploaded-by-id"] ?? "",
+        displayName: m["x-uploaded-by-name"] ?? "",
+      },
+      retention: {
+        mode: "compliance" as const,
+        retainUntil: m["x-retain-until"] ?? "",
+      },
+      tags: Object.freeze({ ...parseTagMetadata(head.metadata) }),
+      immutable: true,
+    });
+    return meta;
+  }
+
+  return {
+    async put(input: EvidencePutInput): Promise<EvidenceMetadata> {
+      authorize(input.actor, "evidence:put");
+
+      if (input.retentionMode !== "compliance") {
+        throw new EvidenceAdapterConfigError(
+          "S3 adapter supports COMPLIANCE retention only (NIST MP-6). Use governance with a different bucket.",
+        );
+      }
+      const contentHash = await sha256Hex(input.bytes);
+      const id = `ev-${contentHash.slice(0, 16)}`;
+      const uploadedAt = now().toISOString();
+
+      const metadata: Record<string, string> = {
+        "x-evidence-id": id,
+        "x-content-hash": contentHash,
+        "x-uploaded-at": uploadedAt,
+        "x-uploaded-by-id": input.actor.userId,
+        "x-uploaded-by-name": input.actor.displayName,
+        "x-retain-until": input.retainUntil,
+      };
+      for (const [k, v] of Object.entries(input.tags ?? {})) metadata[`tag-${k}`] = v;
+
+      await config.driver.putObject({
+        key: keyFor(id),
+        body: input.bytes,
+        contentType: input.mimeType,
+        kmsKeyId: config.kmsKeyId,
+        objectLock: { mode: "COMPLIANCE", retainUntil: input.retainUntil },
+        metadata,
+      });
+
+      const meta: EvidenceMetadata = Object.freeze({
+        id,
+        contentHash,
+        mimeType: input.mimeType,
+        sizeBytes: input.bytes.byteLength,
+        uploadedAt,
+        uploadedBy: { userId: input.actor.userId, displayName: input.actor.displayName },
+        retention: { mode: "compliance" as const, retainUntil: input.retainUntil },
+        tags: Object.freeze({ ...(input.tags ?? {}) }),
+        immutable: true,
+      });
+
+      logAudit({
+        action: "compliance.evidence.put",
+        resourceType: "Evidence",
+        resourceId: id,
+        actor: input.actor,
+        outcome: "success",
+        context: { contentHash, bucket: config.bucket },
+      });
+
+      return meta;
+    },
+
+    async get(id, { actor }): Promise<EvidenceMetadata> {
+      authorize(actor, "evidence:read");
+      const head = await config.driver.headObject(keyFor(id));
+      if (!head) throw new EvidenceNotFoundError(id);
+      return metaFromHead(head);
+    },
+
+    async getSignedReadUrl(id, expiresInSeconds, { actor }): Promise<string> {
+      authorize(actor, "evidence:read");
+      const head = await config.driver.headObject(keyFor(id));
+      if (!head) throw new EvidenceNotFoundError(id);
+      const url = await config.driver.presignGet(keyFor(id), expiresInSeconds);
+
+      logAudit({
+        action: "compliance.evidence.signedUrl",
+        resourceType: "Evidence",
+        resourceId: id,
+        actor,
+        outcome: "success",
+        context: { expiresInSeconds, bucket: config.bucket },
+      });
+
+      return url;
+    },
+
+    async list(filter: EvidenceListFilter, { actor }): Promise<EvidenceMetadata[]> {
+      authorize(actor, "evidence:read");
+      const heads = await config.driver.listObjects("evidence/");
+      let items = heads.map(metaFromHead);
+      if (filter.uploadedBy) items = items.filter((m) => m.uploadedBy.userId === filter.uploadedBy);
+      if (filter.uploadedAfter) items = items.filter((m) => m.uploadedAt >= filter.uploadedAfter!);
+      if (filter.uploadedBefore)
+        items = items.filter((m) => m.uploadedAt <= filter.uploadedBefore!);
+      if (filter.tags) {
+        items = items.filter((m) =>
+          Object.entries(filter.tags!).every(([k, v]) => m.tags[k] === v),
+        );
+      }
+      items.sort((a, b) => b.uploadedAt.localeCompare(a.uploadedAt));
+      if (typeof filter.limit === "number") items = items.slice(0, filter.limit);
+      return items;
+    },
+  };
+}
+
+function parseTagMetadata(md: Readonly<Record<string, string>>): Record<string, string> {
+  const tags: Record<string, string> = {};
+  for (const [k, v] of Object.entries(md)) {
+    if (k.startsWith("tag-")) tags[k.slice(4)] = v;
+  }
+  return tags;
+}

--- a/src/lib/compliance/evidence/use-evidence.tsx
+++ b/src/lib/compliance/evidence/use-evidence.tsx
@@ -1,0 +1,128 @@
+/**
+ * React hooks for the evidence store primitive (Story 28.1).
+ *
+ * - `useEvidence(id)` — reads metadata. `staleTime: Infinity` because
+ *   immutable records never become stale.
+ * - `useEvidenceSignedUrl(id, expiresInSeconds)` — mints a short-lived
+ *   signed read URL; refreshes before expiry with a 30-second safety margin.
+ * - `useUploadEvidence()` — mutation for `put()` with TanStack Query.
+ * - `EvidenceStoreProvider` — React context that supplies the active
+ *   `IEvidenceStore` + current `ComplianceActor` to the hooks.
+ */
+
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
+import type { ReactNode } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { queryKeys } from "../../query-keys";
+import type { ComplianceActor } from "../types";
+import type {
+  EvidenceMetadata,
+  EvidencePutInput,
+  IEvidenceStore,
+} from "./evidence-store.interface";
+
+interface EvidenceContextValue {
+  readonly store: IEvidenceStore;
+  readonly actor: ComplianceActor;
+}
+
+const EvidenceContext = createContext<EvidenceContextValue | null>(null);
+
+export interface EvidenceStoreProviderProps {
+  readonly store: IEvidenceStore;
+  readonly actor: ComplianceActor;
+  readonly children: ReactNode;
+}
+
+export function EvidenceStoreProvider({
+  store,
+  actor,
+  children,
+}: EvidenceStoreProviderProps): JSX.Element {
+  const value = useMemo<EvidenceContextValue>(() => ({ store, actor }), [store, actor]);
+  return <EvidenceContext.Provider value={value}>{children}</EvidenceContext.Provider>;
+}
+
+function useEvidenceCtx(): EvidenceContextValue {
+  const ctx = useContext(EvidenceContext);
+  if (!ctx) {
+    throw new Error("useEvidence* hooks require <EvidenceStoreProvider> higher in the tree.");
+  }
+  return ctx;
+}
+
+export function useEvidence(id: string | undefined) {
+  const { store, actor } = useEvidenceCtx();
+  return useQuery({
+    queryKey: id
+      ? queryKeys.compliance.evidence.detail(id)
+      : ["compliance", "evidence", "detail", "?"],
+    queryFn: () => store.get(id!, { actor }),
+    enabled: Boolean(id),
+    staleTime: Number.POSITIVE_INFINITY,
+    gcTime: Number.POSITIVE_INFINITY,
+  });
+}
+
+export interface UseEvidenceSignedUrlResult {
+  readonly url: string | undefined;
+  readonly expiresAt: Date | undefined;
+  readonly isLoading: boolean;
+  readonly error: Error | undefined;
+  readonly refresh: () => void;
+}
+
+const SIGNED_URL_REFRESH_SAFETY_MS = 30_000;
+
+export function useEvidenceSignedUrl(
+  id: string | undefined,
+  expiresInSeconds = 300,
+): UseEvidenceSignedUrlResult {
+  const { store, actor } = useEvidenceCtx();
+  const [tick, setTick] = useState(0);
+
+  const query = useQuery({
+    queryKey: id
+      ? [...queryKeys.compliance.evidence.signedUrl(id, expiresInSeconds), tick]
+      : ["compliance", "evidence", "signedUrl", "?", 0],
+    queryFn: async () => {
+      const url = await store.getSignedReadUrl(id!, expiresInSeconds, { actor });
+      const expiresAt = new Date(Date.now() + expiresInSeconds * 1000);
+      return { url, expiresAt };
+    },
+    enabled: Boolean(id),
+    staleTime: Math.max(0, expiresInSeconds * 1000 - SIGNED_URL_REFRESH_SAFETY_MS),
+  });
+
+  useEffect(() => {
+    if (!query.data?.expiresAt) return;
+    const delay = Math.max(
+      1_000,
+      query.data.expiresAt.getTime() - Date.now() - SIGNED_URL_REFRESH_SAFETY_MS,
+    );
+    const timer = setTimeout(() => setTick((n) => n + 1), delay);
+    return () => clearTimeout(timer);
+  }, [query.data?.expiresAt]);
+
+  return {
+    url: query.data?.url,
+    expiresAt: query.data?.expiresAt,
+    isLoading: query.isLoading,
+    error: (query.error as Error | undefined) ?? undefined,
+    refresh: () => setTick((n) => n + 1),
+  };
+}
+
+export function useUploadEvidence() {
+  const { store, actor } = useEvidenceCtx();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: Omit<EvidencePutInput, "actor">) =>
+      store.put({ ...input, actor }) as Promise<EvidenceMetadata>,
+    onSuccess: (meta) => {
+      qc.setQueryData(queryKeys.compliance.evidence.detail(meta.id), meta);
+      qc.invalidateQueries({ queryKey: queryKeys.compliance.evidence.all });
+    },
+  });
+}

--- a/src/lib/compliance/index.ts
+++ b/src/lib/compliance/index.ts
@@ -1,0 +1,23 @@
+/**
+ * Epic 28 — Enterprise Compliance Workflow Patterns
+ *
+ * Generic, domain-agnostic compliance primitives. This library explicitly
+ * does NOT import from any IMS / firmware / device feature folder — every
+ * type uses generics so consumers can parameterize for their domain.
+ *
+ * Public surface exported from this barrel:
+ * - Evidence store (Story 28.1): immutable, provider-pluggable, audited
+ * - Checklist engine (Story 28.2): N-of-M completeness with waiver kinds
+ * - Approval state machine (Story 28.3): 4-state workflow with SoD + audit
+ *
+ * Upcoming primitives (not yet shipped — see Docs/epics/epic-28/):
+ * - 28.4 SLA tracker for conditional approvals
+ * - 28.5 Scoped one-time secure distribution
+ * - 28.6 Two-phase action confirmation
+ * - 28.7 Inverse dependency / blast-radius query
+ */
+
+export * from "./types";
+export * from "./evidence";
+export * from "./checklist";
+export * from "./approval";

--- a/src/lib/compliance/types.ts
+++ b/src/lib/compliance/types.ts
@@ -1,0 +1,46 @@
+/**
+ * Shared types for the compliance primitives library (Epic 28).
+ *
+ * Types in this file are strictly domain-agnostic. No IMS / firmware / device
+ * references are permitted here. Consumers parameterize generics with their
+ * own identifiers and metadata shapes.
+ */
+
+/**
+ * The principal performing a compliance action. Adapters and primitives never
+ * reach into an auth context directly — the caller provides the actor so the
+ * library remains testable and framework-neutral.
+ */
+export interface ComplianceActor {
+  readonly userId: string;
+  readonly displayName: string;
+}
+
+/**
+ * Base class for all compliance primitive errors. Subclasses are defined in
+ * each primitive's `*-errors.ts` file so they can be caught individually.
+ *
+ * All compliance errors are "classified" — they carry a `kind` string so the
+ * global error boundary and toast pipeline can surface appropriate messages.
+ */
+export abstract class ComplianceError extends Error {
+  public abstract readonly kind: string;
+
+  public constructor(message: string) {
+    super(message);
+    this.name = new.target.name;
+  }
+}
+
+/** Access-denied — RBAC failure. Thrown by every primitive when canPerform fails. */
+export class AccessDeniedError extends ComplianceError {
+  public readonly kind = "compliance.access-denied";
+
+  public constructor(
+    public readonly action: string,
+    public readonly actorId: string,
+    message?: string,
+  ) {
+    super(message ?? `Actor ${actorId} is not permitted to ${action}`);
+  }
+}

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -1,0 +1,40 @@
+/**
+ * Feature flag utility — reads `import.meta.env.VITE_FEATURE_*` and caches results.
+ *
+ * Flags are resolved once at module load. Consumers call `isFeatureEnabled("COMPLIANCE_LIB")`.
+ *
+ * @example
+ * if (isFeatureEnabled("COMPLIANCE_LIB")) {
+ *   return <NewComplianceWiring />;
+ * }
+ * return <LegacyFlow />;
+ */
+
+export type FeatureFlag = "COMPLIANCE_LIB";
+
+const FLAG_PREFIX = "VITE_FEATURE_";
+
+function readFlag(name: FeatureFlag): boolean {
+  const envKey = `${FLAG_PREFIX}${name}` as const;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const env = (import.meta as any).env as Record<string, string | undefined> | undefined;
+  const raw = env?.[envKey];
+  if (raw === undefined) return false;
+  return raw === "true" || raw === "1" || raw === "on";
+}
+
+const cache = new Map<FeatureFlag, boolean>();
+
+export function isFeatureEnabled(flag: FeatureFlag): boolean {
+  let v = cache.get(flag);
+  if (v === undefined) {
+    v = readFlag(flag);
+    cache.set(flag, v);
+  }
+  return v;
+}
+
+/** Reset flag cache — test-only helper. */
+export function _resetFeatureFlagsForTest(): void {
+  cache.clear();
+}

--- a/src/lib/query-keys.ts
+++ b/src/lib/query-keys.ts
@@ -45,6 +45,27 @@ export const queryKeys = {
     all: ["compliance"] as const,
     list: (filters?: Record<string, unknown>) =>
       [...queryKeys.compliance.all, "list", filters] as const,
+    // Epic 28 — compliance primitives
+    evidence: {
+      all: ["compliance", "evidence"] as const,
+      detail: (id: string) => ["compliance", "evidence", "detail", id] as const,
+      signedUrl: (id: string, expiresInSeconds: number) =>
+        ["compliance", "evidence", "signedUrl", id, expiresInSeconds] as const,
+      list: (filters?: Record<string, unknown>) =>
+        ["compliance", "evidence", "list", filters] as const,
+    },
+    checklist: {
+      all: ["compliance", "checklist"] as const,
+      state: (schemaId: string, subjectId: string) =>
+        ["compliance", "checklist", "state", schemaId, subjectId] as const,
+      schema: (schemaId: string) => ["compliance", "checklist", "schema", schemaId] as const,
+    },
+    approval: {
+      all: ["compliance", "approval"] as const,
+      bySubject: (subjectId: string) => ["compliance", "approval", "bySubject", subjectId] as const,
+      pending: (filters?: Record<string, unknown>) =>
+        ["compliance", "approval", "pending", filters] as const,
+    },
   },
 
   // Service Orders

--- a/src/lib/rbac.ts
+++ b/src/lib/rbac.ts
@@ -3,11 +3,44 @@
  *
  * 5 roles: Admin, Manager, Technician, Viewer, CustomerAdmin
  * Each role has a set of allowed pages and actions.
+ *
+ * NIST 800-53 controls enforced by this module:
+ * - AC-3 (Access Enforcement): canPerformAction / canAccessPage gate every
+ *   sensitive operation. Every compliance primitive (Epic 28) calls
+ *   canPerformAction BEFORE side-effects and writes an audit-denial record
+ *   on failure (AU-2 / AU-3).
+ * - AC-5 (Separation of Duties): submit vs decide, request vs approve,
+ *   initiate vs complete are deliberately split across distinct actions so a
+ *   single principal cannot both raise and ratify a compliance decision.
+ *   Runtime SoD (same-principal-rejection) is additionally enforced at the
+ *   compliance engine adapters (see src/lib/compliance/approval/).
+ * - AC-6 (Least Privilege): Viewer + CustomerAdmin receive read/submit-only
+ *   subsets of the compliance action surface.
  */
 
 export type Role = "Admin" | "Manager" | "Technician" | "Viewer" | "CustomerAdmin";
 
-export type Action = "create" | "edit" | "delete" | "approve";
+export type Action =
+  | "create"
+  | "edit"
+  | "delete"
+  | "approve"
+  // Epic 28 — Compliance primitives (generic, domain-agnostic).
+  // NIST AC-3 enforcement points; AC-5 pair splits (submit/decide,
+  // request/approve, initiate/complete) are intentional so no single
+  // principal can both propose and ratify the same compliance event.
+  | "evidence:put"
+  | "evidence:read"
+  | "checklist:attach"
+  | "checklist:waive"
+  | "approval:submit" // AC-5: pair with "approval:decide"
+  | "approval:decide" // AC-5: pair with "approval:submit"
+  | "distribution:request" // AC-5: pair with "distribution:approve"
+  | "distribution:approve" // AC-5: pair with "distribution:request"
+  | "confirmation:initiate" // AC-5: pair with "confirmation:complete"
+  | "confirmation:complete" // AC-5: pair with "confirmation:initiate"
+  | "confirmation:abandon"
+  | "impact:query";
 
 export interface RolePermissions {
   pages: string[];
@@ -32,7 +65,24 @@ const PERMISSIONS: Record<Role, RolePermissions> = {
       "user-management",
       "customers",
     ],
-    actions: ["create", "edit", "delete", "approve"],
+    actions: [
+      "create",
+      "edit",
+      "delete",
+      "approve",
+      "evidence:put",
+      "evidence:read",
+      "checklist:attach",
+      "checklist:waive",
+      "approval:submit",
+      "approval:decide",
+      "distribution:request",
+      "distribution:approve",
+      "confirmation:initiate",
+      "confirmation:complete",
+      "confirmation:abandon",
+      "impact:query",
+    ],
     filterByCustomer: false,
   },
   Manager: {
@@ -48,14 +98,34 @@ const PERMISSIONS: Record<Role, RolePermissions> = {
       "incidents",
       "digital-twin",
       "executive-summary",
-      "customers", // AC-3: Customer management access
+      "customers",
     ],
-    actions: ["create", "edit", "approve"],
+    actions: [
+      "create",
+      "edit",
+      "approve",
+      "evidence:put",
+      "evidence:read",
+      "checklist:attach",
+      "checklist:waive",
+      "approval:decide",
+      "distribution:approve",
+      "impact:query",
+    ],
     filterByCustomer: false,
   },
   Technician: {
     pages: ["dashboard", "inventory", "account-service"],
-    actions: ["create", "edit"],
+    actions: [
+      "create",
+      "edit",
+      "evidence:read",
+      "checklist:attach",
+      "approval:submit",
+      "distribution:request",
+      "confirmation:initiate",
+      "confirmation:complete",
+    ],
     filterByCustomer: false,
   },
   Viewer: {
@@ -70,14 +140,14 @@ const PERMISSIONS: Record<Role, RolePermissions> = {
       "telemetry",
       "incidents",
       "digital-twin",
-      "customers", // AC-3: Read-only customer view access
+      "customers",
     ],
-    actions: [],
+    actions: ["evidence:read", "impact:query"],
     filterByCustomer: false,
   },
   CustomerAdmin: {
     pages: ["dashboard", "inventory", "account-service"],
-    actions: ["create", "edit"],
+    actions: ["create", "edit", "evidence:read", "approval:submit"],
     filterByCustomer: true,
   },
 };


### PR DESCRIPTION
## Summary

Ships the **Phase 1 foundation of Epic 28** — a generic, domain-agnostic compliance workflow primitives library under `src/lib/compliance/`. Three provider-pluggable primitives that any regulated application cloning the template can wire up without rebuilding.

**Stories shipped:**
- Closes #453 — Story 28.1 Immutable Evidence Store
- Closes #454 — Story 28.2 Document Completeness Engine
- Closes #455 — Story 28.3 Gated Approval State Machine

**Epic:** #452

## What's in the library

| Primitive | Interface | Adapters | Key invariant |
|---|---|---|---|
| Evidence store | `IEvidenceStore` | `createMockEvidenceStore`, `createS3EvidenceStore` | NO delete/update/patch on the interface; SHA-256 content hash on every put; S3 adapter requires Object Lock COMPLIANCE + KMS |
| Checklist engine | `IChecklistStore` + pure `evaluateCompleteness()` | `createMockChecklistStore` | Four slot states; waiver authority server-enforced (AC-5); 100% branch coverage on evaluator |
| Approval state machine | `IApprovalEngine` + pure `transition()` | `createMockApprovalEngine` | 4-state machine w/ exhaustive transition table; server-side SoD (reviewer ≠ submitter); checklist-gated decisions |

Components shipped: `<EvidenceViewer>` (with Storybook), `<ChecklistPanel>`, `<ChecklistSummary>`, `<WaiverDialog>`, `<ApprovalGateBadge>`, `<ApprovalDecisionPanel>`.

## Domain-agnostic by enforcement

- No IMS / firmware / device / SBOM / customer types referenced inside `src/lib/compliance/**`
- ESLint `no-restricted-imports` rule added (`eslint.config.js`) that fails CI if a future commit imports domain code into the library
- All types use generics (`Approval<TSubjectId>`, `ChecklistSchema<TKey>`, etc.)
- Reference wiring into firmware flows is deferred to a follow-up PR behind `VITE_FEATURE_COMPLIANCE_LIB` — keeps this PR focused on the library contract

## NIST 800-53 controls enforced

| Control | Where |
|---|---|
| AC-3 (Access Enforcement) | Every adapter method calls `canPerformAction` before side-effects |
| AC-5 (Separation of Duties) | `rbac.ts` splits submit/decide, request/approve, initiate/complete; approval engine server-side rejects self-decide |
| AC-6 (Least Privilege) | Viewer + CustomerAdmin receive read/submit-only compliance subsets |
| AU-2 / AU-3 (Audit) | Every state transition + denial writes AUDIT# via new `src/lib/audit/log-audit.ts` |
| MP-6 (Sanitization forbidden) | `IEvidenceStore` has no delete operation at the type level |
| SC-12 (Key Management) | S3 adapter requires `kmsKeyId` — throws `EvidenceAdapterConfigError` if missing |
| SI-10 (Input Validation) | Reason length (10-500), due-date range (today..+365d), state-machine transitions all validated |

## Rulebook compliance

- ✅ `security-nist-rulebook.md` — controls above, inline annotations in rbac.ts and adapters
- ✅ `architecture-rulebook.md` — factory fns, interface-first, domain-free, UI→hook→adapter layering
- ✅ `api-data-layer-rulebook.md` — TanStack Query everywhere, typed errors, hierarchical query keys, `staleTime: Infinity` for immutable records
- ✅ `code-quality-rulebook.md` — no `any`, ≥85% coverage on primitives, 100% branch coverage on pure evaluator + state machine
- ✅ `git-workflow-rulebook.md` — branch name, commit format with story #s

## Test evidence

- **57 new unit tests** covering: evidence store behavior + RBAC + immutability, checklist evaluator exhaustive states + validation rules, approval transition table (all 16 cells + conditional-approved special case + reason validation + history tracking), mock approval engine SoD + gating + RBAC
- Full project test suite: **706 passed / 51 test files**
- `npx tsc --noEmit` — clean
- `npx eslint` — 0 errors (9 pre-existing warnings unrelated to this change)
- `npm run build` — green, 13.4s

## Follow-up work (NOT in this PR)

- Story 28.4 — Conditional Approval with SLA Tracking
- Story 28.5 — Scoped One-Time Secure Distribution
- Story 28.6 — Two-Phase Action Confirmation
- Story 28.7 — Inverse Dependency Query
- Real S3 + DynamoDB adapter SDK wiring (interfaces + config contracts are in; concrete SDK drivers are injected by deployment)
- Reference firmware flow migration behind `VITE_FEATURE_COMPLIANCE_LIB`
- Storybook stories for `<ChecklistPanel>`, `<WaiverDialog>`, `<ApprovalDecisionPanel>` (only `<EvidenceViewer>` has stories in this PR)

## Test plan

- [ ] Review the ESLint `no-restricted-imports` rule — confirm the block list is right for template reuse
- [ ] Confirm NIST control mapping matches `Docs/nist-800-53-control-mapping.md` conventions
- [ ] Spot-check the S3 adapter JSDoc — is the deploy-time bucket configuration doc correct for the target env?
- [ ] Storybook: `npm run storybook` → Compliance/EvidenceViewer — verify PDF + image previews + immutability badge
- [ ] Run `npx vitest run src/__tests__/lib/compliance` → verify 57 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)