### PR TITLE
docs(compliance): Storybook stories for 9 compliance UI components

### DIFF
--- a/src/app/components/compliance/__stories/compliance-story-harness.tsx
+++ b/src/app/components/compliance/__stories/compliance-story-harness.tsx
@@ -1,0 +1,124 @@
+/**
+ * Shared Storybook harness for compliance components.
+ *
+ * Sets up a per-story QueryClient and the full set of mock compliance
+ * adapters + providers so individual stories can render any primitive
+ * without bespoke wiring. Story authors pass `seed` callbacks to populate
+ * the in-memory stores before rendering.
+ *
+ * This file is scoped to Storybook; the production app wires its own
+ * provider tree via `EvidenceStoreProvider` / `ChecklistProvider` /
+ * `ApprovalProvider` / `SecureDistributionProvider` etc.
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
+import type { ReactNode } from "react";
+
+import {
+  ChecklistProvider,
+  createMockChecklistStore,
+  type ChecklistSchema,
+  type IChecklistStore,
+} from "@/lib/compliance/checklist";
+import {
+  createMockEvidenceStore,
+  EvidenceStoreProvider,
+  type IEvidenceStore,
+} from "@/lib/compliance/evidence";
+import {
+  ApprovalProvider,
+  createMockApprovalEngine,
+  type IApprovalEngine,
+} from "@/lib/compliance/approval";
+import {
+  createMockSecureDistribution,
+  SecureDistributionProvider,
+  type ISecureDistribution,
+} from "@/lib/compliance/distribution";
+import {
+  createMockConfirmationEngine,
+  type IConfirmationEngine,
+} from "@/lib/compliance/confirmation";
+import { createMockDependencyGraph, type IDependencyGraph } from "@/lib/compliance/impact";
+import type { ComplianceActor } from "@/lib/compliance/types";
+import type { Role } from "@/lib/rbac";
+
+export interface ComplianceHarnessStores {
+  readonly evidenceStore: IEvidenceStore;
+  readonly checklistStore: IChecklistStore;
+  readonly approvalEngine: IApprovalEngine;
+  readonly distribution: ISecureDistribution;
+  readonly confirmationEngine: IConfirmationEngine;
+  readonly dependencyGraph: IDependencyGraph;
+}
+
+export interface ComplianceHarnessProps {
+  readonly actor?: ComplianceActor;
+  readonly role?: Role;
+  readonly schemas?: readonly ChecklistSchema[];
+  readonly now?: () => Date;
+  readonly seed?: (stores: ComplianceHarnessStores) => Promise<void> | void;
+  readonly children: (stores: ComplianceHarnessStores) => ReactNode;
+}
+
+const DEFAULT_ACTOR: ComplianceActor = { userId: "demo-user", displayName: "Demo User" };
+
+export function ComplianceHarness({
+  actor = DEFAULT_ACTOR,
+  role = "Admin",
+  schemas,
+  now,
+  seed,
+  children,
+}: ComplianceHarnessProps) {
+  const [qc] = useState(() => new QueryClient({ defaultOptions: { queries: { retry: false } } }));
+
+  const stores = useMemo<ComplianceHarnessStores>(() => {
+    const resolveRole = () => role;
+    return {
+      evidenceStore: createMockEvidenceStore({ resolveRole, now }),
+      checklistStore: createMockChecklistStore({
+        resolveRole,
+        now,
+        seedSchemas: schemas,
+      }),
+      approvalEngine: createMockApprovalEngine({ resolveRole, now }),
+      distribution: createMockSecureDistribution({ resolveRole, now }),
+      confirmationEngine: createMockConfirmationEngine({ resolveRole, now }),
+      dependencyGraph: createMockDependencyGraph({ resolveRole, now }),
+    };
+  }, [role, now, schemas]);
+
+  const [ready, setReady] = useState(() => (seed ? false : true));
+
+  useEffect(() => {
+    if (!seed) return;
+    let cancelled = false;
+    void Promise.resolve(seed(stores)).then(() => {
+      if (!cancelled) setReady(true);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [seed, stores]);
+
+  return (
+    <QueryClientProvider client={qc}>
+      <EvidenceStoreProvider store={stores.evidenceStore} actor={actor}>
+        <ChecklistProvider store={stores.checklistStore} actor={actor}>
+          <ApprovalProvider engine={stores.approvalEngine} actor={actor}>
+            <SecureDistributionProvider driver={stores.distribution} actor={actor}>
+              <div className="p-4 max-w-3xl">
+                {ready ? children(stores) : <p className="text-xs">Seeding demo data…</p>}
+              </div>
+            </SecureDistributionProvider>
+          </ApprovalProvider>
+        </ChecklistProvider>
+      </EvidenceStoreProvider>
+    </QueryClientProvider>
+  );
+}
+
+export const DEMO_ACTOR = DEFAULT_ACTOR;
+export const OTHER_ACTOR: ComplianceActor = { userId: "bob", displayName: "Bob Reviewer" };

--- a/src/app/components/compliance/approval-decision-panel.stories.tsx
+++ b/src/app/components/compliance/approval-decision-panel.stories.tsx
@@ -1,0 +1,90 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { ApprovalDecisionPanel } from "./approval-decision-panel";
+import type { Approval, ApprovalState } from "@/lib/compliance/approval";
+import type { Completeness } from "@/lib/compliance/checklist";
+
+const BASE: Omit<Approval, "state" | "reviewer" | "reason" | "decidedAt"> = {
+  id: "a-1",
+  subjectId: "subj-1",
+  submittedBy: { userId: "alice", displayName: "Alice" },
+  conditions: [],
+  history: [],
+};
+
+function initial(state: ApprovalState): Approval {
+  return { ...BASE, state, reviewer: null, reason: null, decidedAt: null };
+}
+
+interface HarnessProps {
+  readonly initialState: ApprovalState;
+  readonly completeness: Completeness;
+  readonly canDecide: boolean;
+}
+
+function Harness({ initialState, completeness, canDecide }: HarnessProps) {
+  const [approval, setApproval] = useState<Approval>(() => initial(initialState));
+  return (
+    <ApprovalDecisionPanel
+      approval={approval}
+      completeness={completeness}
+      canDecide={canDecide}
+      onDecide={async ({ nextState, reason }) => {
+        setApproval((prev) => ({
+          ...prev,
+          state: nextState,
+          reviewer: { userId: "bob", displayName: "Bob Reviewer" },
+          reason: reason ?? null,
+          decidedAt: new Date().toISOString(),
+        }));
+      }}
+    />
+  );
+}
+
+const meta: Meta<typeof ApprovalDecisionPanel> = {
+  title: "Compliance/ApprovalDecisionPanel",
+  component: ApprovalDecisionPanel,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Reviewer-only sticky decision surface. Buttons are enabled only when the transition is legal given the current state + checklist completeness. Server is the ground truth — client disabling is ergonomic only.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ApprovalDecisionPanel>;
+
+export const PendingAndComplete: Story = {
+  render: () => <Harness initialState="pending" completeness={{ kind: "complete" }} canDecide />,
+};
+
+export const PendingButIncomplete: Story = {
+  render: () => (
+    <Harness
+      initialState="pending"
+      completeness={{ kind: "incomplete", missing: ["sbom", "fat"] }}
+      canDecide
+    />
+  ),
+};
+
+export const PendingAndConditional: Story = {
+  render: () => (
+    <Harness
+      initialState="pending"
+      completeness={{ kind: "conditionally-complete", pendingWaivers: ["fat"] }}
+      canDecide
+    />
+  ),
+};
+
+export const ReadOnlyNoDecideAuth: Story = {
+  render: () => (
+    <Harness initialState="pending" completeness={{ kind: "complete" }} canDecide={false} />
+  ),
+};

--- a/src/app/components/compliance/approval-gate-badge.stories.tsx
+++ b/src/app/components/compliance/approval-gate-badge.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ApprovalGateBadge } from "./approval-gate-badge";
+import type { Approval } from "@/lib/compliance/approval";
+
+const BASE: Omit<Approval, "state" | "reviewer" | "reason" | "decidedAt"> = {
+  id: "a-1",
+  subjectId: "subj-1",
+  submittedBy: { userId: "alice", displayName: "Alice" },
+  conditions: [],
+  history: [],
+};
+const BOB = { userId: "bob", displayName: "Bob Reviewer" };
+
+function mk(
+  state: Approval["state"],
+  reviewer: Approval["reviewer"] = null,
+  reason: string | null = null,
+): Approval {
+  return {
+    ...BASE,
+    state,
+    reviewer,
+    reason,
+    decidedAt: reviewer ? "2026-04-21T10:00:00Z" : null,
+  };
+}
+
+const meta: Meta<typeof ApprovalGateBadge> = {
+  title: "Compliance/ApprovalGateBadge",
+  component: ApprovalGateBadge,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Compact 22px pill showing approval state. Hover reveals reviewer, decision time, and reason.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ApprovalGateBadge>;
+
+export const Pending: Story = {
+  args: { approval: mk("pending") },
+};
+export const Approved: Story = {
+  args: { approval: mk("approved", BOB) },
+};
+export const ConditionallyApproved: Story = {
+  args: {
+    approval: mk(
+      "conditionally-approved",
+      BOB,
+      "Shipping as conditional — FAT report pending within two weeks.",
+    ),
+  },
+};
+export const Rejected: Story = {
+  args: {
+    approval: mk("rejected", BOB, "Architecture diagram is missing — resubmit with diagrams."),
+  },
+};
+export const Missing: Story = {
+  args: { approval: null },
+};

--- a/src/app/components/compliance/checklist-panel.stories.tsx
+++ b/src/app/components/compliance/checklist-panel.stories.tsx
@@ -1,0 +1,160 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ComplianceHarness, DEMO_ACTOR } from "./__stories/compliance-story-harness";
+import { ChecklistPanel } from "./checklist-panel";
+import type { ChecklistSchema } from "@/lib/compliance/checklist";
+
+const DEMO_SCHEMA: ChecklistSchema = {
+  schemaId: "release-bundle",
+  label: "Release Bundle Checklist",
+  slots: [
+    { key: "sbom", label: "Software Bill of Materials", required: true },
+    { key: "hbom", label: "Hardware Bill of Materials", required: true },
+    { key: "fat", label: "FAT / QA Test Results", required: true },
+    { key: "release-notes", label: "Release Notes", required: true },
+    { key: "attestation", label: "Attestation", required: false },
+  ],
+};
+
+const meta: Meta<typeof ChecklistPanel> = {
+  title: "Compliance/ChecklistPanel",
+  component: ChecklistPanel,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Domain-agnostic N-of-M checklist with four slot states: present, missing, waived-permanent, waived-conditional. Actions gated on caller-supplied `canAttach` / `canWaive`.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ChecklistPanel>;
+
+export const AllMissing: Story = {
+  render: () => (
+    <ComplianceHarness schemas={[DEMO_SCHEMA]}>
+      {() => (
+        <ChecklistPanel schemaId={DEMO_SCHEMA.schemaId} subjectId="sub-1" canAttach canWaive />
+      )}
+    </ComplianceHarness>
+  ),
+};
+
+export const Complete: Story = {
+  render: () => (
+    <ComplianceHarness
+      schemas={[DEMO_SCHEMA]}
+      seed={async ({ checklistStore }) => {
+        for (const key of ["sbom", "hbom", "fat", "release-notes"]) {
+          await checklistStore.attachSlot(
+            DEMO_SCHEMA.schemaId,
+            "sub-2",
+            key,
+            `ev-${key}`,
+            DEMO_ACTOR,
+          );
+        }
+      }}
+    >
+      {() => (
+        <ChecklistPanel schemaId={DEMO_SCHEMA.schemaId} subjectId="sub-2" canAttach canWaive />
+      )}
+    </ComplianceHarness>
+  ),
+};
+
+export const ConditionallyComplete: Story = {
+  render: () => (
+    <ComplianceHarness
+      schemas={[DEMO_SCHEMA]}
+      seed={async ({ checklistStore }) => {
+        await checklistStore.attachSlot(
+          DEMO_SCHEMA.schemaId,
+          "sub-3",
+          "sbom",
+          "ev-sbom",
+          DEMO_ACTOR,
+        );
+        await checklistStore.attachSlot(
+          DEMO_SCHEMA.schemaId,
+          "sub-3",
+          "hbom",
+          "ev-hbom",
+          DEMO_ACTOR,
+        );
+        await checklistStore.attachSlot(
+          DEMO_SCHEMA.schemaId,
+          "sub-3",
+          "release-notes",
+          "ev-rn",
+          DEMO_ACTOR,
+        );
+        await checklistStore.waiveConditional(
+          DEMO_SCHEMA.schemaId,
+          "sub-3",
+          "fat",
+          "Hardware regression lab queued — expected within two weeks.",
+          new Date(Date.now() + 14 * 24 * 60 * 60 * 1000).toISOString(),
+          DEMO_ACTOR,
+        );
+      }}
+    >
+      {() => (
+        <ChecklistPanel schemaId={DEMO_SCHEMA.schemaId} subjectId="sub-3" canAttach canWaive />
+      )}
+    </ComplianceHarness>
+  ),
+};
+
+export const MixedStates: Story = {
+  render: () => (
+    <ComplianceHarness
+      schemas={[DEMO_SCHEMA]}
+      seed={async ({ checklistStore }) => {
+        await checklistStore.attachSlot(
+          DEMO_SCHEMA.schemaId,
+          "sub-4",
+          "sbom",
+          "ev-sbom",
+          DEMO_ACTOR,
+        );
+        await checklistStore.waivePermanent(
+          DEMO_SCHEMA.schemaId,
+          "sub-4",
+          "hbom",
+          "Not applicable to this product line — software-only release.",
+          DEMO_ACTOR,
+        );
+        await checklistStore.waiveConditional(
+          DEMO_SCHEMA.schemaId,
+          "sub-4",
+          "fat",
+          "FAT scheduled for next week — interim approval granted.",
+          new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+          DEMO_ACTOR,
+        );
+      }}
+    >
+      {() => (
+        <ChecklistPanel schemaId={DEMO_SCHEMA.schemaId} subjectId="sub-4" canAttach canWaive />
+      )}
+    </ComplianceHarness>
+  ),
+};
+
+export const NoWaiveAuthority: Story = {
+  render: () => (
+    <ComplianceHarness schemas={[DEMO_SCHEMA]}>
+      {() => (
+        <ChecklistPanel
+          schemaId={DEMO_SCHEMA.schemaId}
+          subjectId="sub-5"
+          canAttach
+          canWaive={false}
+        />
+      )}
+    </ComplianceHarness>
+  ),
+};

--- a/src/app/components/compliance/conditions-panel.stories.tsx
+++ b/src/app/components/compliance/conditions-panel.stories.tsx
@@ -1,0 +1,152 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useEffect, useState } from "react";
+import {
+  ComplianceHarness,
+  DEMO_ACTOR,
+  OTHER_ACTOR,
+  type ComplianceHarnessStores,
+} from "./__stories/compliance-story-harness";
+import { ConditionsPanel } from "./conditions-panel";
+import type { Approval, SlaCondition } from "@/lib/compliance/approval";
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function mkCond(
+  id: string,
+  inMs: number,
+  status: SlaCondition["status"] = "pending",
+): SlaCondition {
+  return {
+    id,
+    description: `Condition ${id}: evidence expected`,
+    dueAt: new Date(Date.now() + inMs).toISOString(),
+    status,
+  };
+}
+
+async function seedApproval(
+  engine: ComplianceHarnessStores["approvalEngine"],
+  conditions: readonly SlaCondition[],
+): Promise<Approval> {
+  const created = await engine.create("subj-demo", DEMO_ACTOR);
+  const decided = await engine.decide(
+    created.id,
+    {
+      nextState: "conditionally-approved",
+      reviewer: OTHER_ACTOR,
+      reason: "Conditional approval with tracked SLA conditions.",
+      conditions,
+    },
+    { completeness: { kind: "conditionally-complete", pendingWaivers: ["fat"] } },
+  );
+  return decided;
+}
+
+function useSeededApproval(
+  seed: () => Promise<Approval>,
+): readonly [Approval | null, (a: Approval) => void] {
+  const [approval, setApproval] = useState<Approval | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    void seed().then((a) => {
+      if (!cancelled) setApproval(a);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [seed]);
+  return [approval, setApproval] as const;
+}
+
+interface RenderHostProps {
+  readonly stores: ComplianceHarnessStores;
+  readonly conditions: readonly SlaCondition[];
+  readonly canSatisfy: boolean;
+}
+
+function ConditionsPanelRenderHost({ stores, conditions, canSatisfy }: RenderHostProps) {
+  const [approval] = useSeededApproval(() => {
+    if (conditions.length === 0) {
+      return Promise.resolve<Approval>({
+        id: "a-empty",
+        subjectId: "subj-demo",
+        submittedBy: DEMO_ACTOR,
+        state: "approved",
+        reviewer: OTHER_ACTOR,
+        reason: null,
+        decidedAt: new Date().toISOString(),
+        conditions: [],
+        history: [],
+      });
+    }
+    return seedApproval(stores.approvalEngine, conditions);
+  });
+
+  if (!approval) return <p className="text-xs">Seeding approval…</p>;
+  return (
+    <ConditionsPanel
+      approval={approval}
+      engine={stores.approvalEngine}
+      actor={OTHER_ACTOR}
+      canSatisfy={canSatisfy}
+    />
+  );
+}
+
+const meta: Meta<typeof ConditionsPanel> = {
+  title: "Compliance/ConditionsPanel",
+  component: ConditionsPanel,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Lists SLA conditions attached to a conditionally-approved subject. Reviewers can mark individual conditions satisfied with a required reason (10-500 chars).",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ConditionsPanel>;
+
+export const MixedStatuses: Story = {
+  render: () => (
+    <ComplianceHarness>
+      {(stores) => (
+        <ConditionsPanelRenderHost
+          stores={stores}
+          conditions={[
+            mkCond("c-1", 5 * MS_PER_DAY),
+            mkCond("c-2", 12 * 60 * 60 * 1000),
+            mkCond("c-3", -MS_PER_DAY),
+            mkCond("c-4", 2 * MS_PER_DAY, "satisfied"),
+          ]}
+          canSatisfy
+        />
+      )}
+    </ComplianceHarness>
+  ),
+};
+
+export const Empty: Story = {
+  render: () => (
+    <ComplianceHarness>
+      {(stores) => <ConditionsPanelRenderHost stores={stores} conditions={[]} canSatisfy />}
+    </ComplianceHarness>
+  ),
+};
+
+export const ReadOnly: Story = {
+  render: () => (
+    <ComplianceHarness>
+      {(stores) => (
+        <ConditionsPanelRenderHost
+          stores={stores}
+          conditions={[mkCond("c-1", 4 * MS_PER_DAY), mkCond("c-2", -MS_PER_DAY)]}
+          canSatisfy={false}
+        />
+      )}
+    </ComplianceHarness>
+  ),
+};

--- a/src/app/components/compliance/confirmation-dialog.stories.tsx
+++ b/src/app/components/compliance/confirmation-dialog.stories.tsx
@@ -1,0 +1,141 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { ConfirmationDialog } from "./confirmation-dialog";
+import type { ActionInitiation, ProofValidator } from "@/lib/compliance/confirmation";
+
+interface DeployProof {
+  readonly note: string;
+  readonly photos: readonly string[];
+}
+
+const DEPLOY_INIT: ActionInitiation<{ readonly siteId: string }> = {
+  id: "init-1",
+  kind: "deploy-firmware",
+  payload: { siteId: "site-alpha" },
+  initiatedAt: "2026-04-21T10:00:00Z",
+  initiatedBy: { userId: "alice", displayName: "Alice Tech" },
+  state: "initiated",
+};
+
+const DEPLOY_VALIDATOR: ProofValidator<DeployProof> = (p) => {
+  const messages: string[] = [];
+  if (p.note.length < 10) messages.push("note must be at least 10 characters");
+  if (p.photos.length < 1) messages.push("at least one photo reference is required");
+  return { ok: messages.length === 0, messages };
+};
+
+function Harness() {
+  const [open, setOpen] = useState(true);
+  const [confirmed, setConfirmed] = useState<DeployProof | null>(null);
+
+  if (confirmed) {
+    return (
+      <div className="rounded-lg border border-border bg-card p-3 text-[12px]">
+        <p className="font-medium">Confirmed</p>
+        <pre className="mt-1 whitespace-pre-wrap text-muted-foreground">
+          {JSON.stringify(confirmed, null, 2)}
+        </pre>
+        <button
+          type="button"
+          onClick={() => {
+            setConfirmed(null);
+            setOpen(true);
+          }}
+          className="mt-2 rounded-md border border-border bg-card px-3 py-1.5 text-[11px]"
+        >
+          Reset
+        </button>
+      </div>
+    );
+  }
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="rounded-md border border-border bg-card px-3 py-1.5 text-[12px]"
+      >
+        Re-open
+      </button>
+    );
+  }
+
+  return (
+    <ConfirmationDialog<DeployProof>
+      initiation={DEPLOY_INIT as ActionInitiation}
+      validator={DEPLOY_VALIDATOR}
+      initialProof={{ note: "", photos: [] }}
+      onConfirm={async (proof) => {
+        setConfirmed(proof);
+        setOpen(false);
+      }}
+      onClose={() => setOpen(false)}
+      title="Confirm deployment"
+      renderFields={({ proof, setProof }) => (
+        <>
+          <div>
+            <label
+              htmlFor="confirm-demo-note"
+              className="mb-1 block text-[12px] font-medium text-foreground"
+            >
+              Installation notes
+            </label>
+            <textarea
+              id="confirm-demo-note"
+              value={proof.note}
+              onChange={(e) => setProof({ ...proof, note: e.target.value })}
+              rows={3}
+              className="w-full rounded-md border border-border bg-card px-2 py-1.5 text-[12px] outline-none focus:border-primary"
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="confirm-demo-photos"
+              className="mb-1 block text-[12px] font-medium text-foreground"
+            >
+              Photo evidence references (one per line)
+            </label>
+            <textarea
+              id="confirm-demo-photos"
+              value={proof.photos.join("\n")}
+              onChange={(e) =>
+                setProof({
+                  ...proof,
+                  photos: e.target.value
+                    .split("\n")
+                    .map((s) => s.trim())
+                    .filter(Boolean),
+                })
+              }
+              rows={2}
+              placeholder="ev-photo-1&#10;ev-photo-2"
+              className="w-full rounded-md border border-border bg-card px-2 py-1.5 text-[12px] outline-none focus:border-primary"
+            />
+          </div>
+        </>
+      )}
+    />
+  );
+}
+
+const meta: Meta<typeof ConfirmationDialog> = {
+  title: "Compliance/ConfirmationDialog",
+  component: ConfirmationDialog,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Caller-driven proof capture. Validator is a pure function; the dialog renders caller-supplied fields. Same component works for any action kind — deployment, shipment, settings reconciliation, etc.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ConfirmationDialog>;
+
+export const DeploymentConfirmation: Story = {
+  render: () => <Harness />,
+};

--- a/src/app/components/compliance/impact-query-table.stories.tsx
+++ b/src/app/components/compliance/impact-query-table.stories.tsx
@@ -1,0 +1,98 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import {
+  ComplianceHarness,
+  DEMO_ACTOR,
+  type ComplianceHarnessStores,
+} from "./__stories/compliance-story-harness";
+import { ImpactQueryTable } from "./impact-query-table";
+
+async function seedConsumers(
+  graph: ComplianceHarnessStores["dependencyGraph"],
+  count: number,
+): Promise<void> {
+  const sites = ["site:alpha", "site:beta", "site:gamma"];
+  const states = ["active", "quarantined", "decommissioned"];
+  const versions = ["1.0", "1.1", "1.2"];
+  for (let i = 0; i < count; i++) {
+    await graph.upsertBinding({
+      consumerId: `dev-${i.toString().padStart(4, "0")}`,
+      consumerType: "Device",
+      resourceId: "fw-demo",
+      version: versions[i % versions.length]!,
+      scope: [sites[i % sites.length]!],
+      state: states[i % states.length]!,
+      meta: { model: "SG5000HV" },
+      actor: DEMO_ACTOR,
+    });
+  }
+}
+
+const meta: Meta<typeof ImpactQueryTable> = {
+  title: "Compliance/ImpactQueryTable",
+  component: ImpactQueryTable,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Version-first blast-radius query. Scope + state filters compose with ANY-OF semantics; CSV export iterates all pages so large result sets ship consistently.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ImpactQueryTable>;
+
+export const Populated: Story = {
+  render: () => (
+    <ComplianceHarness seed={async ({ dependencyGraph }) => seedConsumers(dependencyGraph, 60)}>
+      {(stores) => (
+        <ImpactQueryTable
+          driver={stores.dependencyGraph}
+          actor={DEMO_ACTOR}
+          resourceId="fw-demo"
+          version="1.0"
+          scopeOptions={["site:alpha", "site:beta", "site:gamma"]}
+          stateOptions={["active", "quarantined", "decommissioned"]}
+          limit={10}
+        />
+      )}
+    </ComplianceHarness>
+  ),
+};
+
+export const Empty: Story = {
+  render: () => (
+    <ComplianceHarness>
+      {(stores) => (
+        <ImpactQueryTable
+          driver={stores.dependencyGraph}
+          actor={DEMO_ACTOR}
+          resourceId="fw-demo"
+          version="9.9"
+          scopeOptions={["site:alpha"]}
+          stateOptions={["active"]}
+        />
+      )}
+    </ComplianceHarness>
+  ),
+};
+
+export const LargeResultSet: Story = {
+  render: () => (
+    <ComplianceHarness seed={async ({ dependencyGraph }) => seedConsumers(dependencyGraph, 250)}>
+      {(stores) => (
+        <ImpactQueryTable
+          driver={stores.dependencyGraph}
+          actor={DEMO_ACTOR}
+          resourceId="fw-demo"
+          version="1.0"
+          scopeOptions={["site:alpha", "site:beta", "site:gamma"]}
+          stateOptions={["active", "quarantined", "decommissioned"]}
+          limit={25}
+        />
+      )}
+    </ComplianceHarness>
+  ),
+};

--- a/src/app/components/compliance/secure-download-button.stories.tsx
+++ b/src/app/components/compliance/secure-download-button.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ComplianceHarness, DEMO_ACTOR } from "./__stories/compliance-story-harness";
+import { SecureDownloadButton } from "./secure-download-button";
+
+const meta: Meta<typeof SecureDownloadButton> = {
+  title: "Compliance/SecureDownloadButton",
+  component: SecureDownloadButton,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Single-click mint → (optional step-up MFA) → redeem → open. Driven by the callerinjected `ISecureDistribution` driver; tokens are single-use, recipient-bound, and expire on first use.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SecureDownloadButton>;
+
+export const Default: Story = {
+  render: () => (
+    <ComplianceHarness>
+      {(stores) => (
+        <SecureDownloadButton
+          driver={stores.distribution}
+          actor={DEMO_ACTOR}
+          recipientUserId={DEMO_ACTOR.userId}
+          evidenceId="ev-demo-1"
+          purpose="Storybook demo"
+        />
+      )}
+    </ComplianceHarness>
+  ),
+};
+
+export const RequiresStepUpMfa: Story = {
+  render: () => (
+    <ComplianceHarness>
+      {(stores) => (
+        <SecureDownloadButton
+          driver={stores.distribution}
+          actor={DEMO_ACTOR}
+          recipientUserId={DEMO_ACTOR.userId}
+          evidenceId="ev-demo-2"
+          purpose="Storybook demo (MFA-gated)"
+          requireStepUpMfa
+          onStepUpMfa={async () => {
+            // Storybook mock: simulate a 1-second MFA challenge that resolves to a fresh timestamp
+            await new Promise((resolve) => setTimeout(resolve, 1_000));
+            return new Date().toISOString();
+          }}
+        />
+      )}
+    </ComplianceHarness>
+  ),
+};
+
+export const CustomLabelAndExpiry: Story = {
+  render: () => (
+    <ComplianceHarness>
+      {(stores) => (
+        <SecureDownloadButton
+          driver={stores.distribution}
+          actor={DEMO_ACTOR}
+          recipientUserId={DEMO_ACTOR.userId}
+          evidenceId="ev-demo-3"
+          label="Download audit bundle"
+          expiresInSeconds={300}
+        />
+      )}
+    </ComplianceHarness>
+  ),
+};

--- a/src/app/components/compliance/sla-countdown.stories.tsx
+++ b/src/app/components/compliance/sla-countdown.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { SlaCountdown } from "./sla-countdown";
+import type { SlaCondition } from "@/lib/compliance/approval";
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function cond(inMs: number, status: SlaCondition["status"] = "pending"): SlaCondition {
+  return {
+    id: `c-${inMs}`,
+    description: "sample condition",
+    dueAt: new Date(Date.now() + inMs).toISOString(),
+    status,
+  };
+}
+
+const meta: Meta<typeof SlaCountdown> = {
+  title: "Compliance/SlaCountdown",
+  component: SlaCountdown,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Severity pill for a conditional-approval SLA — safe (>7d), warn (≤7d), urgent (≤24h), breached. Text updates once per minute.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SlaCountdown>;
+
+export const Safe: Story = {
+  args: { condition: cond(10 * MS_PER_DAY) },
+};
+export const Warn: Story = {
+  args: { condition: cond(3 * MS_PER_DAY) },
+};
+export const Urgent: Story = {
+  args: { condition: cond(12 * 60 * 60 * 1000) },
+};
+export const Breached: Story = {
+  args: { condition: cond(-2 * MS_PER_DAY) },
+};
+export const Satisfied: Story = {
+  args: { condition: cond(-2 * MS_PER_DAY, "satisfied") },
+};

--- a/src/app/components/compliance/waiver-dialog.stories.tsx
+++ b/src/app/components/compliance/waiver-dialog.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { WaiverDialog } from "./waiver-dialog";
+
+const meta: Meta<typeof WaiverDialog> = {
+  title: "Compliance/WaiverDialog",
+  component: WaiverDialog,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Reviewer-only dialog for recording permanent or conditional waivers. Reason is 10-500 chars; conditional waivers require a due date bounded to today..+365d (SI-10).",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof WaiverDialog>;
+
+function Harness({ slotKey = "sbom" }: { readonly slotKey?: string }) {
+  const [open, setOpen] = useState(true);
+  const [recorded, setRecorded] = useState<string | null>(null);
+  if (!open && !recorded) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="rounded-md border border-border bg-card px-3 py-1.5 text-[12px]"
+      >
+        Re-open
+      </button>
+    );
+  }
+  if (recorded) {
+    return (
+      <div className="rounded-lg border border-border bg-card p-3 text-[12px]">
+        <p className="font-medium">Recorded</p>
+        <p className="mt-1 text-muted-foreground">{recorded}</p>
+        <button
+          type="button"
+          onClick={() => {
+            setRecorded(null);
+            setOpen(true);
+          }}
+          className="mt-2 rounded-md border border-border bg-card px-3 py-1.5 text-[11px]"
+        >
+          Reset
+        </button>
+      </div>
+    );
+  }
+  return (
+    <WaiverDialog
+      slotKey={slotKey}
+      onClose={() => setOpen(false)}
+      onPermanent={(reason) => {
+        setRecorded(`Permanent waiver: ${reason}`);
+        setOpen(false);
+      }}
+      onConditional={(reason, dueAt) => {
+        setRecorded(`Conditional waiver due ${dueAt}: ${reason}`);
+        setOpen(false);
+      }}
+    />
+  );
+}
+
+export const Default: Story = {
+  render: () => <Harness />,
+};
+
+export const WithCustomSlot: Story = {
+  render: () => <Harness slotKey="architecture-diagram" />,
+};


### PR DESCRIPTION
## Summary

Closes the deferred DoD items across Epic 28 stories 28.2-28.7 by adding Storybook stories for every remaining compliance UI component. Pure additive change — no library code modified; only new `.stories.tsx` files and a shared story harness.

## What's in the PR

### Shared harness

`src/app/components/compliance/__stories/compliance-story-harness.tsx` — per-story QueryClient wired to the full set of mock compliance adapters (`<ComplianceHarness>`). Story authors pass `seed` callbacks to populate mock stores before render; individual stories focus on state matrix rather than provider plumbing.

### Stories (9 components, 30+ variants)

| Component | Variants |
|---|---|
| `<ChecklistPanel>` | AllMissing, Complete, ConditionallyComplete, MixedStates, NoWaiveAuthority |
| `<WaiverDialog>` | Default, WithCustomSlot |
| `<ApprovalGateBadge>` | Pending, Approved, ConditionallyApproved, Rejected, Missing |
| `<ApprovalDecisionPanel>` | PendingAndComplete, PendingButIncomplete, PendingAndConditional, ReadOnlyNoDecideAuth |
| `<SlaCountdown>` | Safe, Warn, Urgent, Breached, Satisfied |
| `<ConditionsPanel>` | MixedStatuses, Empty, ReadOnly |
| `<SecureDownloadButton>` | Default, RequiresStepUpMfa (with mocked MFA resolver), CustomLabelAndExpiry |
| `<ConfirmationDialog>` | DeploymentConfirmation (caller-driven fields + validator) |
| `<ImpactQueryTable>` | Populated, Empty, LargeResultSet (250 rows seeded) |

## Why this matters for the template

Template consumers (teams cloning this repo for a regulated app) previously had to read tests + library source to understand each primitive. With this PR, they navigate Storybook, see every state visually, and copy the wiring pattern from the harness.

## Verification

| Check | Result |
|---|---|
| `npm run build-storybook` | green (23s) |
| `npx tsc --noEmit` | clean |
| `npx eslint 'src/app/components/compliance/**'` | 0 errors, 1 warning (react-refresh on harness — acceptable for Storybook infrastructure) |
| `npm run build` | green (11.8s) |
| `npx vitest run` | 762/763 passing |

### One test flake (pre-existing, not caused by this PR)

`src/__tests__/a11y/accessibility.test.tsx > PageLoader skeleton has no a11y violations` fails in the full parallel run with `useAuth must be used within an AuthProvider`. Confirmed pre-existing by stashing this PR and running the test on clean main — also fails in full-suite context, passes in isolation. Test ordering / shared global state issue unrelated to Storybook.

## Test plan

- [ ] `npm run storybook` → browse to the Compliance section; verify each primitive renders in all variants without console errors
- [ ] Try the interactive flows: WaiverDialog submit, ApprovalDecisionPanel decide, ConditionsPanel mark-satisfied, ConfirmationDialog with proof validation, ImpactQueryTable filter + export
- [ ] Confirm the `<ComplianceHarness>` pattern is reusable for future template-consumer stories

🤖 Generated with [Claude Code](https://claude.com/claude-code)