### PR TITLE
feat(compliance): wire firmware secure-distribution post-approval

### DIFF
--- a/src/app/components/firmware/firmware-compliance-provider.tsx
+++ b/src/app/components/firmware/firmware-compliance-provider.tsx
@@ -1,7 +1,8 @@
 /**
  * <FirmwareComplianceProvider /> — reference-implementation wrapper that
- * wires the Epic 28 compliance primitives (evidence, checklist, approval)
- * into the firmware flow with shared state across tabs.
+ * wires the Epic 28 compliance primitives (evidence, checklist, approval,
+ * secure distribution) into the firmware flow with shared state across
+ * tabs.
  *
  * Lifting the stores here (instead of per-tab) lets the Artifacts tab's
  * checklist completeness drive the Review tab's approval-decision logic
@@ -13,12 +14,17 @@
  * component itself is unconditional and can be rendered anywhere.
  */
 
-import { useMemo } from "react";
+import { createContext, useContext, useMemo } from "react";
 import type { ReactNode } from "react";
 
 import { firmwareIntakeChecklistSchema } from "@/lib/firmware/firmware-artifact-schema";
 import { ApprovalProvider, createMockApprovalEngine } from "@/lib/compliance/approval";
 import { ChecklistProvider, createMockChecklistStore } from "@/lib/compliance/checklist";
+import {
+  SecureDistributionProvider,
+  createMockSecureDistribution,
+  type ISecureDistribution,
+} from "@/lib/compliance/distribution";
 import { EvidenceStoreProvider, createMockEvidenceStore } from "@/lib/compliance/evidence";
 import type { ComplianceActor } from "@/lib/compliance/types";
 import type { Role } from "@/lib/rbac";
@@ -27,6 +33,28 @@ export interface FirmwareComplianceProviderProps {
   readonly actor: ComplianceActor;
   readonly role: Role;
   readonly children: ReactNode;
+}
+
+interface DistributionDriverCtx {
+  readonly driver: ISecureDistribution;
+}
+
+const DistributionDriverContext = createContext<DistributionDriverCtx | null>(null);
+
+/**
+ * Access the mock secure-distribution driver used inside the firmware
+ * compliance scope. Exposed so reference components (e.g., `<SecureDownloadButton>`
+ * placements) can pass the concrete driver without re-instantiating a new
+ * mock that would have its own disconnected jti / consumed-token state.
+ */
+export function useFirmwareDistributionDriver(): ISecureDistribution {
+  const ctx = useContext(DistributionDriverContext);
+  if (!ctx) {
+    throw new Error(
+      "useFirmwareDistributionDriver requires <FirmwareComplianceProvider> higher in the tree.",
+    );
+  }
+  return ctx.driver;
 }
 
 export function FirmwareComplianceProvider({
@@ -43,14 +71,24 @@ export function FirmwareComplianceProvider({
         seedSchemas: [firmwareIntakeChecklistSchema],
       }),
       approvalEngine: createMockApprovalEngine({ resolveRole }),
+      distribution: createMockSecureDistribution({ resolveRole }),
     };
   }, [role]);
