### PR TITLE
feat(compliance): wire firmware review flow + lift providers to shared scope

### DIFF
--- a/src/app/components/firmware/firmware-artifacts-tab.tsx
+++ b/src/app/components/firmware/firmware-artifacts-tab.tsx
@@ -7,24 +7,20 @@
  * picker, uploads the file to the immutable evidence store, then calls
  * the checklist engine's `attachSlot` to mark the slot present.
  *
- * All state lives inside the tab via per-mount mock stores for the
- * reference implementation — in production, the app would lift the
- * providers higher and wire them to the real S3 / DynamoDB adapters.
+ * Stores are provided externally via `<FirmwareComplianceProvider>` so
+ * the checklist completeness can also drive the sibling Review tab's
+ * approval state.
  */
 
-import { useMemo, useRef, useState } from "react";
+import { useRef, useState } from "react";
 
 import { ChecklistPanel } from "@/app/components/compliance/checklist-panel";
-import { useAuth } from "@/lib/use-auth";
-import { ChecklistProvider, createMockChecklistStore } from "@/lib/compliance/checklist";
-import { EvidenceStoreProvider, createMockEvidenceStore } from "@/lib/compliance/evidence";
 import { useChecklist } from "@/lib/compliance/checklist";
 import { useUploadEvidence } from "@/lib/compliance/evidence";
-import type { ComplianceActor } from "@/lib/compliance/types";
-import { canPerformAction, getPrimaryRole, type Role } from "@/lib/rbac";
+import { useAuth } from "@/lib/use-auth";
+import { canPerformAction, getPrimaryRole } from "@/lib/rbac";
 import {
   FIRMWARE_INTAKE_SCHEMA_ID,
-  firmwareIntakeChecklistSchema,
   type FirmwareArtifactSlotKey,
 } from "@/lib/firmware/firmware-artifact-schema";
 
