### PR TITLE
feat(compliance): wire firmware intake artifacts through compliance library

### DIFF
--- a/src/__tests__/lib/firmware/firmware-artifact-schema.test.ts
+++ b/src/__tests__/lib/firmware/firmware-artifact-schema.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import {
+  FIRMWARE_INTAKE_SCHEMA_ID,
+  firmwareIntakeChecklistSchema,
+} from "@/lib/firmware/firmware-artifact-schema";
+import { evaluateCompleteness } from "@/lib/compliance/checklist";
+import type { ChecklistState, SlotState } from "@/lib/compliance/checklist";
+
+const NOW = "2026-04-21T10:00:00Z";
+const ACTOR = { userId: "alice", displayName: "Alice" };
+
+function mkState(slots: Record<string, SlotState>): ChecklistState {
+  return {
+    schemaId: FIRMWARE_INTAKE_SCHEMA_ID,
+    subjectId: "fw-v1",
+    slots,
+  };
+}
+
+function present(id = "ev-test"): SlotState {
+  return { kind: "present", evidenceId: id, filledAt: NOW, filledBy: ACTOR };
+}
+
+describe("firmware artifact schema", () => {
+  it("every required slot is captured and stable", () => {
+    const required = firmwareIntakeChecklistSchema.slots
+      .filter((s) => s.required)
+      .map((s) => s.key)
+      .sort();
+    expect(required).toEqual([
+      "architecture-diagram",
+      "attestation",
+      "fat-qa-results",
+      "hbom",
+      "release-notes",
+      "sbom",
+    ]);
+  });
+
+  it("patch-notes is optional (waiveable without blocking approval)", () => {
+    const patchNotes = firmwareIntakeChecklistSchema.slots.find((s) => s.key === "patch-notes");
+    expect(patchNotes?.required).toBe(false);
+  });
+
+  it("evaluateCompleteness returns complete when all required slots are present", () => {
+    const state = mkState({
+      sbom: present(),
+      hbom: present(),
+      "fat-qa-results": present(),
+      "release-notes": present(),
+      "architecture-diagram": present(),
+      attestation: present(),
+    });
+    const c = evaluateCompleteness(firmwareIntakeChecklistSchema, state);
+    expect(c.kind).toBe("complete");
+  });
+
+  it("missing SBOM makes checklist incomplete", () => {
+    const state = mkState({
+      sbom: { kind: "missing" },
+      hbom: present(),
+      "fat-qa-results": present(),
+      "release-notes": present(),
+      "architecture-diagram": present(),
+      attestation: present(),
+    });
+    const c = evaluateCompleteness(firmwareIntakeChecklistSchema, state);
+    expect(c.kind).toBe("incomplete");
+    if (c.kind === "incomplete") expect(c.missing).toContain("sbom");
+  });
+
+  it("conditional HBOM waiver yields conditionally-complete", () => {
+    const state = mkState({
+      sbom: present(),
+      hbom: {
+        kind: "waived-conditional",
+        reason: "H-BOM format change scheduled for next release — temporary waiver.",
+        dueAt: "2030-01-01T00:00:00Z",
+        waivedAt: NOW,
+        waivedBy: ACTOR,
+      },
+      "fat-qa-results": present(),
+      "release-notes": present(),
+      "architecture-diagram": present(),
+      attestation: present(),
+    });
+    const c = evaluateCompleteness(firmwareIntakeChecklistSchema, state);
+    expect(c.kind).toBe("conditionally-complete");
+    if (c.kind === "conditionally-complete") {
+      expect(c.pendingWaivers).toContain("hbom");
+    }
+  });
+
+  it("permanent HBOM waiver counts as complete (not conditional)", () => {
+    const state = mkState({
+      sbom: present(),
+      hbom: {
+        kind: "waived-permanent",
+        reason: "Software-only product line — H-BOM does not apply.",
+        waivedAt: NOW,
+        waivedBy: ACTOR,
+      },
+      "fat-qa-results": present(),
+      "release-notes": present(),
+      "architecture-diagram": present(),
+      attestation: present(),
+    });
+    const c = evaluateCompleteness(firmwareIntakeChecklistSchema, state);
+    expect(c.kind).toBe("complete");
+  });
+
+  it("optional patch-notes missing does not affect completeness", () => {
+    const state = mkState({
+      sbom: present(),
+      hbom: present(),
+      "fat-qa-results": present(),
+      "release-notes": present(),
+      "architecture-diagram": present(),
+      "patch-notes": { kind: "missing" },
+      attestation: present(),
+    });
+    const c = evaluateCompleteness(firmwareIntakeChecklistSchema, state);
+    expect(c.kind).toBe("complete");
+  });
+});