+
+  const distributionCtx = useMemo<DistributionDriverCtx>(
+    () => ({ driver: stores.distribution }),
+    [stores.distribution],
+  );
 
   return (
     <EvidenceStoreProvider store={stores.evidenceStore} actor={actor}>
       <ChecklistProvider store={stores.checklistStore} actor={actor}>
         <ApprovalProvider engine={stores.approvalEngine} actor={actor}>
-          {children}
+          <SecureDistributionProvider driver={stores.distribution} actor={actor}>
+            <DistributionDriverContext.Provider value={distributionCtx}>
+              {children}
+            </DistributionDriverContext.Provider>
+          </SecureDistributionProvider>
         </ApprovalProvider>
       </ChecklistProvider>
     </EvidenceStoreProvider>

--- a/src/app/components/firmware/firmware-review-tab.tsx
+++ b/src/app/components/firmware/firmware-review-tab.tsx
@@ -1,6 +1,7 @@
 /**
- * <FirmwareReviewTab /> — reference wiring for Epic 28 approval + SLA
- * primitives on the firmware review flow (behind `VITE_FEATURE_COMPLIANCE_LIB`).
+ * <FirmwareReviewTab /> — reference wiring for Epic 28 approval + SLA +
+ * secure-distribution primitives on the firmware review flow (behind
+ * `VITE_FEATURE_COMPLIANCE_LIB`).
  *
  * Composition:
  * - `<ApprovalGateBadge>` — current approval state pill
@@ -9,6 +10,9 @@
  *   + approval state permit the transition
  * - `<ConditionsPanel>` — SLA condition tracker, shown when the approval
  *   is conditionally-approved
+ * - `<SecureDownloadButton>` — mint/redeem a single-use secure download
+ *   link for the reviewer once the approval has reached the `approved`
+ *   state. Demonstrates the secure-distribution primitive end-to-end.
  *
  * Checklist completeness comes from the sibling Artifacts tab (shared
  * `<FirmwareComplianceProvider>`). No IMS/firmware types leak into
@@ -20,12 +24,14 @@ import { useEffect } from "react";
 import { ApprovalDecisionPanel } from "@/app/components/compliance/approval-decision-panel";
 import { ApprovalGateBadge } from "@/app/components/compliance/approval-gate-badge";
 import { ConditionsPanel } from "@/app/components/compliance/conditions-panel";
+import { SecureDownloadButton } from "@/app/components/compliance/secure-download-button";
 import { useApproval, useApprovalEngine } from "@/lib/compliance/approval";
 import { useChecklist } from "@/lib/compliance/checklist";
 import type { Completeness } from "@/lib/compliance/checklist";
 import { useAuth } from "@/lib/use-auth";
 import { canPerformAction, getPrimaryRole } from "@/lib/rbac";
 import { FIRMWARE_INTAKE_SCHEMA_ID } from "@/lib/firmware/firmware-artifact-schema";
+import { useFirmwareDistributionDriver } from "./firmware-compliance-provider";
 
 export interface FirmwareReviewTabProps {
   readonly firmwareVersionId: string;
@@ -94,6 +100,47 @@ export function FirmwareReviewTab({ firmwareVersionId }: FirmwareReviewTabProps)
       {approval?.state === "conditionally-approved" && (
         <ConditionsPanel approval={approval} engine={engine} actor={actor} canSatisfy={canDecide} />
       )}
+
+      {approval?.state === "approved" && (
+        <SecureDistributionSection
+          firmwareVersionId={firmwareVersionId}
+          recipientUserId={actor.userId}
+          actor={actor}
+        />
+      )}
+    </div>
+  );
+}
+
+function SecureDistributionSection({
+  firmwareVersionId,
+  recipientUserId,
+  actor,
+}: {
+  readonly firmwareVersionId: string;
+  readonly recipientUserId: string;
+  readonly actor: { readonly userId: string; readonly displayName: string };
+}) {
+  const driver = useFirmwareDistributionDriver();
+  return (
+    <div className="rounded-lg border border-border bg-card p-4">
+      <h3 className="text-[14px] font-semibold text-foreground">Secure distribution</h3>
+      <p className="mt-0.5 text-[11px] text-muted-foreground">
+        Approval is final. Mint a single-use, recipient-bound download link. The token is signed,
+        bound to your user, expires on first use, and every mint/redeem is audit-logged (NIST
+        AU-2/3).
+      </p>
+      <div className="mt-3">
+        <SecureDownloadButton
+          driver={driver}
+          actor={actor}
+          recipientUserId={recipientUserId}
+          evidenceId={firmwareVersionId}
+          purpose={`Firmware ${firmwareVersionId} post-approval distribution`}
+          label="Secure download"
+          expiresInSeconds={900}
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Third reference migration onto the Epic 28 compliance library. Adds a **Secure Distribution** section on the firmware Review tab that appears once an approval reaches `approved`. Mints a single-use, recipient-bound, signed download link via the library's `createMockSecureDistribution` driver — demonstrates the mint→redeem flow end-to-end **without touching the legacy `GenerateDownloadLinkModal` path**.

Follow-up to PR #465 (firmware review wiring).

## What's in the PR

### Extended shared provider

`firmware-compliance-provider.tsx` adds `<SecureDistributionProvider>` into the shared chain so the review tab (and any future tab) share one mock driver instance — which matters because the driver holds the consumed-jti set that enforces single-use tokens.

New tiny helper context `useFirmwareDistributionDriver()` exposes the raw driver. The `<SecureDownloadButton>` component takes `driver` as a prop (Story 28.5 API) rather than reading from context, so this indirection lets reference wiring pass the same driver without re-instantiating.

### New Review-tab section

`firmware-review-tab.tsx` renders a `SecureDistributionSection` **only** when `approval.state === "approved"`. Creates a natural flow in the demo:
1. Attach artifacts → checklist complete
2. Decide → Approved
3. Secure Distribution section appears → Mint + redeem secure link

Helpful inline copy surfaces the NIST AU-2/3 audit guarantee so reviewers understand what the button actually does.

## Flow demo

With `VITE_FEATURE_COMPLIANCE_LIB=true`:
1. Firmware detail page → Artifacts tab: attach all 6 required slots
2. Review tab: Approve button now enabled → click Approve
3. Approval pill flips to **Approved** → Secure Distribution section appears
4. Click **Secure download** → library mints a signed token → immediately redeems (same driver instance) → opens a `mock-storage://firmware-X?t=<iso>` URL in a new tab
5. Click again → the token is single-use, so the same mint flow produces a fresh link (new jti, fresh expiry)
6. Check audit log → `compliance.distribution.minted` + `compliance.distribution.redeemed` events recorded

## NIST 800-53

| Control | Where |
|---|---|
| AC-3 | `distribution:approve` required to mint, `distribution:request` required to redeem (both enforced at the adapter) |
| AC-5 | Approve→Distribution split matches the `distribution:approve` vs `distribution:request` RBAC pair (from PR #460) |
| AU-2 / AU-3 | Every mint + redeem + denial writes an audit record |
| IA-2 | Step-up MFA enforcement available via `requireStepUpMfa` flag (off for this initial wiring; reviewer is the recipient) |

## Test evidence

- 154 / 154 compliance + firmware tests pass (no new tests — composition of primitives already covered by the library's 114 unit tests)
- `npx tsc --noEmit` — clean
- `npx eslint` — 0 errors
- `npm run build` — green (14.7s)

## What remains

- **Deployment confirmation** (two-phase confirmation + graph binding)
- **Impact tab** (inverse dependency query)
- Replace legacy `GenerateDownloadLinkModal` flow when ready to cut over

## Test plan

- [ ] Turn flag on → drive flow through approve → verify Secure Distribution section appears
- [ ] Verify clicking the button mints and immediately redeems (new window opens with mock-storage URL)
- [ ] Verify multiple clicks mint multiple distinct tokens (check audit log)
- [ ] Turn flag off → verify legacy Generate Link flow unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)