@@ -34,53 +30,11 @@ export interface FirmwareArtifactsTabProps {
 
 export function FirmwareArtifactsTab({ firmwareVersionId }: FirmwareArtifactsTabProps) {
   const { user } = useAuth();
-
-  const actor: ComplianceActor = useMemo(
-    () => ({
-      userId: user?.id ?? "anonymous",
-      displayName: user?.name ?? user?.email ?? "Anonymous",
-    }),
-    [user],
-  );
-
-  const role: Role = useMemo(() => getPrimaryRole(user?.groups ?? []), [user]);
+  const role = getPrimaryRole(user?.groups ?? []);
   const canAttach =
     canPerformAction(role, "checklist:attach") && canPerformAction(role, "evidence:put");
   const canWaive = canPerformAction(role, "checklist:waive");
 
-  // Per-mount stores — reference wiring only. Real app would lift these
-  // into a higher-level provider against production adapters.
-  const stores = useMemo(() => {
-    const resolveRole = () => role;
-    return {
-      evidenceStore: createMockEvidenceStore({ resolveRole }),
-      checklistStore: createMockChecklistStore({
-        resolveRole,
-        seedSchemas: [firmwareIntakeChecklistSchema],
-      }),
-    };
-  }, [role]);
-
-  return (
-    <EvidenceStoreProvider store={stores.evidenceStore} actor={actor}>
-      <ChecklistProvider store={stores.checklistStore} actor={actor}>
-        <ArtifactsTabBody
-          firmwareVersionId={firmwareVersionId}
-          canAttach={canAttach}
-          canWaive={canWaive}
-        />
-      </ChecklistProvider>
-    </EvidenceStoreProvider>
-  );
-}
-
-interface BodyProps {
-  readonly firmwareVersionId: string;
-  readonly canAttach: boolean;
-  readonly canWaive: boolean;
-}
-
-function ArtifactsTabBody({ firmwareVersionId, canAttach, canWaive }: BodyProps) {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const pendingSlotRef = useRef<FirmwareArtifactSlotKey | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -97,7 +51,6 @@ function ArtifactsTabBody({ firmwareVersionId, canAttach, canWaive }: BodyProps)
   const onFileChosen = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     const slot = pendingSlotRef.current;
-    // Reset the input value so picking the same file twice still fires change
     if (fileInputRef.current) fileInputRef.current.value = "";
     pendingSlotRef.current = null;
     if (!file || !slot) return;

--- a/src/app/components/firmware/firmware-compliance-provider.tsx
+++ b/src/app/components/firmware/firmware-compliance-provider.tsx
@@ -1,0 +1,58 @@
+/**
+ * <FirmwareComplianceProvider /> — reference-implementation wrapper that
+ * wires the Epic 28 compliance primitives (evidence, checklist, approval)
+ * into the firmware flow with shared state across tabs.
+ *
+ * Lifting the stores here (instead of per-tab) lets the Artifacts tab's
+ * checklist completeness drive the Review tab's approval-decision logic
+ * without duplicate state. When the codebase eventually replaces the mock
+ * adapters with real AWS SDK-backed drivers, this is the single file that
+ * needs to swap out.
+ *
+ * Gated by `VITE_FEATURE_COMPLIANCE_LIB` at the consumer side; this
+ * component itself is unconditional and can be rendered anywhere.
+ */
+
+import { useMemo } from "react";
+import type { ReactNode } from "react";
+
+import { firmwareIntakeChecklistSchema } from "@/lib/firmware/firmware-artifact-schema";
+import { ApprovalProvider, createMockApprovalEngine } from "@/lib/compliance/approval";
+import { ChecklistProvider, createMockChecklistStore } from "@/lib/compliance/checklist";
+import { EvidenceStoreProvider, createMockEvidenceStore } from "@/lib/compliance/evidence";
+import type { ComplianceActor } from "@/lib/compliance/types";
+import type { Role } from "@/lib/rbac";
+
+export interface FirmwareComplianceProviderProps {
+  readonly actor: ComplianceActor;
+  readonly role: Role;
+  readonly children: ReactNode;
+}
+
+export function FirmwareComplianceProvider({
+  actor,
+  role,
+  children,
+}: FirmwareComplianceProviderProps) {
+  const stores = useMemo(() => {
+    const resolveRole = () => role;
+    return {
+      evidenceStore: createMockEvidenceStore({ resolveRole }),
+      checklistStore: createMockChecklistStore({
+        resolveRole,
+        seedSchemas: [firmwareIntakeChecklistSchema],
+      }),
+      approvalEngine: createMockApprovalEngine({ resolveRole }),
+    };
+  }, [role]);
+
+  return (
+    <EvidenceStoreProvider store={stores.evidenceStore} actor={actor}>
+      <ChecklistProvider store={stores.checklistStore} actor={actor}>
+        <ApprovalProvider engine={stores.approvalEngine} actor={actor}>
+          {children}
+        </ApprovalProvider>
+      </ChecklistProvider>
+    </EvidenceStoreProvider>
+  );
+}

--- a/src/app/components/firmware/firmware-detail-page.tsx
+++ b/src/app/components/firmware/firmware-detail-page.tsx
@@ -29,7 +29,10 @@ import { VersionTimeline, type TimelineEvent } from "../shared/version-timeline"
 import { FirmwareDeployedSitesTab } from "./firmware-deployed-sites-tab";
 import { FirmwareActiveLinksTab } from "./firmware-active-links-tab";
 import { FirmwareArtifactsTab } from "./firmware-artifacts-tab";
+import { FirmwareReviewTab } from "./firmware-review-tab";
+import { FirmwareComplianceProvider } from "./firmware-compliance-provider";
 import { isFeatureEnabled } from "@/lib/feature-flags";
+import type { ComplianceActor } from "@/lib/compliance/types";
 import { GenerateDownloadLinkModal } from "./generate-download-link-modal";
 import { EVENT_COLOR_MAP } from "@/lib/types/firmware-version";
 import type { FirmwareVersion } from "@/lib/types";
@@ -38,10 +41,10 @@ import type { FirmwareVersion } from "@/lib/types";
 // Types
 // ---------------------------------------------------------------------------
 
-type DetailTab = "details" | "deployed-sites" | "active-links" | "artifacts";
+type DetailTab = "details" | "deployed-sites" | "active-links" | "artifacts" | "review";
 
-// Epic 28 reference wiring — the Artifacts tab is only surfaced when the
-// compliance library feature flag is on. When off, the legacy tab set is
+// Epic 28 reference wiring — Artifacts + Review tabs are only surfaced when
+// the compliance library feature flag is on. When off, the legacy tab set is
 // preserved exactly as before.
 const BASE_TABS: { id: DetailTab; label: string }[] = [
   { id: "details", label: "Version Details" },
@@ -50,8 +53,10 @@ const BASE_TABS: { id: DetailTab; label: string }[] = [
 ];
 
 const TABS: { id: DetailTab; label: string }[] = isFeatureEnabled("COMPLIANCE_LIB")
-  ? [...BASE_TABS, { id: "artifacts", label: "Artifacts" }]
+  ? [...BASE_TABS, { id: "artifacts", label: "Artifacts" }, { id: "review", label: "Review" }]
   : BASE_TABS;
+
+const COMPLIANCE_TABS: readonly DetailTab[] = ["artifacts", "review"] as const;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -426,8 +431,23 @@ export function FirmwareDetailPage() {
             />
           )}
 
-          {activeTab === "artifacts" && isFeatureEnabled("COMPLIANCE_LIB") && (
-            <FirmwareArtifactsTab firmwareVersionId={selectedVersion.id} />
+          {COMPLIANCE_TABS.includes(activeTab) && isFeatureEnabled("COMPLIANCE_LIB") && (
+            <FirmwareComplianceProvider
+              actor={
+                {
+                  userId: user?.id ?? "anonymous",
+                  displayName: user?.name ?? user?.email ?? "Anonymous",
+                } satisfies ComplianceActor
+              }
+              role={role}
+            >
+              {activeTab === "artifacts" && (
+                <FirmwareArtifactsTab firmwareVersionId={selectedVersion.id} />
+              )}
+              {activeTab === "review" && (
+                <FirmwareReviewTab firmwareVersionId={selectedVersion.id} />
+              )}
+            </FirmwareComplianceProvider>
           )}
         </>
       )}

--- a/src/app/components/firmware/firmware-review-tab.tsx
+++ b/src/app/components/firmware/firmware-review-tab.tsx
@@ -1,0 +1,118 @@
+/**
+ * <FirmwareReviewTab /> — reference wiring for Epic 28 approval + SLA
+ * primitives on the firmware review flow (behind `VITE_FEATURE_COMPLIANCE_LIB`).
+ *
+ * Composition:
+ * - `<ApprovalGateBadge>` — current approval state pill
+ * - `<ApprovalDecisionPanel>` — reviewer actions (Approve / Conditional /
+ *   Reject); buttons enabled only when the current checklist completeness
+ *   + approval state permit the transition
+ * - `<ConditionsPanel>` — SLA condition tracker, shown when the approval
+ *   is conditionally-approved
+ *
+ * Checklist completeness comes from the sibling Artifacts tab (shared
+ * `<FirmwareComplianceProvider>`). No IMS/firmware types leak into
+ * `src/lib/compliance/**`; the library stays domain-free.
+ */
+
+import { useEffect } from "react";
+
+import { ApprovalDecisionPanel } from "@/app/components/compliance/approval-decision-panel";
+import { ApprovalGateBadge } from "@/app/components/compliance/approval-gate-badge";
+import { ConditionsPanel } from "@/app/components/compliance/conditions-panel";
+import { useApproval, useApprovalEngine } from "@/lib/compliance/approval";
+import { useChecklist } from "@/lib/compliance/checklist";
+import type { Completeness } from "@/lib/compliance/checklist";
+import { useAuth } from "@/lib/use-auth";
+import { canPerformAction, getPrimaryRole } from "@/lib/rbac";
+import { FIRMWARE_INTAKE_SCHEMA_ID } from "@/lib/firmware/firmware-artifact-schema";
+
+export interface FirmwareReviewTabProps {
+  readonly firmwareVersionId: string;
+}
+
+export function FirmwareReviewTab({ firmwareVersionId }: FirmwareReviewTabProps) {
+  const { user } = useAuth();
+  const role = getPrimaryRole(user?.groups ?? []);
+  const actor = {
+    userId: user?.id ?? "anonymous",
+    displayName: user?.name ?? user?.email ?? "Anonymous",
+  };
+  const canDecide = canPerformAction(role, "approval:decide");
+
+  const { completeness } = useChecklist(FIRMWARE_INTAKE_SCHEMA_ID, firmwareVersionId);
+  const { approval, create, decide } = useApproval(firmwareVersionId);
+  const { engine } = useApprovalEngine();
+
+  // First-time viewers see a pending approval auto-created so the decision
+  // panel has something to bind to. This mirrors how a real app would create
+  // the approval record at submission time; the check is idempotent at the
+  // engine level so repeated renders are safe.
+  useEffect(() => {
+    if (approval === null) {
+      void create();
+    }
+  }, [approval, create]);
+
+  const effectiveCompleteness: Completeness = completeness ?? {
+    kind: "incomplete",
+    missing: [],
+  };
+
+  const onDecide = async (input: {
+    readonly nextState: Exclude<NonNullable<typeof approval>["state"], "pending">;
+    readonly reason?: string;
+  }) => {
+    await decide({
+      nextState: input.nextState,
+      reason: input.reason,
+      completeness: effectiveCompleteness,
+    });
+  };
+
+  return (
+    <div className="space-y-4">
+      <header className="flex items-center justify-between rounded-lg border border-border bg-card px-4 py-3">
+        <div>
+          <h3 className="text-[14px] font-semibold text-foreground">
+            Review — Firmware {firmwareVersionId}
+          </h3>
+          <p className="mt-0.5 text-[11px] text-muted-foreground">
+            Checklist: <CompletenessInline completeness={effectiveCompleteness} />
+          </p>
+        </div>
+        <ApprovalGateBadge approval={approval} />
+      </header>
+
+      <ApprovalDecisionPanel
+        approval={approval}
+        completeness={effectiveCompleteness}
+        canDecide={canDecide}
+        onDecide={onDecide}
+      />
+
+      {approval?.state === "conditionally-approved" && (
+        <ConditionsPanel approval={approval} engine={engine} actor={actor} canSatisfy={canDecide} />
+      )}
+    </div>
+  );
+}
+
+function CompletenessInline({ completeness }: { readonly completeness: Completeness }) {
+  switch (completeness.kind) {
+    case "complete":
+      return <span className="text-emerald-700">complete</span>;
+    case "conditionally-complete":
+      return (
+        <span className="text-amber-700">
+          conditional ({completeness.pendingWaivers.length} waivers pending)
+        </span>
+      );
+    case "incomplete":
+      return (
+        <span className="text-red-700">
+          incomplete ({completeness.missing.length} slots missing)
+        </span>
+      );
+  }
+}

--- a/src/lib/compliance/approval/index.ts
+++ b/src/lib/compliance/approval/index.ts
@@ -23,7 +23,7 @@ export {
   NoConditionalWaiverError,
   SelfApprovalError,
 } from "./approval-errors";
-export { ApprovalProvider, useApproval } from "./use-approval";
+export { ApprovalProvider, useApproval, useApprovalEngine } from "./use-approval";
 export type { ApprovalProviderProps, UseApprovalResult } from "./use-approval";
 // Story 28.4 — SLA tracking
 export {

--- a/src/lib/compliance/approval/use-approval.tsx
+++ b/src/lib/compliance/approval/use-approval.tsx
@@ -36,6 +36,18 @@ function useCtx(): ApprovalCtxValue {
   return ctx;
 }
 
+/**
+ * Access the underlying `IApprovalEngine` and current actor from the
+ * surrounding `<ApprovalProvider>`.
+ *
+ * Use this only when you need to pass the engine into a component that
+ * expects it as a prop (e.g., `<ConditionsPanel>`). Prefer `useApproval`
+ * for the hook-based API.
+ */
+export function useApprovalEngine(): ApprovalCtxValue {
+  return useCtx();
+}
+
 export interface UseApprovalResult {
   readonly approval: Approval | null | undefined;
   readonly isLoading: boolean;


### PR DESCRIPTION
## Summary

Second reference migration of a real IMS flow onto the Epic 28 compliance primitives. Adds a **Review** tab to the firmware detail page that drives `<ApprovalGateBadge>` + `<ApprovalDecisionPanel>` + `<ConditionsPanel>` off the sibling Artifacts tab's checklist completeness. Both compliance tabs now share state through a new `<FirmwareComplianceProvider>`, so **approval eligibility flips in real time as artifacts are attached or waived**.

Follow-up to PR #464 (firmware intake / Artifacts tab).

## What's in the PR

### New: shared compliance provider

`src/app/components/firmware/firmware-compliance-provider.tsx` — wraps `<EvidenceStoreProvider>` + `<ChecklistProvider>` + `<ApprovalProvider>` around compliance-scoped tabs. Single file to swap when the mock adapters are replaced with real AWS SDK drivers.

### Refactor: artifacts tab consumes shared stores

`firmware-artifacts-tab.tsx` no longer instantiates its own per-mount mock stores. Consumes evidence + checklist via hooks from the shared provider. Behavior unchanged from the user's perspective.

### New: review tab

`src/app/components/firmware/firmware-review-tab.tsx` composes the three approval primitives:
- Header with approval state pill + inline checklist completeness summary
- `<ApprovalDecisionPanel>` — Approve / Conditional Approve / Reject; buttons enabled only when the current state + completeness permit the transition
- `<ConditionsPanel>` — rendered only when the approval is in `conditionally-approved` state

Auto-creates a pending approval on first mount (idempotent at engine level) so the decision surface has something to bind to.

### Library addition (non-breaking)

Exported `useApprovalEngine()` from the approval barrel so reference wiring can reach the raw engine when a component expects it as a prop. Existing `useApproval()` callers unchanged.

## Flow demonstration

With `VITE_FEATURE_COMPLIANCE_LIB=true`, walk through:

1. Visit firmware detail page → see new **Artifacts** + **Review** tabs
2. On Review: approval pill shows `Pending`, completeness shows `incomplete (6 slots missing)`, all decide buttons disabled with tooltip "Checklist incomplete"
3. Switch to Artifacts → attach files to 6 required slots
4. Switch back to Review → completeness shows `complete`, **Approve** button now enabled
5. Conditionally waive HBOM on Artifacts → Review shows `conditional (1 waivers pending)`, **Conditional Approve** now enabled; submit with reason → approval moves to `conditionally-approved`; `<ConditionsPanel>` appears with the auto-created SLA condition
6. Mark the SLA condition satisfied → can now transition to `approved`

Each transition writes an audit record (AU-2 / AU-3).

## NIST 800-53 (this PR)

| Control | Where |
|---|---|
| AC-3 | `canPerformAction("approval:decide")` gates decide buttons + server-side enforcement at the engine |
| AC-5 | Self-approval blocked at the engine layer (from PR #460); surfaces as a denied audit record |
| AU-2 / AU-3 | Every create / decide / conditionSatisfied transition writes a classified record |

## Test evidence

- Full compliance + firmware suite: **154 / 154 passing** (no new tests — this PR is composition of already-covered primitives)
- `npx tsc --noEmit` — clean
- `npx eslint` — 0 errors, 2 warnings (fast-refresh on `useApprovalEngine` addition — expected, same pattern as the library's other hook+provider exports)
- `npm run build` — green (16.4s)

## What remains

- Firmware **download** flow migration (secure distribution primitive)
- **Deployment confirmation** (two-phase confirmation + graph binding)
- **Impact tab** (inverse dependency query)
- Real AWS SDK driver injection

## Test plan

- [ ] Set `VITE_FEATURE_COMPLIANCE_LIB=true` → verify Artifacts + Review tabs appear
- [ ] Run the 6-step flow above; verify state is shared across tabs
- [ ] As Technician: Review tab shows "You do not have permission to decide this approval."
- [ ] Unset flag → verify both new tabs disappear and legacy tab set is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)