--- a/src/app/components/firmware/firmware-artifacts-tab.tsx
+++ b/src/app/components/firmware/firmware-artifacts-tab.tsx
@@ -1,0 +1,156 @@
+/**
+ * <FirmwareArtifactsTab /> — reference wiring of the Epic 28 compliance
+ * library against the real firmware flow (behind `VITE_FEATURE_COMPLIANCE_LIB`).
+ *
+ * Renders the generic `<ChecklistPanel>` against the firmware-specific
+ * `firmwareIntakeChecklistSchema`. On "Attach" the tab opens a file
+ * picker, uploads the file to the immutable evidence store, then calls
+ * the checklist engine's `attachSlot` to mark the slot present.
+ *
+ * All state lives inside the tab via per-mount mock stores for the
+ * reference implementation — in production, the app would lift the
+ * providers higher and wire them to the real S3 / DynamoDB adapters.
+ */
+
+import { useMemo, useRef, useState } from "react";
+
+import { ChecklistPanel } from "@/app/components/compliance/checklist-panel";
+import { useAuth } from "@/lib/use-auth";
+import { ChecklistProvider, createMockChecklistStore } from "@/lib/compliance/checklist";
+import { EvidenceStoreProvider, createMockEvidenceStore } from "@/lib/compliance/evidence";
+import { useChecklist } from "@/lib/compliance/checklist";
+import { useUploadEvidence } from "@/lib/compliance/evidence";
+import type { ComplianceActor } from "@/lib/compliance/types";
+import { canPerformAction, getPrimaryRole, type Role } from "@/lib/rbac";
+import {
+  FIRMWARE_INTAKE_SCHEMA_ID,
+  firmwareIntakeChecklistSchema,
+  type FirmwareArtifactSlotKey,
+} from "@/lib/firmware/firmware-artifact-schema";
+
+export interface FirmwareArtifactsTabProps {
+  readonly firmwareVersionId: string;
+}
+
+export function FirmwareArtifactsTab({ firmwareVersionId }: FirmwareArtifactsTabProps) {
+  const { user } = useAuth();
+
+  const actor: ComplianceActor = useMemo(
+    () => ({
+      userId: user?.id ?? "anonymous",
+      displayName: user?.name ?? user?.email ?? "Anonymous",
+    }),
+    [user],
+  );
+
+  const role: Role = useMemo(() => getPrimaryRole(user?.groups ?? []), [user]);
+  const canAttach =
+    canPerformAction(role, "checklist:attach") && canPerformAction(role, "evidence:put");
+  const canWaive = canPerformAction(role, "checklist:waive");
+
+  // Per-mount stores — reference wiring only. Real app would lift these
+  // into a higher-level provider against production adapters.
+  const stores = useMemo(() => {
+    const resolveRole = () => role;
+    return {
+      evidenceStore: createMockEvidenceStore({ resolveRole }),
+      checklistStore: createMockChecklistStore({
+        resolveRole,
+        seedSchemas: [firmwareIntakeChecklistSchema],
+      }),
+    };
+  }, [role]);
+
+  return (
+    <EvidenceStoreProvider store={stores.evidenceStore} actor={actor}>
+      <ChecklistProvider store={stores.checklistStore} actor={actor}>
+        <ArtifactsTabBody
+          firmwareVersionId={firmwareVersionId}
+          canAttach={canAttach}
+          canWaive={canWaive}
+        />
+      </ChecklistProvider>
+    </EvidenceStoreProvider>
+  );
+}
+
+interface BodyProps {
+  readonly firmwareVersionId: string;
+  readonly canAttach: boolean;
+  readonly canWaive: boolean;
+}
+
+function ArtifactsTabBody({ firmwareVersionId, canAttach, canWaive }: BodyProps) {
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const pendingSlotRef = useRef<FirmwareArtifactSlotKey | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const { attachSlot } = useChecklist(FIRMWARE_INTAKE_SCHEMA_ID, firmwareVersionId);
+  const uploadEvidence = useUploadEvidence();
+
+  const onAttachClick = (slotKey: string) => {
+    setError(null);
+    pendingSlotRef.current = slotKey as FirmwareArtifactSlotKey;
+    fileInputRef.current?.click();
+  };
+
+  const onFileChosen = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    const slot = pendingSlotRef.current;
+    // Reset the input value so picking the same file twice still fires change
+    if (fileInputRef.current) fileInputRef.current.value = "";
+    pendingSlotRef.current = null;
+    if (!file || !slot) return;
+
+    try {
+      const bytes = new Uint8Array(await file.arrayBuffer());
+      const meta = await uploadEvidence.mutateAsync({
+        bytes,
+        mimeType: file.type || "application/octet-stream",
+        retentionMode: "compliance",
+        retainUntil: tenYearsFromNowISO(),
+        tags: {
+          subject: firmwareVersionId,
+          slot,
+          filename: file.name,
+        },
+      });
+      await attachSlot(slot, meta.id);
+    } catch (e) {
+      setError((e as Error).message ?? "Upload failed");
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <ChecklistPanel
+        schemaId={FIRMWARE_INTAKE_SCHEMA_ID}
+        subjectId={firmwareVersionId}
+        canAttach={canAttach}
+        canWaive={canWaive}
+        onAttach={onAttachClick}
+      />
+      <input
+        ref={fileInputRef}
+        type="file"
+        className="hidden"
+        onChange={onFileChosen}
+        aria-hidden="true"
+      />
+      {error && (
+        <p
+          role="alert"
+          className="rounded-md border border-red-200 bg-red-50 p-2 text-[12px] text-red-800"
+        >
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function tenYearsFromNowISO(): string {
+  const d = new Date();
+  d.setFullYear(d.getFullYear() + 10);
+  return d.toISOString();
+}

--- a/src/app/components/firmware/firmware-detail-page.tsx
+++ b/src/app/components/firmware/firmware-detail-page.tsx
@@ -28,6 +28,8 @@ import { FirmwareStateBadge } from "./firmware-lifecycle";
 import { VersionTimeline, type TimelineEvent } from "../shared/version-timeline";
 import { FirmwareDeployedSitesTab } from "./firmware-deployed-sites-tab";
 import { FirmwareActiveLinksTab } from "./firmware-active-links-tab";
+import { FirmwareArtifactsTab } from "./firmware-artifacts-tab";
+import { isFeatureEnabled } from "@/lib/feature-flags";
 import { GenerateDownloadLinkModal } from "./generate-download-link-modal";
 import { EVENT_COLOR_MAP } from "@/lib/types/firmware-version";
 import type { FirmwareVersion } from "@/lib/types";
@@ -36,13 +38,20 @@ import type { FirmwareVersion } from "@/lib/types";
 // Types
 // ---------------------------------------------------------------------------
 
-type DetailTab = "details" | "deployed-sites" | "active-links";
+type DetailTab = "details" | "deployed-sites" | "active-links" | "artifacts";
 
-const TABS: { id: DetailTab; label: string }[] = [
+// Epic 28 reference wiring — the Artifacts tab is only surfaced when the
+// compliance library feature flag is on. When off, the legacy tab set is
+// preserved exactly as before.
+const BASE_TABS: { id: DetailTab; label: string }[] = [
   { id: "details", label: "Version Details" },
   { id: "deployed-sites", label: "Deployed Sites" },
   { id: "active-links", label: "Active Links" },
 ];
+
+const TABS: { id: DetailTab; label: string }[] = isFeatureEnabled("COMPLIANCE_LIB")
+  ? [...BASE_TABS, { id: "artifacts", label: "Artifacts" }]
+  : BASE_TABS;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -415,6 +424,10 @@ export function FirmwareDetailPage() {
               onGenerateClick={() => setGenerateModalOpen(true)}
               canGenerate={canGenerate}
             />
+          )}
+
+          {activeTab === "artifacts" && isFeatureEnabled("COMPLIANCE_LIB") && (
+            <FirmwareArtifactsTab firmwareVersionId={selectedVersion.id} />
           )}
         </>
       )}

--- a/src/lib/firmware/firmware-artifact-schema.ts
+++ b/src/lib/firmware/firmware-artifact-schema.ts
@@ -1,0 +1,85 @@
+/**
+ * Firmware intake artifact checklist (Epic 28 reference wiring).
+ *
+ * Domain-specific checklist schema for a firmware bundle submission.
+ * This file lives in the firmware feature folder (NOT in
+ * `src/lib/compliance/`) so the compliance library itself stays
+ * domain-agnostic. The schema is consumed by `<FirmwareArtifactsTab>`
+ * and fed to the generic `<ChecklistPanel>` compliance primitive.
+ *
+ * The slot taxonomy mirrors the real regulatory artifacts required by
+ * SOC 2 / ISO 27001 for a firmware release:
+ *
+ * - sbom                 Software Bill of Materials (CycloneDX / SPDX)
+ * - hbom                 Hardware Bill of Materials (per-unit; may be waived
+ *                        permanent for purely software releases)
+ * - fat-qa-results       Factory Acceptance Test / QA regression results
+ * - release-notes        Customer-facing release notes
+ * - architecture-diagram System / component diagram for the release
+ * - patch-notes          Security patch notes (may be waived for features
+ *                        with no security implications — permanent)
+ * - attestation          Vendor attestation signed by Security Reviewer
+ */
+
+import type { ChecklistSchema } from "@/lib/compliance/checklist";
+
+export type FirmwareArtifactSlotKey =
+  | "sbom"
+  | "hbom"
+  | "fat-qa-results"
+  | "release-notes"
+  | "architecture-diagram"
+  | "patch-notes"
+  | "attestation";
+
+export const FIRMWARE_INTAKE_SCHEMA_ID = "firmware-intake-v1" as const;
+
+export const firmwareIntakeChecklistSchema: ChecklistSchema<FirmwareArtifactSlotKey> = {
+  schemaId: FIRMWARE_INTAKE_SCHEMA_ID,
+  label: "Firmware Intake Artifacts",
+  slots: [
+    {
+      key: "sbom",
+      label: "Software Bill of Materials",
+      required: true,
+      description: "CycloneDX or SPDX — lists every software component in the firmware image.",
+    },
+    {
+      key: "hbom",
+      label: "Hardware Bill of Materials",
+      required: true,
+      description:
+        "Per-device component manifest. Waive permanently for software-only releases or product lines where H-BOM does not apply.",
+    },
+    {
+      key: "fat-qa-results",
+      label: "FAT / QA Test Results",
+      required: true,
+      description: "Factory Acceptance Test and regression results signed off by QA.",
+    },
+    {
+      key: "release-notes",
+      label: "Release Notes",
+      required: true,
+      description: "Customer-facing summary of changes shipped in this version.",
+    },
+    {
+      key: "architecture-diagram",
+      label: "Architecture / System Diagram",
+      required: true,
+      description: "System-level diagram showing component interactions for this release.",
+    },
+    {
+      key: "patch-notes",
+      label: "Security Patch Notes",
+      required: false,
+      description: "Only required when the release addresses a CVE or internal security finding.",
+    },
+    {
+      key: "attestation",
+      label: "Security Reviewer Attestation",
+      required: true,
+      description: "Signed attestation that the release has cleared security review.",
+    },
+  ],
+};


### PR DESCRIPTION
## Summary

**First reference migration of a real IMS flow onto the Epic 28 compliance primitives.** Adds an **Artifacts** tab on the firmware detail page that renders the generic `<ChecklistPanel>` against a firmware-specific slot taxonomy, backed by the evidence store + checklist engine primitives. Fully behind `VITE_FEATURE_COMPLIANCE_LIB` — the legacy detail page is byte-identical when the flag is off.

Opens the path to the Epic 28 success metric: *"auditor walkthrough in under 10 minutes."*

## What's in the PR

### New schema (firmware feature folder — NOT in compliance lib)

`src/lib/firmware/firmware-artifact-schema.ts` — 7 slots matching the regulatory artifacts required by SOC 2 / ISO 27001 for a firmware release:

| Slot | Required? | Notes |
|---|---|---|
| SBOM | yes | CycloneDX / SPDX |
| HBOM | yes | Permanent-waive-able for software-only product lines |
| FAT / QA results | yes | |
| Release notes | yes | |
| Architecture diagram | yes | |
| Patch notes | **no** | Only required when the release addresses a CVE |
| Attestation | yes | Security reviewer sign-off |

Kept in the firmware feature folder so the compliance library itself stays domain-free — the ESLint `no-restricted-imports` rule from PR #460 still enforces that boundary.

### New component

`src/app/components/firmware/firmware-artifacts-tab.tsx` — renders `<ChecklistPanel>` wired through:
- `<EvidenceStoreProvider>` + `<ChecklistProvider>` with per-mount mock stores
- RBAC gated via `canPerformAction` for both `evidence:put` and `checklist:attach` (Attach button) and `checklist:waive` (Waive button)
- File-picker attach handler: `useUploadEvidence().mutateAsync(...)` → evidence store → `attachSlot(slotKey, evidenceId)`

### Detail page integration

`firmware-detail-page.tsx` — adds the `Artifacts` tab ONLY when `isFeatureEnabled("COMPLIANCE_LIB")`. Base tab set is preserved verbatim when the flag is off.

## NIST 800-53 controls

- **AC-3** — both `canPerformAction("evidence:put")` and `("checklist:attach")` checked before surfacing Attach; adapter layer re-validates at the server boundary
- **AU-2 / AU-3** — every evidence put and checklist transition writes an audit record via the existing pipeline
- **SC-12** — mock adapter in this PR; `createS3EvidenceStore(config)` already implemented, requires KMS key id when wired to real S3
- **SI-10** — file bytes, retention dates, and slot keys validated at the evidence + checklist adapter boundaries

## Test evidence

- **7 new schema tests** covering the completeness matrix (complete / incomplete / conditionally-complete / permanent-waiver-as-complete / optional-slot-missing)
- Full project suite: **765 / 765 passing** (7 new)
- `npx tsc --noEmit` — clean
- `npx eslint` — 0 errors
- `npm run build` — green (19.9s)

## Rollout

- Feature flag off by default (flag reads `VITE_FEATURE_COMPLIANCE_LIB` env)
- Set `VITE_FEATURE_COMPLIANCE_LIB=true` in `.env.local` to exercise the wiring during dev
- When ready, enable for non-prod environments first; legacy flow remains available for rollback

## What remains

Natural follow-ups (deferred from this PR to keep scope reviewable):

- Wire the **approval state machine + conditions panel** into the firmware detail page (the natural next touchpoint — review flow)
- Wire the **secure distribution** primitive into the firmware download flow
- Wire the **two-phase confirmation** primitive into the deployment completion flow
- Wire the **impact query table** as a firmware version Impact tab
- Lift providers from per-mount local stores into a top-level app provider (production wiring)
- Real AWS SDK driver injection for `createS3EvidenceStore`

## Test plan

- [ ] Set `VITE_FEATURE_COMPLIANCE_LIB=true` → verify Artifacts tab appears on firmware detail page
- [ ] As Admin: click Attach on a slot → pick a file → verify slot flips to "present" with correct evidence metadata
- [ ] As Admin: click Waive on a missing slot → record conditional waiver → verify slot shows countdown
- [ ] As Technician: verify Waive button is hidden (RBAC), Attach still visible
- [ ] Unset flag → verify the Artifacts tab disappears and legacy tab behavior is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)