### PR TITLE
feat(compliance): wire firmware deployment two-phase confirmation

### DIFF
--- a/src/__tests__/lib/firmware/firmware-deployment-validator.test.ts
+++ b/src/__tests__/lib/firmware/firmware-deployment-validator.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  FIRMWARE_DEPLOYMENT_KIND,
+  firmwareDeploymentValidator,
+  type FirmwareDeploymentProof,
+} from "@/lib/firmware/firmware-deployment-validator";
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function mkProof(overrides: Partial<FirmwareDeploymentProof> = {}): FirmwareDeploymentProof {
+  return {
+    note: "Installed cleanly on-site, no issues observed during smoke test.",
+    photoEvidenceIds: ["ev-photo-1"],
+    confirmedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe("firmwareDeploymentValidator", () => {
+  it("kind constant is stable", () => {
+    expect(FIRMWARE_DEPLOYMENT_KIND).toBe("firmware-deployment");
+  });
+
+  it("accepts a valid proof", () => {
+    expect(firmwareDeploymentValidator(mkProof())).toEqual({ ok: true, messages: [] });
+  });
+
+  it("rejects short note", () => {
+    const r = firmwareDeploymentValidator(mkProof({ note: "short" }));
+    expect(r.ok).toBe(false);
+    expect(r.messages.some((m) => m.includes("Note must be"))).toBe(true);
+  });
+
+  it("rejects empty photo evidence list", () => {
+    const r = firmwareDeploymentValidator(mkProof({ photoEvidenceIds: [] }));
+    expect(r.ok).toBe(false);
+    expect(r.messages.some((m) => m.includes("photo"))).toBe(true);
+  });
+
+  it("rejects invalid timestamp", () => {
+    const r = firmwareDeploymentValidator(mkProof({ confirmedAt: "not-a-date" }));
+    expect(r.ok).toBe(false);
+    expect(r.messages.some((m) => m.includes("valid ISO-8601"))).toBe(true);
+  });
+
+  it("rejects future timestamp", () => {
+    const future = new Date(Date.now() + 2 * MS_PER_DAY).toISOString();
+    const r = firmwareDeploymentValidator(mkProof({ confirmedAt: future }));
+    expect(r.ok).toBe(false);
+    expect(r.messages.some((m) => m.includes("cannot be in the future"))).toBe(true);
+  });
+
+  it("rejects timestamp older than 30 days", () => {
+    const old = new Date(Date.now() - 31 * MS_PER_DAY).toISOString();
+    const r = firmwareDeploymentValidator(mkProof({ confirmedAt: old }));
+    expect(r.ok).toBe(false);
+    expect(r.messages.some((m) => m.includes("last 30 days"))).toBe(true);
+  });
+
+  it("aggregates multiple validation errors", () => {
+    const r = firmwareDeploymentValidator(
+      mkProof({ note: "", photoEvidenceIds: [], confirmedAt: "bad" }),
+    );
+    expect(r.ok).toBe(false);
+    expect(r.messages.length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/src/app/components/firmware/firmware-compliance-provider.tsx
+++ b/src/app/components/firmware/firmware-compliance-provider.tsx
@@ -18,8 +18,16 @@ import { createContext, useContext, useMemo } from "react";
 import type { ReactNode } from "react";
 
 import { firmwareIntakeChecklistSchema } from "@/lib/firmware/firmware-artifact-schema";
+import {
+  FIRMWARE_DEPLOYMENT_KIND,
+  firmwareDeploymentValidator,
+} from "@/lib/firmware/firmware-deployment-validator";
 import { ApprovalProvider, createMockApprovalEngine } from "@/lib/compliance/approval";
 import { ChecklistProvider, createMockChecklistStore } from "@/lib/compliance/checklist";
+import {
+  createMockConfirmationEngine,
+  type IConfirmationEngine,
+} from "@/lib/compliance/confirmation";
 import {
   SecureDistributionProvider,
   createMockSecureDistribution,
@@ -35,11 +43,22 @@ export interface FirmwareComplianceProviderProps {
   readonly children: ReactNode;
 }
 
-interface DistributionDriverCtx {
-  readonly driver: ISecureDistribution;
+interface FirmwareComplianceCtx {
+  readonly distribution: ISecureDistribution;
+  readonly confirmation: IConfirmationEngine;
 }
 
-const DistributionDriverContext = createContext<DistributionDriverCtx | null>(null);
+const FirmwareComplianceContext = createContext<FirmwareComplianceCtx | null>(null);
+
+function useComplianceCtx(): FirmwareComplianceCtx {
+  const ctx = useContext(FirmwareComplianceContext);
+  if (!ctx) {
+    throw new Error(
+      "Firmware compliance hooks require <FirmwareComplianceProvider> higher in the tree.",
+    );
+  }
+  return ctx;
+}
 
 /**
  * Access the mock secure-distribution driver used inside the firmware
@@ -48,13 +67,16 @@ const DistributionDriverContext = createContext<DistributionDriverCtx | null>(nu
  * mock that would have its own disconnected jti / consumed-token state.
  */
 export function useFirmwareDistributionDriver(): ISecureDistribution {
-  const ctx = useContext(DistributionDriverContext);
-  if (!ctx) {
-    throw new Error(
-      "useFirmwareDistributionDriver requires <FirmwareComplianceProvider> higher in the tree.",
-    );
-  }
-  return ctx.driver;
+  return useComplianceCtx().distribution;
+}
+
+/**
+ * Access the mock two-phase confirmation engine used inside the firmware
+ * compliance scope. The firmware deployment validator is pre-registered
+ * under kind `"firmware-deployment"` at provider construction time.
+ */
+export function useFirmwareConfirmationEngine(): IConfirmationEngine {
+  return useComplianceCtx().confirmation;
 }
 
 export function FirmwareComplianceProvider({
@@ -64,6 +86,10 @@ export function FirmwareComplianceProvider({
 }: FirmwareComplianceProviderProps) {
   const stores = useMemo(() => {
     const resolveRole = () => role;
+    const confirmation = createMockConfirmationEngine({ resolveRole });
+    // Register the domain-specific validator once per provider instance.
+    // The compliance library stays generic; the validator lives here.
+    confirmation.validators.register(FIRMWARE_DEPLOYMENT_KIND, firmwareDeploymentValidator);
     return {
       evidenceStore: createMockEvidenceStore({ resolveRole }),
       checklistStore: createMockChecklistStore({
@@ -72,12 +98,16 @@ export function FirmwareComplianceProvider({
       }),
       approvalEngine: createMockApprovalEngine({ resolveRole }),
       distribution: createMockSecureDistribution({ resolveRole }),
+      confirmation,
     };
   }, [role]);
 
-  const distributionCtx = useMemo<DistributionDriverCtx>(
-    () => ({ driver: stores.distribution }),
-    [stores.distribution],
+  const ctxValue = useMemo<FirmwareComplianceCtx>(
+    () => ({
+      distribution: stores.distribution,
+      confirmation: stores.confirmation,
+    }),
+    [stores.distribution, stores.confirmation],
   );
 
   return (
@@ -85,9 +115,9 @@ export function FirmwareComplianceProvider({
       <ChecklistProvider store={stores.checklistStore} actor={actor}>
         <ApprovalProvider engine={stores.approvalEngine} actor={actor}>
           <SecureDistributionProvider driver={stores.distribution} actor={actor}>
-            <DistributionDriverContext.Provider value={distributionCtx}>
+            <FirmwareComplianceContext.Provider value={ctxValue}>
               {children}
-            </DistributionDriverContext.Provider>
+            </FirmwareComplianceContext.Provider>
           </SecureDistributionProvider>
         </ApprovalProvider>
       </ChecklistProvider>

--- a/src/app/components/firmware/firmware-deployment-confirm-section.tsx
+++ b/src/app/components/firmware/firmware-deployment-confirm-section.tsx
@@ -1,0 +1,235 @@
+/**
+ * <FirmwareDeploymentConfirmSection /> — Epic 28 reference wiring for the
+ * two-phase action confirmation primitive.
+ *
+ * Pattern:
+ *   initiate()   — button click creates an ActionInitiation record
+ *   complete()   — dialog submit runs the firmware-deployment validator
+ *                  and transitions the record to "confirmed"
+ *   abandon()    — explicit abandon action with reason
+ *
+ * All flow state lives in the engine (shared via `<FirmwareComplianceProvider>`),
+ * so the section surfaces "initiated" vs "confirmed" vs "abandoned" from
+ * the engine's records without holding its own state.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+
+import { ConfirmationDialog } from "@/app/components/compliance/confirmation-dialog";
+import {
+  FIRMWARE_DEPLOYMENT_KIND,
+  type FirmwareDeploymentProof,
+} from "@/lib/firmware/firmware-deployment-validator";
+import type { ActionInitiation } from "@/lib/compliance/confirmation";
+import { useFirmwareConfirmationEngine } from "./firmware-compliance-provider";
+
+export interface FirmwareDeploymentConfirmSectionProps {
+  readonly firmwareVersionId: string;
+  readonly actor: { readonly userId: string; readonly displayName: string };
+}
+
+export function FirmwareDeploymentConfirmSection({
+  firmwareVersionId,
+  actor,
+}: FirmwareDeploymentConfirmSectionProps) {
+  const engine = useFirmwareConfirmationEngine();
+
+  const [initiation, setInitiation] = useState<ActionInitiation | null>(null);
+  const [allByFirmware, setAllByFirmware] = useState<readonly ActionInitiation[]>([]);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    const records = await engine.loadByKind(FIRMWARE_DEPLOYMENT_KIND, {});
+    const forThisFirmware = records.filter(
+      (r) => (r.payload as { firmwareVersionId?: string }).firmwareVersionId === firmwareVersionId,
+    );
+    setAllByFirmware(forThisFirmware);
+  }, [engine, firmwareVersionId]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const onInitiate = async () => {
+    setError(null);
+    try {
+      const created = await engine.initiate<{ readonly firmwareVersionId: string }>(
+        FIRMWARE_DEPLOYMENT_KIND,
+        { firmwareVersionId },
+        actor,
+      );
+      setInitiation(created);
+      setDialogOpen(true);
+      await refresh();
+    } catch (e) {
+      setError((e as Error).message ?? "Failed to initiate deployment record");
+    }
+  };
+
+  const onAbandon = async (id: string) => {
+    const reason = prompt("Why are you abandoning this deployment?");
+    if (!reason) return;
+    if (reason.length < 10 || reason.length > 500) {
+      setError("Abandon reason must be 10-500 characters.");
+      return;
+    }
+    try {
+      await engine.abandon(id, reason, actor);
+      await refresh();
+    } catch (e) {
+      setError((e as Error).message ?? "Failed to abandon");
+    }
+  };
+
+  const onConfirm = async (proof: FirmwareDeploymentProof) => {
+    if (!initiation) return;
+    try {
+      await engine.complete(initiation.id, proof, actor);
+      setDialogOpen(false);
+      setInitiation(null);
+      await refresh();
+    } catch (e) {
+      setError((e as Error).message ?? "Confirmation failed");
+    }
+  };
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h3 className="text-[14px] font-semibold text-foreground">Deployment confirmation</h3>
+          <p className="mt-0.5 text-[11px] text-muted-foreground">
+            Close the chain of custody: record when + where the firmware was installed with photo
+            evidence. Initiate → complete-with-proof (NIST AU-2/3).
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => void onInitiate()}
+          className="rounded-md bg-primary px-3 py-1.5 text-[12px] font-medium text-primary-foreground hover:bg-primary/90"
+        >
+          Record deployment
+        </button>
+      </div>
+
+      {error && (
+        <p
+          role="alert"
+          className="mt-3 rounded-md border border-red-200 bg-red-50 p-2 text-[12px] text-red-800"
+        >
+          {error}
+        </p>
+      )}
+
+      {allByFirmware.length > 0 && (
+        <ul className="mt-3 space-y-2">
+          {allByFirmware.map((r) => (
+            <li
+              key={r.id}
+              className="flex items-center justify-between rounded-md border border-border px-3 py-2 text-[12px]"
+            >
+              <div>
+                <span className="font-medium text-foreground">{r.id}</span>
+                <span
+                  className={
+                    r.state === "confirmed"
+                      ? "ml-2 rounded-full bg-emerald-50 px-2 py-0.5 text-[10px] text-emerald-800"
+                      : r.state === "abandoned"
+                        ? "ml-2 rounded-full bg-muted px-2 py-0.5 text-[10px] text-muted-foreground"
+                        : "ml-2 rounded-full bg-amber-50 px-2 py-0.5 text-[10px] text-amber-900"
+                  }
+                >
+                  {r.state}
+                </span>
+                <span className="ml-2 text-muted-foreground">
+                  {new Date(r.initiatedAt).toLocaleString()}
+                </span>
+              </div>
+              {r.state === "initiated" && (
+                <button
+                  type="button"
+                  onClick={() => void onAbandon(r.id)}
+                  className="rounded-md border border-border px-2 py-1 text-[11px] text-muted-foreground hover:bg-muted"
+                >
+                  Abandon
+                </button>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {dialogOpen && initiation && (
+        <ConfirmationDialog<FirmwareDeploymentProof>
+          initiation={initiation}
+          validator={
+            engine.validators.get<FirmwareDeploymentProof>(FIRMWARE_DEPLOYMENT_KIND) ??
+            (() => ({ ok: false, messages: ["validator not registered"] }))
+          }
+          initialProof={{
+            note: "",
+            photoEvidenceIds: [],
+            confirmedAt: new Date().toISOString(),
+          }}
+          onConfirm={onConfirm}
+          onClose={() => {
+            setDialogOpen(false);
+            setInitiation(null);
+          }}
+          title="Confirm firmware deployment"
+          renderFields={({ proof, setProof }) => (
+            <>
+              <div>
+                <label
+                  htmlFor="fw-deploy-note"
+                  className="mb-1 block text-[12px] font-medium text-foreground"
+                >
+                  Installation notes
+                </label>
+                <textarea
+                  id="fw-deploy-note"
+                  value={proof.note}
+                  onChange={(e) => setProof({ ...proof, note: e.target.value })}
+                  rows={3}
+                  placeholder="Where, when, and how the firmware was installed."
+                  className="w-full rounded-md border border-border bg-card px-2 py-1.5 text-[12px] outline-none focus:border-primary"
+                />
+                <p className="mt-0.5 text-[10px] text-muted-foreground">
+                  {proof.note.length}/2000 characters (min 10)
+                </p>
+              </div>
+              <div>
+                <label
+                  htmlFor="fw-deploy-photos"
+                  className="mb-1 block text-[12px] font-medium text-foreground"
+                >
+                  Photo evidence references (one per line)
+                </label>
+                <textarea
+                  id="fw-deploy-photos"
+                  value={proof.photoEvidenceIds.join("\n")}
+                  onChange={(e) =>
+                    setProof({
+                      ...proof,
+                      photoEvidenceIds: e.target.value
+                        .split("\n")
+                        .map((s) => s.trim())
+                        .filter(Boolean),
+                    })
+                  }
+                  rows={2}
+                  placeholder="ev-install-photo-1&#10;ev-install-photo-2"
+                  className="w-full rounded-md border border-border bg-card px-2 py-1.5 text-[12px] outline-none focus:border-primary"
+                />
+                <p className="mt-0.5 text-[10px] text-muted-foreground">
+                  Attach at least one photo evidence id
+                </p>
+              </div>
+            </>
+          )}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/app/components/firmware/firmware-review-tab.tsx
+++ b/src/app/components/firmware/firmware-review-tab.tsx
@@ -32,6 +32,7 @@ import { useAuth } from "@/lib/use-auth";
 import { canPerformAction, getPrimaryRole } from "@/lib/rbac";
 import { FIRMWARE_INTAKE_SCHEMA_ID } from "@/lib/firmware/firmware-artifact-schema";
 import { useFirmwareDistributionDriver } from "./firmware-compliance-provider";
+import { FirmwareDeploymentConfirmSection } from "./firmware-deployment-confirm-section";
 
 export interface FirmwareReviewTabProps {
   readonly firmwareVersionId: string;
@@ -102,11 +103,14 @@ export function FirmwareReviewTab({ firmwareVersionId }: FirmwareReviewTabProps)
       )}
 
       {approval?.state === "approved" && (
-        <SecureDistributionSection
-          firmwareVersionId={firmwareVersionId}
-          recipientUserId={actor.userId}
-          actor={actor}
-        />
+        <>
+          <SecureDistributionSection
+            firmwareVersionId={firmwareVersionId}
+            recipientUserId={actor.userId}
+            actor={actor}
+          />
+          <FirmwareDeploymentConfirmSection firmwareVersionId={firmwareVersionId} actor={actor} />
+        </>
       )}
     </div>
   );

--- a/src/lib/firmware/firmware-deployment-validator.ts
+++ b/src/lib/firmware/firmware-deployment-validator.ts
@@ -1,0 +1,52 @@
+/**
+ * Firmware deployment proof validator (Story 28.6 reference wiring).
+ *
+ * Domain-specific validator that plugs into the generic
+ * `IConfirmationEngine.validators` registry under the
+ * `"firmware-deployment"` kind. Keeps all firmware schema knowledge
+ * OUTSIDE the compliance library so the library itself stays generic.
+ */
+
+import type { ProofValidator } from "@/lib/compliance/confirmation";
+
+export const FIRMWARE_DEPLOYMENT_KIND = "firmware-deployment" as const;
+
+export interface FirmwareDeploymentProof {
+  readonly note: string;
+  readonly photoEvidenceIds: readonly string[];
+  readonly confirmedAt: string;
+}
+
+const NOTE_MIN = 10;
+const NOTE_MAX = 2000;
+const MAX_CONFIRM_AGE_DAYS = 30;
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Validates a firmware deployment proof payload. Pure function — safe to
+ * call every render.
+ */
+export const firmwareDeploymentValidator: ProofValidator<FirmwareDeploymentProof> = (proof) => {
+  const messages: string[] = [];
+
+  if (proof.note.length < NOTE_MIN || proof.note.length > NOTE_MAX) {
+    messages.push(`Note must be ${NOTE_MIN}-${NOTE_MAX} characters.`);
+  }
+  if (proof.photoEvidenceIds.length < 1) {
+    messages.push("At least one photo evidence reference is required.");
+  }
+  const ts = Date.parse(proof.confirmedAt);
+  if (Number.isNaN(ts)) {
+    messages.push("Confirmation timestamp must be a valid ISO-8601 date.");
+  } else {
+    const ageMs = Date.now() - ts;
+    if (ageMs < 0) {
+      messages.push("Confirmation timestamp cannot be in the future.");
+    } else if (ageMs > MAX_CONFIRM_AGE_DAYS * MS_PER_DAY) {
+      messages.push(`Confirmation timestamp must be within the last ${MAX_CONFIRM_AGE_DAYS} days.`);
+    }
+  }
+
+  return { ok: messages.length === 0, messages };
+};


### PR DESCRIPTION
## Summary

Fourth reference migration onto the Epic 28 compliance library. Adds a **Deployment confirmation** section on the firmware Review tab that appears once approval reaches `approved`. Technicians (or demo reviewers) initiate a deployment record, then complete it with a proof payload validated by a firmware-specific validator. **Closes the chain of custody** from approval → distribution → installed-and-verified.

Follow-up to PR #466 (firmware distribution wiring).

## What's in the PR

### Domain validator (firmware folder, NOT in compliance lib)

`src/lib/firmware/firmware-deployment-validator.ts` — caller-registered `ProofValidator` with these rules:
- `note` — 10-2000 chars
- `photoEvidenceIds` — at least 1
- `confirmedAt` — valid ISO-8601, within last 30 days, not in the future

Aggregates multiple failures. 8 unit tests cover every branch.

### Shared provider extension

`firmware-compliance-provider.tsx` adds `createMockConfirmationEngine` and registers the firmware deployment validator under `kind = "firmware-deployment"` at provider construction. New `useFirmwareConfirmationEngine()` helper exposes the engine for reference components that need the raw API.

### New Review-tab section

`firmware-deployment-confirm-section.tsx` renders:
- A "Record deployment" button that calls `engine.initiate("firmware-deployment", { firmwareVersionId }, actor)`
- A list of all initiations for the current firmware version with state badges (initiated / confirmed / abandoned)
- `<ConfirmationDialog>` (shipped in #462) with firmware-specific proof fields: notes textarea + photo evidence ids textarea
- An Abandon action on records still in the `initiated` state, with prompt-based reason capture (10-500 chars server-enforced)

## Flow demo (end-to-end now)

With `VITE_FEATURE_COMPLIANCE_LIB=true`:
1. Attach artifacts → checklist complete
2. Approve
3. Mint secure download
4. **Record deployment** → dialog opens
5. Fill notes + photo evidence ids + confirm → record moves to **confirmed**
6. Abandon a different record → moves to **abandoned (auto=false)**

Every transition writes an `AUDIT#` record through the existing audit pipeline.

## NIST 800-53 coverage (this PR)

- **AC-3** — `confirmation:initiate` / `confirmation:complete` / `confirmation:abandon` all gated via `canPerformAction` at engine layer
- **AC-5** (optional) — `requireDistinctConfirmer` available on the engine config (off by default in this reference wiring; reviewer acts as installer for demo)
- **AU-2 / AU-3** — every transition + validator failure + denial writes a classified audit record
- **SI-10** — proof validator runs at complete time; invalid proofs rejected with aggregated messages

## Test evidence

- **8 new validator tests**
- Full compliance + firmware suite: **162 / 162 passing**
- `npx tsc --noEmit` — clean
- `npx eslint` — 0 errors
- `npm run build` — green (12.0s)

## Where we stand

| Flow step | Library primitive | PR |
|---|---|---|
| 1. Intake | Evidence + Checklist | #464 |
| 2. Review | Approval + SLA | #465 |
| 3. Distribution | Secure distribution | #466 |
| 4. Deployment confirmation | Two-phase confirmation | **this PR** |
| 5. Impact query | Inverse dependency | pending |

One more to close the Epic 28 reference-wiring loop.

## Test plan

- [ ] With flag on, drive to approved state
- [ ] Click Record deployment → verify dialog opens with empty fields
- [ ] Submit with missing photo → verify inline validator errors
- [ ] Fill fields + submit → verify record flips to confirmed
- [ ] Initiate a second record, click Abandon → verify abandoned state
- [ ] Flag off → verify the section disappears and legacy behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)